### PR TITLE
Add parallel Claude Review baseline + auto-resolve old threads

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,42 @@
+name: Claude Code Review (baseline)
+
+# Stock anthropics/claude-code-action review running alongside clud-bug-review.yml
+# for direct comparison until we're confident clud-bug consistently surpasses it.
+# Removing this workflow once clud-bug has a track record is intended.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
+          prompt: |
+            Review this pull request. Start your comment with the line:
+
+              ## 🤖 Claude Review (baseline)
+
+            so it's clearly distinguished from clud-bug's project-aware review on
+            the same PR. Focus on critical issues only — bugs, security,
+            performance, broken tests. Skip nits.
+
+            Post via:
+              gh pr comment "$PR_NUMBER" --body "<your review>"
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -22,7 +22,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*)"
           prompt: |
             This project is "clud-bug". Claude Code PR review GitHub Action with project-aware skills auto-discovered from skills.sh. It's primarily javascript.
 
@@ -52,6 +52,21 @@ jobs:
 
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"
+
+            If you previously reviewed this PR (you'll see prior claude[bot]
+            comments starting with "## 🐛 Clud Bug review"), resolve your
+            prior unresolved inline review threads where the flagged issue
+            is fixed in the current diff. List threads:
+
+              gh api graphql -f query='{ repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") { pullRequest(number: '"$PR_NUMBER"') { reviewThreads(first: 30) { nodes { id isResolved comments(first: 1) { nodes { body author { login } } } } } } } }'
+
+            For each unresolved thread you (claude[bot]) authored where the
+            issue is now addressed:
+
+              gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<id>"}) { thread { isResolved } } }'
+
+            Only resolve threads where the fix is verifiable in the diff.
+            Leave unresolved any thread whose issue still stands.
             For line-specific issues, use the github_inline_comment MCP tool
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -22,7 +22,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 
@@ -51,6 +51,21 @@ jobs:
 
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"
+
+            If you previously reviewed this PR (you'll see prior claude[bot]
+            comments starting with "## 🐛 Clud Bug review"), resolve your
+            prior unresolved inline review threads where the flagged issue
+            is fixed in the current diff. List threads:
+
+              gh api graphql -f query='{ repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") { pullRequest(number: '"$PR_NUMBER"') { reviewThreads(first: 30) { nodes { id isResolved comments(first: 1) { nodes { body author { login } } } } } } } }'
+
+            For each unresolved thread you (claude[bot]) authored where the
+            issue is now addressed:
+
+              gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<id>"}) { thread { isResolved } } }'
+
+            Only resolve threads where the fix is verifiable in the diff.
+            Leave unresolved any thread whose issue still stands.
             For line-specific issues, use the github_inline_comment MCP tool
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -22,7 +22,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 
@@ -52,6 +52,21 @@ jobs:
 
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"
+
+            If you previously reviewed this PR (you'll see prior claude[bot]
+            comments starting with "## 🐛 Clud Bug review"), resolve your
+            prior unresolved inline review threads where the flagged issue
+            is fixed in the current diff. List threads:
+
+              gh api graphql -f query='{ repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") { pullRequest(number: '"$PR_NUMBER"') { reviewThreads(first: 30) { nodes { id isResolved comments(first: 1) { nodes { body author { login } } } } } } } }'
+
+            For each unresolved thread you (claude[bot]) authored where the
+            issue is now addressed:
+
+              gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<id>"}) { thread { isResolved } } }'
+
+            Only resolve threads where the fix is verifiable in the diff.
+            Leave unresolved any thread whose issue still stands.
             For line-specific issues, use the github_inline_comment MCP tool
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -22,7 +22,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 
@@ -48,6 +48,21 @@ jobs:
 
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"
+
+            If you previously reviewed this PR (you'll see prior claude[bot]
+            comments starting with "## 🐛 Clud Bug review"), resolve your
+            prior unresolved inline review threads where the flagged issue
+            is fixed in the current diff. List threads:
+
+              gh api graphql -f query='{ repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") { pullRequest(number: '"$PR_NUMBER"') { reviewThreads(first: 30) { nodes { id isResolved comments(first: 1) { nodes { body author { login } } } } } } } }'
+
+            For each unresolved thread you (claude[bot]) authored where the
+            issue is now addressed:
+
+              gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<id>"}) { thread { isResolved } } }'
+
+            Only resolve threads where the fix is verifiable in the diff.
+            Leave unresolved any thread whose issue still stands.
             For line-specific issues, use the github_inline_comment MCP tool
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.


### PR DESCRIPTION
## Summary

Two related changes addressing UX gaps surfaced after the v0.1 ship:

### 1. Run stock Claude Review in parallel as a baseline

Adds \`.github/workflows/claude-code-review.yml\` — the official anthropics/claude-code-action with the same \`--allowedTools\` fix clud-bug ships, but no skills, no project-aware prompt. Comments are labeled \`## 🤖 Claude Review (baseline)\` so they're visually distinct from clud-bug's \`## 🐛 Clud Bug review\`.

Goal: keep both running on every PR until clud-bug's curated/skill-aware review has a track record of consistently doing more useful work than the stock baseline. Remove the baseline workflow once that's clear.

### 2. Auto-resolve prior review threads

Branch protection requires conversation resolution before merge. Today, when clud-bug re-reviews an updated PR, its old inline review threads stay open even after the issues are fixed in code — blocking the merge until a human resolves them manually.

All four workflows (3 templates + dogfooded) now instruct the bot to:
1. List its own prior unresolved review threads on the current PR.
2. Check each one against the current diff.
3. Resolve only the threads where the flagged issue is verifiably addressed.
4. Leave unresolved any thread whose issue still stands.

This unblocks iterative PRs without admin overrides.

\`allowedTools\` widened to include \`gh api graphql:*\` and \`gh api repos/:*\` (needed for the resolve mutation).

## Test plan

- [x] \`npm test\` → 48/48 still pass (no JS changes)
- [ ] CI green
- [ ] Both Claude Review (baseline) and Clud Bug review post comments on this PR — confirms parallel setup works
- [ ] On a follow-up push, clud-bug resolves its own prior threads if their issues are fixed

## Forward plan

Remove \`claude-code-review.yml\` once we've seen ~5-10 PRs where clud-bug's review is clearly more useful than the baseline. Until then, having both running is cheap insurance.