### PR TITLE
Add skill management commands (list, add, remove, refresh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ npx clud-bug init [options]
   --help,-h       Show help.
 ```
 
+## Managing skills
+
+After `init`, four commands let you evolve the skill set without re-running the whole setup:
+
+```bash
+clud-bug list                                       # show what's installed
+clud-bug add vercel-labs/skills/next-best-practices # install one from skills.sh
+clud-bug remove next-best-practices                 # uninstall (refuses custom skills)
+clud-bug refresh                                    # re-query skills.sh, diff vs installed
+```
+
+Skills are tracked in `.claude/skills/.clud-bug.json` (a small manifest). Anything in `.claude/skills/` that *isn't* in the manifest is treated as your custom work and never modified by `clud-bug` commands.
+
 ## Adding your own skills
 
 Drop any `.md` file into `.claude/skills/<your-skill>/SKILL.md` — Claude Code auto-discovers it on the next PR. Same format as skills from skills.sh:

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -10,7 +10,7 @@ import { detect, buildDescriptionLine } from '../lib/detect.js';
 import { renderFile, pickTemplate } from '../lib/render.js';
 import {
   SkillsClient, rankAndCap, writeSkills, writeSkill, loadBaseline,
-  readManifest, removeSkill, listInstalled, diffManifest,
+  readManifest, writeManifest, removeSkill, listInstalled, diffManifest,
 } from '../lib/skills.js';
 
 const PKG_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -221,7 +221,6 @@ async function runAdd(args) {
   const entry = await writeSkill(skillsDir, { source, name, kind: 'remote' }, client);
   const manifest = await readManifest(skillsDir);
   const merged = { version: 1, installed: [...manifest.installed.filter(e => e.slug !== entry.slug), entry] };
-  const { writeManifest } = await import('../lib/skills.js');
   await writeManifest(skillsDir, merged);
   log(`  ✓ installed ${entry.slug} → .claude/skills/${entry.slug}/SKILL.md`);
   log('  Commit + push to apply on the next PR.');
@@ -256,7 +255,7 @@ async function runRefresh(args) {
   let curated = [];
   let searched = [];
   if (args.offline) {
-    log('  --offline: skipping skills.sh — diff will only show baseline updates');
+    log('  --offline: skipping skills.sh — only baseline additions will be diffed; existing remote skills are preserved');
   } else {
     const client = new SkillsClient();
     let curatedErr, searchedErr;
@@ -274,6 +273,11 @@ async function runRefresh(args) {
   }
   const recommended = rankAndCap(curated, searched, baseline);
   const diff = diffManifest(manifest, recommended);
+
+  // In --offline mode the recommendation set isn't authoritative (we only have
+  // baseline locally), so any "missing from recommendations" entry is a false
+  // positive. Suppress removals to avoid mass-deleting the user's remote skills.
+  if (args.offline) diff.remove = [];
 
   log('');
   log(`  add:       ${diff.add.length}`);

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -256,13 +256,21 @@ async function runRefresh(args) {
   let curated = [];
   let searched = [];
   if (args.offline) {
-    log('  --offline: skipping skills.sh');
+    log('  --offline: skipping skills.sh — diff will only show baseline updates');
   } else {
     const client = new SkillsClient();
+    let curatedErr, searchedErr;
     [curated, searched] = await Promise.all([
-      client.curated().catch(() => []),
-      client.search(signals.searchTerms).catch(() => []),
+      client.curated().catch(err => { curatedErr = err; return []; }),
+      client.search(signals.searchTerms).catch(err => { searchedErr = err; return []; }),
     ]);
+    if (curatedErr || searchedErr) {
+      const err = curatedErr || searchedErr;
+      warn(`skills.sh unreachable (${err.message})`);
+      warn('refusing to compute removals — an empty API response would look like "delete everything from skills.sh".');
+      warn('Try again later, or run with --offline to install only baseline updates.');
+      process.exit(1);
+    }
   }
   const recommended = rankAndCap(curated, searched, baseline);
   const diff = diffManifest(manifest, recommended);

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -8,7 +8,10 @@ import { stdin as input, stdout as output } from 'node:process';
 
 import { detect, buildDescriptionLine } from '../lib/detect.js';
 import { renderFile, pickTemplate } from '../lib/render.js';
-import { SkillsClient, rankAndCap, writeSkills, loadBaseline } from '../lib/skills.js';
+import {
+  SkillsClient, rankAndCap, writeSkills, writeSkill, loadBaseline,
+  readManifest, removeSkill, listInstalled, diffManifest,
+} from '../lib/skills.js';
 
 const PKG_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const TEMPLATES = join(PKG_ROOT, 'templates');
@@ -27,17 +30,24 @@ function parseArgs(argv) {
   return args;
 }
 
-const HELP = `clud-bug — install Claude PR review with project-aware skills
+const HELP = `clud-bug — Claude PR review with project-aware skills
 
 Usage:
-  npx clud-bug init [options]
+  npx clud-bug <command> [options]
+
+Commands:
+  init                  First-time setup: detect repo, install skills, write workflow.
+  list                  Show currently installed skills (baseline / remote / custom).
+  add <source/name>     Install one skill from skills.sh (e.g. vercel-labs/skills/next-best-practices).
+  remove <slug>         Remove an installed skill (refuses if it's a custom skill).
+  refresh               Re-query skills.sh and diff against installed; prompt to update.
 
 Options:
-  --offline       Skip skills.sh; install only the bundled baseline skills.
-  --accept-all,-y Accept the recommended skill set without prompting.
-  --commit        git add + commit the generated files when done.
-  --help,-h       Show this help.
-  --version,-v    Show version.
+  --offline             Skip skills.sh; only use bundled baseline skills (init/refresh).
+  --accept-all,-y       Accept recommendations without prompting.
+  --commit              git add + commit the generated files when done (init only).
+  --help,-h             Show this help.
+  --version,-v          Show version.
 `;
 
 async function readPkgVersion() {
@@ -51,12 +61,16 @@ async function main() {
   if (args.version) { process.stdout.write((await readPkgVersion()) + '\n'); return; }
 
   const cmd = args._[0];
-  if (cmd !== 'init') {
-    process.stderr.write(`Unknown command: ${cmd || '(none)'}\n\n${HELP}`);
-    process.exit(2);
+  switch (cmd) {
+    case 'init':    return runInit(args);
+    case 'list':    return runList(args);
+    case 'add':     return runAdd(args);
+    case 'remove':  return runRemove(args);
+    case 'refresh': return runRefresh(args);
+    default:
+      process.stderr.write(`Unknown command: ${cmd || '(none)'}\n\n${HELP}`);
+      process.exit(2);
   }
-
-  await runInit(args);
 }
 
 async function runInit(args) {
@@ -161,6 +175,127 @@ async function promptForSkills(recommended) {
   } finally {
     rl.close();
   }
+}
+
+async function runList(_args) {
+  const skillsDir = join(process.cwd(), '.claude', 'skills');
+  const groups = await listInstalled(skillsDir);
+  const total = groups.baseline.length + groups.remote.length + groups.custom.length;
+  if (total === 0) {
+    log('No skills installed yet. Run `clud-bug init` to get started.');
+    return;
+  }
+  log(`🐛 ${total} skill${total === 1 ? '' : 's'} in .claude/skills/`);
+  if (groups.baseline.length) {
+    log('');
+    log('Baseline (always installed):');
+    for (const s of groups.baseline) log(`  • ${s.slug}`);
+  }
+  if (groups.remote.length) {
+    log('');
+    log('From skills.sh:');
+    for (const s of groups.remote) log(`  • ${s.slug}  ${s.source ? `[${s.source}]` : ''}`);
+  }
+  if (groups.custom.length) {
+    log('');
+    log('Custom (yours, never auto-modified):');
+    for (const s of groups.custom) {
+      log(`  • ${s.slug}${s.description ? `  — ${s.description}` : ''}`);
+    }
+  }
+}
+
+async function runAdd(args) {
+  const ref = args._[1];
+  if (!ref || !ref.includes('/')) {
+    process.stderr.write('Usage: clud-bug add <source/name>  (e.g. vercel-labs/skills/next-best-practices)\n');
+    process.exit(2);
+  }
+  // Last segment is the skill name; everything before is the source repo path.
+  const lastSlash = ref.lastIndexOf('/');
+  const source = ref.slice(0, lastSlash);
+  const name = ref.slice(lastSlash + 1);
+  const skillsDir = join(process.cwd(), '.claude', 'skills');
+  log(`  fetching ${source}/${name} from skills.sh...`);
+  const client = new SkillsClient();
+  const entry = await writeSkill(skillsDir, { source, name, kind: 'remote' }, client);
+  const manifest = await readManifest(skillsDir);
+  const merged = { version: 1, installed: [...manifest.installed.filter(e => e.slug !== entry.slug), entry] };
+  const { writeManifest } = await import('../lib/skills.js');
+  await writeManifest(skillsDir, merged);
+  log(`  ✓ installed ${entry.slug} → .claude/skills/${entry.slug}/SKILL.md`);
+  log('  Commit + push to apply on the next PR.');
+}
+
+async function runRemove(args) {
+  const slug = args._[1];
+  if (!slug) {
+    process.stderr.write('Usage: clud-bug remove <slug>  (run `clud-bug list` to see installed slugs)\n');
+    process.exit(2);
+  }
+  const skillsDir = join(process.cwd(), '.claude', 'skills');
+  const entry = await removeSkill(skillsDir, slug);
+  log(`  ✓ removed ${entry.slug}${entry.kind === 'baseline' ? ' (baseline — will return on next init)' : ''}`);
+}
+
+async function runRefresh(args) {
+  const cwd = process.cwd();
+  const skillsDir = join(cwd, '.claude', 'skills');
+  const manifest = await readManifest(skillsDir);
+  if (manifest.installed.length === 0) {
+    log('No clud-bug-managed skills found. Run `clud-bug init` first.');
+    return;
+  }
+
+  log('  detecting repo signals...');
+  const signals = await detect(cwd);
+  log(`    primary language: ${signals.primaryLanguage || '(unknown)'}`);
+  log(`    search terms:     ${signals.searchTerms.join(', ') || '(none)'}`);
+
+  const baseline = await loadBaseline(BASELINE_DIR);
+  let curated = [];
+  let searched = [];
+  if (args.offline) {
+    log('  --offline: skipping skills.sh');
+  } else {
+    const client = new SkillsClient();
+    [curated, searched] = await Promise.all([
+      client.curated().catch(() => []),
+      client.search(signals.searchTerms).catch(() => []),
+    ]);
+  }
+  const recommended = rankAndCap(curated, searched, baseline);
+  const diff = diffManifest(manifest, recommended);
+
+  log('');
+  log(`  add:       ${diff.add.length}`);
+  log(`  remove:    ${diff.remove.length} (custom skills untouched)`);
+  log(`  unchanged: ${diff.unchanged.length}`);
+
+  if (diff.add.length === 0 && diff.remove.length === 0) {
+    log('');
+    log('Nothing to update. Skills are in sync with skills.sh recommendations.');
+    return;
+  }
+
+  log('');
+  for (const s of diff.add)    log(`  + ${s.name} [${s.source || s.kind}]`);
+  for (const s of diff.remove) log(`  - ${s.slug} [${s.source || s.kind}]`);
+
+  if (!args.acceptAll) {
+    const rl = createInterface({ input, output });
+    const answer = await rl.question('\nApply these changes? [y/N] ');
+    rl.close();
+    if (answer.trim().toLowerCase() !== 'y') {
+      log('Aborted. No files changed.');
+      return;
+    }
+  }
+
+  const client = new SkillsClient();
+  if (diff.add.length) await writeSkills(skillsDir, diff.add, client);
+  for (const entry of diff.remove) await removeSkill(skillsDir, entry.slug);
+  log('  ✓ skills updated. Commit + push to apply on the next PR.');
 }
 
 function rel(from, to) {

--- a/lib/skills.js
+++ b/lib/skills.js
@@ -7,9 +7,9 @@ const MANIFEST_FILE = '.clud-bug.json';
 const MANIFEST_VERSION = 1;
 
 export class SkillsClient {
-  constructor({ fetch = globalThis.fetch, base = API_BASE, userAgent = 'clud-bug' } = {}) {
+  constructor({ fetch = globalThis.fetch, base, userAgent = 'clud-bug' } = {}) {
     this.fetch = fetch;
-    this.base = base;
+    this.base = base ?? process.env.CLUD_BUG_SKILLS_SH_BASE ?? API_BASE;
     this.userAgent = userAgent;
   }
 

--- a/lib/skills.js
+++ b/lib/skills.js
@@ -1,8 +1,10 @@
-import { mkdir, writeFile, readdir, readFile } from 'node:fs/promises';
+import { mkdir, writeFile, readdir, readFile, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const API_BASE = 'https://skills.sh/api/v1';
 const MAX_SKILLS = 8;
+const MANIFEST_FILE = '.clud-bug.json';
+const MANIFEST_VERSION = 1;
 
 export class SkillsClient {
   constructor({ fetch = globalThis.fetch, base = API_BASE, userAgent = 'clud-bug' } = {}) {
@@ -103,18 +105,139 @@ export async function writeSkills(targetDir, skills, client) {
   await mkdir(targetDir, { recursive: true });
   const written = [];
   for (const skill of skills) {
-    const slug = sanitizeSlug(skill.name);
-    const skillDir = join(targetDir, slug);
-    await mkdir(skillDir, { recursive: true });
-    const content = skill.content ?? await client.getContent(skill.source, skill.name);
-    await writeFile(join(skillDir, 'SKILL.md'), content);
-    written.push({ slug, source: skill.source, kind: skill.kind || 'remote' });
+    const entry = await writeSkill(targetDir, skill, client);
+    written.push(entry);
   }
+  await writeManifest(targetDir, mergeManifest(await readManifest(targetDir), written));
   return written;
+}
+
+export async function writeSkill(targetDir, skill, client) {
+  await mkdir(targetDir, { recursive: true });
+  const slug = sanitizeSlug(skill.name);
+  const skillDir = join(targetDir, slug);
+  await mkdir(skillDir, { recursive: true });
+  const content = skill.content ?? await client.getContent(skill.source, skill.name);
+  await writeFile(join(skillDir, 'SKILL.md'), content);
+  return {
+    slug,
+    name: skill.name,
+    source: skill.source,
+    kind: skill.kind || 'remote',
+    description: skill.description || '',
+  };
+}
+
+export async function readManifest(targetDir) {
+  try {
+    const text = await readFile(join(targetDir, MANIFEST_FILE), 'utf8');
+    const data = JSON.parse(text);
+    return {
+      version: data.version || MANIFEST_VERSION,
+      installed: Array.isArray(data.installed) ? data.installed : [],
+    };
+  } catch {
+    return { version: MANIFEST_VERSION, installed: [] };
+  }
+}
+
+export async function writeManifest(targetDir, manifest) {
+  await mkdir(targetDir, { recursive: true });
+  const out = {
+    version: manifest.version || MANIFEST_VERSION,
+    installed: manifest.installed || [],
+  };
+  await writeFile(join(targetDir, MANIFEST_FILE), JSON.stringify(out, null, 2) + '\n');
+}
+
+export function mergeManifest(existing, newEntries) {
+  const byKey = new Map();
+  for (const entry of existing.installed || []) {
+    byKey.set(entryKey(entry), entry);
+  }
+  for (const entry of newEntries) {
+    byKey.set(entryKey(entry), entry);
+  }
+  return { version: MANIFEST_VERSION, installed: [...byKey.values()] };
+}
+
+function entryKey(entry) {
+  // Baseline skills have no source; key by slug. Remote skills key by source/name.
+  return entry.kind === 'baseline' ? `baseline:${entry.slug}` : `${entry.source}/${entry.name || entry.slug}`;
+}
+
+export async function removeSkill(targetDir, slug) {
+  const manifest = await readManifest(targetDir);
+  const entry = manifest.installed.find(e => e.slug === slug);
+  if (!entry) {
+    throw new Error(`'${slug}' is not in the clud-bug manifest. If it's a custom skill, delete it manually with: rm -rf .claude/skills/${slug}`);
+  }
+  await rm(join(targetDir, slug), { recursive: true, force: true });
+  manifest.installed = manifest.installed.filter(e => e.slug !== slug);
+  await writeManifest(targetDir, manifest);
+  return entry;
+}
+
+export async function listInstalled(targetDir) {
+  const manifest = await readManifest(targetDir);
+  const managedSlugs = new Set(manifest.installed.map(e => e.slug));
+  const groups = { baseline: [], remote: [], custom: [] };
+  for (const entry of manifest.installed) {
+    (groups[entry.kind === 'baseline' ? 'baseline' : 'remote']).push(entry);
+  }
+
+  let entries;
+  try {
+    entries = await readdir(targetDir, { withFileTypes: true });
+  } catch {
+    return groups;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (managedSlugs.has(entry.name)) continue;
+    const skillFile = join(targetDir, entry.name, 'SKILL.md');
+    let description = '';
+    try {
+      const text = await readFile(skillFile, 'utf8');
+      const m = text.match(/^description:\s*(.+)$/m);
+      description = m?.[1]?.trim() || '';
+    } catch {
+      continue; // not a skill dir
+    }
+    groups.custom.push({ slug: entry.name, kind: 'custom', description });
+  }
+  return groups;
+}
+
+// Diff a current manifest against a freshly-recommended skill set.
+// Returns { add: [], remove: [], unchanged: [] }. Custom skills are never affected.
+export function diffManifest(manifest, recommended) {
+  const recByKey = new Map(recommended.map(s => [
+    s.kind === 'baseline' ? `baseline:${sanitizeSlug(s.name)}` : `${s.source}/${s.name}`,
+    s,
+  ]));
+  const installedByKey = new Map(manifest.installed.map(e => [entryKey(e), e]));
+
+  const add = [];
+  const remove = [];
+  const unchanged = [];
+
+  for (const [key, skill] of recByKey) {
+    if (installedByKey.has(key)) {
+      unchanged.push(skill);
+    } else {
+      add.push(skill);
+    }
+  }
+  for (const [key, entry] of installedByKey) {
+    if (entry.kind === 'baseline') continue; // baseline always stays
+    if (!recByKey.has(key)) remove.push(entry);
+  }
+  return { add, remove, unchanged };
 }
 
 function sanitizeSlug(name) {
   return name.toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '');
 }
 
-export const _internal = { normalizeList, sanitizeSlug, MAX_SKILLS, API_BASE };
+export const _internal = { normalizeList, sanitizeSlug, entryKey, MAX_SKILLS, API_BASE, MANIFEST_FILE };

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -116,6 +116,36 @@ test('refresh in empty repo prompts to init first', async () => {
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 
+test('refresh aborts (does NOT remove remote skills) when skills.sh is unreachable', async () => {
+  const dir = await makeRepo({ 'package.json': JSON.stringify({ dependencies: { next: '^15' }})});
+  try {
+    // Hand-craft a manifest that includes a remote skill (simulates a previous successful add).
+    await mkdir(join(dir, '.claude/skills/some-remote'), { recursive: true });
+    await writeFile(join(dir, '.claude/skills/some-remote/SKILL.md'), '---\nname: some-remote\n---');
+    await writeFile(
+      join(dir, '.claude/skills/.clud-bug.json'),
+      JSON.stringify({ version: 1, installed: [
+        { slug: 'some-remote', source: 'foo', name: 'some-remote', kind: 'remote' },
+      ]}, null, 2),
+    );
+
+    // Force fetch failure by pointing at an unresolvable host via env.
+    // We can't easily monkey-patch fetch in a child process, so use --offline=false
+    // and an env shim that swaps the SkillsClient base URL.
+    const r = run(dir, ['refresh', '--accept-all'], {
+      env: { CLUD_BUG_SKILLS_SH_BASE: 'http://127.0.0.1:1' },
+    });
+
+    // Either the process exits non-zero with the refusal warning, OR the API isn't
+    // overridable from env (in which case skip — covered by skills.test.js diff logic).
+    // We must NEVER see "skills updated" indicating removal proceeded.
+    assert.doesNotMatch(r.stdout + r.stderr, /skills updated/, 'refresh proceeded with removals despite API failure');
+    // Verify the remote skill is still on disk
+    const stillThere = await readFile(join(dir, '.claude/skills/some-remote/SKILL.md'), 'utf8');
+    assert.match(stillThere, /some-remote/);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
 test('refresh --offline shows no-op when only baseline installed', async () => {
   const dir = await makeRepo({ 'package.json': '{}' });
   try {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,127 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtemp, writeFile, mkdir, rm, readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const CLI = join(dirname(dirname(fileURLToPath(import.meta.url))), 'bin', 'clud-bug.js');
+
+function run(cwd, args, opts = {}) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...(opts.env || {}) },
+    input: opts.input,
+  });
+}
+
+async function makeRepo(files = {}) {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-cli-'));
+  for (const [path, content] of Object.entries(files)) {
+    const full = join(dir, path);
+    await mkdir(join(full, '..'), { recursive: true });
+    await writeFile(full, content);
+  }
+  return dir;
+}
+
+test('--help prints usage including all subcommands', () => {
+  const r = run(process.cwd(), ['--help']);
+  assert.equal(r.status, 0);
+  for (const cmd of ['init', 'list', 'add', 'remove', 'refresh']) {
+    assert.match(r.stdout, new RegExp(cmd));
+  }
+});
+
+test('--version prints package version', () => {
+  const r = run(process.cwd(), ['--version']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout.trim(), /^\d+\.\d+\.\d+$/);
+});
+
+test('unknown command exits 2 with help', () => {
+  const r = run(process.cwd(), ['nonsense']);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /Unknown command/);
+});
+
+test('init --offline --accept-all in a fresh repo writes workflow + manifest', async () => {
+  const dir = await makeRepo({
+    'package.json': JSON.stringify({ name: 'demo', dependencies: { next: '^15' }}),
+  });
+  try {
+    const r = run(dir, ['init', '--offline', '--accept-all']);
+    assert.equal(r.status, 0, `init failed: ${r.stderr}`);
+    const wf = await readFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'utf8');
+    assert.match(wf, /allowedTools/);
+    const manifest = JSON.parse(await readFile(join(dir, '.claude/skills/.clud-bug.json'), 'utf8'));
+    assert.equal(manifest.installed.length, 3, 'should install 3 baseline skills');
+    assert.ok(manifest.installed.every(e => e.kind === 'baseline'));
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('list shows baseline + custom after init + hand-authored skill', async () => {
+  const dir = await makeRepo({ 'package.json': '{}' });
+  try {
+    run(dir, ['init', '--offline', '--accept-all']);
+    // hand-author a custom skill
+    const customDir = join(dir, '.claude/skills/my-team-rules');
+    await mkdir(customDir, { recursive: true });
+    await writeFile(join(customDir, 'SKILL.md'), '---\nname: my-team-rules\ndescription: our rules\n---');
+    const r = run(dir, ['list']);
+    assert.equal(r.status, 0, `list failed: ${r.stderr}`);
+    assert.match(r.stdout, /Baseline/);
+    assert.match(r.stdout, /Custom/);
+    assert.match(r.stdout, /my-team-rules/);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('list reports zero state cleanly', async () => {
+  const dir = await makeRepo({});
+  try {
+    const r = run(dir, ['list']);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /No skills installed/);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('remove refuses unmanaged slug, succeeds on managed one', async () => {
+  const dir = await makeRepo({});
+  try {
+    run(dir, ['init', '--offline', '--accept-all']);
+    const fail = run(dir, ['remove', 'no-such-slug']);
+    assert.notEqual(fail.status, 0);
+    assert.match(fail.stderr, /not in the clud-bug manifest/);
+    // baseline slug should be removable (will return on next init)
+    const ok = run(dir, ['remove', 'critical-issues-only']);
+    assert.equal(ok.status, 0, ok.stderr);
+    assert.match(ok.stdout, /removed critical-issues-only/);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('add rejects malformed ref', () => {
+  const r = run(process.cwd(), ['add', 'no-slash']);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /Usage: clud-bug add/);
+});
+
+test('refresh in empty repo prompts to init first', async () => {
+  const dir = await makeRepo({});
+  try {
+    const r = run(dir, ['refresh', '--offline', '--accept-all']);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /Run `clud-bug init` first/);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('refresh --offline shows no-op when only baseline installed', async () => {
+  const dir = await makeRepo({ 'package.json': '{}' });
+  try {
+    run(dir, ['init', '--offline', '--accept-all']);
+    const r = run(dir, ['refresh', '--offline', '--accept-all']);
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /Nothing to update|skills updated/);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -146,6 +146,29 @@ test('refresh aborts (does NOT remove remote skills) when skills.sh is unreachab
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 
+test('refresh --offline --accept-all does NOT remove remote skills from manifest', async () => {
+  const dir = await makeRepo({ 'package.json': '{}' });
+  try {
+    // Pre-existing manifest with a remote skill (simulates a previous successful add).
+    await mkdir(join(dir, '.claude/skills/keep-me'), { recursive: true });
+    await writeFile(join(dir, '.claude/skills/keep-me/SKILL.md'), '---\nname: keep-me\n---');
+    await writeFile(
+      join(dir, '.claude/skills/.clud-bug.json'),
+      JSON.stringify({ version: 1, installed: [
+        { slug: 'keep-me', source: 'foo', name: 'keep-me', kind: 'remote' },
+      ]}, null, 2),
+    );
+    const r = run(dir, ['refresh', '--offline', '--accept-all']);
+    assert.equal(r.status, 0, r.stderr);
+    // Remote skill must still exist on disk
+    const stillThere = await readFile(join(dir, '.claude/skills/keep-me/SKILL.md'), 'utf8');
+    assert.match(stillThere, /keep-me/);
+    // And still in the manifest
+    const manifest = JSON.parse(await readFile(join(dir, '.claude/skills/.clud-bug.json'), 'utf8'));
+    assert.ok(manifest.installed.some(e => e.slug === 'keep-me'));
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
 test('refresh --offline shows no-op when only baseline installed', async () => {
   const dir = await makeRepo({ 'package.json': '{}' });
   try {

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -1,9 +1,14 @@
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile, mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { SkillsClient, rankAndCap, writeSkills, loadBaseline, _internal } from '../lib/skills.js';
+import {
+  SkillsClient, rankAndCap, writeSkills, loadBaseline,
+  readManifest, writeManifest, mergeManifest,
+  removeSkill, listInstalled, diffManifest,
+  _internal,
+} from '../lib/skills.js';
 
 function mockFetch(routes) {
   return async (url) => {
@@ -131,4 +136,127 @@ test('loadBaseline returns empty if directory missing', async () => {
 test('sanitizeSlug normalizes names safely', () => {
   assert.equal(_internal.sanitizeSlug('Foo Bar!'), 'foo-bar');
   assert.equal(_internal.sanitizeSlug('--Already-OK--'), 'already-ok');
+});
+
+test('writeSkills creates a manifest tracking what it installed', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-manifest-'));
+  try {
+    const client = new SkillsClient({
+      fetch: mockFetch({ '/skills/foo/bar': { content: 'remote body' } }),
+    });
+    await writeSkills(dir, [
+      { source: 'foo', name: 'bar', kind: 'remote' },
+      { source: 'clud-bug-baseline', name: 'baseline-skill', kind: 'baseline', content: 'b' },
+    ], client);
+    const manifest = await readManifest(dir);
+    assert.equal(manifest.installed.length, 2);
+    const baseline = manifest.installed.find(e => e.kind === 'baseline');
+    const remote = manifest.installed.find(e => e.kind === 'remote');
+    assert.equal(baseline.slug, 'baseline-skill');
+    assert.equal(remote.slug, 'bar');
+    assert.equal(remote.source, 'foo');
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('readManifest returns empty when file missing', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-empty-'));
+  try {
+    const m = await readManifest(dir);
+    assert.equal(m.installed.length, 0);
+    assert.equal(m.version, 1);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('mergeManifest replaces by key, never duplicates', () => {
+  const existing = { installed: [
+    { slug: 'a', source: 'x', name: 'a', kind: 'remote' },
+    { slug: 'baseline-thing', kind: 'baseline' },
+  ]};
+  const merged = mergeManifest(existing, [
+    { slug: 'a', source: 'x', name: 'a', kind: 'remote', description: 'updated' },
+    { slug: 'b', source: 'y', name: 'b', kind: 'remote' },
+  ]);
+  assert.equal(merged.installed.length, 3);
+  assert.equal(merged.installed.find(e => e.slug === 'a').description, 'updated');
+});
+
+test('writeSkills called twice merges manifests instead of overwriting', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-merge-'));
+  try {
+    const client = new SkillsClient({ fetch: mockFetch({
+      '/skills/a/x': { content: 'A' },
+      '/skills/b/y': { content: 'B' },
+    })});
+    await writeSkills(dir, [{ source: 'a', name: 'x', kind: 'remote' }], client);
+    await writeSkills(dir, [{ source: 'b', name: 'y', kind: 'remote' }], client);
+    const m = await readManifest(dir);
+    const slugs = m.installed.map(e => e.slug).sort();
+    assert.deepEqual(slugs, ['x', 'y']);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('removeSkill deletes dir and manifest entry; refuses non-managed slug', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-remove-'));
+  try {
+    const client = new SkillsClient({ fetch: mockFetch({ '/skills/x/y': { content: 'C' } })});
+    await writeSkills(dir, [{ source: 'x', name: 'y', kind: 'remote' }], client);
+    await removeSkill(dir, 'y');
+    const m = await readManifest(dir);
+    assert.equal(m.installed.length, 0);
+    await assert.rejects(removeSkill(dir, 'never-installed'), /not in the clud-bug manifest/);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('listInstalled groups baseline / remote / custom correctly', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-list-'));
+  try {
+    const client = new SkillsClient({ fetch: mockFetch({ '/skills/foo/bar': { content: 'r' } })});
+    await writeSkills(dir, [
+      { source: 'foo', name: 'bar', kind: 'remote', description: 'remote desc' },
+      { source: 'clud-bug-baseline', name: 'discipline', kind: 'baseline', content: '---\nname: discipline\ndescription: rules\n---', description: '(bundled baseline)' },
+    ], client);
+    // hand-author a custom skill
+    const customDir = join(dir, 'my-custom');
+    await mkdir(customDir, { recursive: true });
+    await writeFile(join(customDir, 'SKILL.md'), '---\nname: my-custom\ndescription: my team rules\n---\n# rules');
+
+    const groups = await listInstalled(dir);
+    assert.equal(groups.baseline.length, 1);
+    assert.equal(groups.remote.length, 1);
+    assert.equal(groups.custom.length, 1);
+    assert.equal(groups.custom[0].slug, 'my-custom');
+    assert.equal(groups.custom[0].description, 'my team rules');
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('diffManifest produces add/remove/unchanged buckets and ignores baseline removal', () => {
+  const manifest = { installed: [
+    { slug: 'a', source: 'x', name: 'a', kind: 'remote' },
+    { slug: 'b', source: 'y', name: 'b', kind: 'remote' },
+    { slug: 'baseline-1', kind: 'baseline' },
+  ]};
+  const recommended = [
+    { source: 'x', name: 'a', kind: 'remote' },     // unchanged
+    { source: 'z', name: 'c', kind: 'remote' },     // new add
+  ];
+  const diff = diffManifest(manifest, recommended);
+  assert.equal(diff.unchanged.length, 1);
+  assert.equal(diff.add.length, 1);
+  assert.equal(diff.add[0].name, 'c');
+  assert.equal(diff.remove.length, 1);
+  assert.equal(diff.remove[0].slug, 'b');  // baseline-1 not removed
+});
+
+test('writeSkill (single) writes one SKILL.md without touching manifest', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-single-'));
+  try {
+    const client = new SkillsClient({ fetch: mockFetch({ '/skills/p/q': { content: 'single' } })});
+    const { writeSkill } = await import('../lib/skills.js');
+    const entry = await writeSkill(dir, { source: 'p', name: 'q', kind: 'remote' }, client);
+    assert.equal(entry.slug, 'q');
+    assert.equal(await readFile(join(dir, 'q', 'SKILL.md'), 'utf8'), 'single');
+    // No manifest written by writeSkill alone
+    const m = await readManifest(dir);
+    assert.equal(m.installed.length, 0);
+  } finally { await rm(dir, { recursive: true, force: true }); }
 });


### PR DESCRIPTION
## Summary

Adds 4 new CLI subcommands so users can evolve their skill set after `init` without re-running setup or clobbering custom skills:

| Command | Purpose |
|---|---|
| \`clud-bug list\` | Show installed skills grouped by baseline / from skills.sh / custom |
| \`clud-bug add <source/name>\` | Install one skill from skills.sh |
| \`clud-bug remove <slug>\` | Delete a clud-bug-managed skill (refuses custom skills) |
| \`clud-bug refresh\` | Re-query skills.sh, diff vs installed, prompt to apply |

## Why a manifest?

Today \`writeSkills\` drops SKILL.md files with no provenance. Without knowing which files clud-bug installed vs which the user wrote, \`refresh\` would either be unsafe (might delete custom skills) or useless (touches nothing).

Solution: \`.claude/skills/.clud-bug.json\` — a small manifest of \`{ slug, source, name, kind }\` entries. Anything in the skills dir not in the manifest is treated as user-authored and never modified.

## Test plan

- [x] \`npm test\` → 46/46 pass (was 28; +8 manifest unit tests, +10 CLI integration tests)
- [x] Local smoke: \`node bin/clud-bug.js list\` runs against this repo
- [ ] CI green (test + actionlint)
- [ ] Clud Bug self-review on this PR (dogfood — should reference critical-issues-only and evidence-based-review skills)

## Migration note for existing v0.1 installs

Repos that ran \`init\` under v0.1 don't have the manifest yet. \`clud-bug list\` will report their skills as "Custom" until they re-run \`init\` (which will populate the manifest). Existing skills keep working — manifest is purely a clud-bug management concern.