### PR TITLE
Release 0.2.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,22 @@
+# Belt-and-suspenders: package.json `files` is authoritative, but this
+# guarantees nothing accidentally ends up in the tarball if someone adds
+# a new top-level file later.
+
+test/
+site/
+.github/
+.claude/
+.vercel/
+.git/
+.gitignore
+.npmignore
+
+# Build artifacts
+node_modules/
+*.tgz
+*.log
+.DS_Store
+
+# Plans / dev-only
+/Users/
+CHANGELOG.md.bak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] — 2026-05-15
+
+### Added
+- **Public npm release.** `npx clud-bug init` now works from any directory.
+- **Skill management commands.** `clud-bug list`, `clud-bug add <source/name>`, `clud-bug remove <slug>`, `clud-bug refresh` — evolve your skill set after `init` without clobbering custom skills.
+- **`.claude/skills/.clud-bug.json` manifest.** Tracks provenance so commands can distinguish baseline / skills.sh / custom skills.
+- **`CLUD_BUG_SKILLS_SH_BASE` env var.** Test seam for overriding the skills.sh API base URL.
+- **1-page site at [cludbug.dev](https://cludbug.dev).** Field-guide aesthetic; install instructions and the differentiating wedge in one place.
+- **Parallel baseline review workflow** (`.github/workflows/claude-code-review.yml` in this repo only). Stock `anthropics/claude-code-action` runs alongside clud-bug-review for comparison until clud-bug's track record is established.
+- **Auto-resolve prior review threads.** Workflow templates now teach the bot to resolve its own prior inline review threads when re-reviewing a PR, unblocking the conversation-resolution branch protection rule on iterative PRs.
+
+### Fixed
+- **`refresh` no longer mass-deletes skills when skills.sh is unreachable.** Previously, a transient API failure or `.catch(() => [])` would surface as an empty recommendation set, and `--accept-all` would silently remove every remote skill in the manifest. Now aborts with exit 1.
+- **`refresh --offline` no longer mass-deletes remote skills.** Same root cause as above. In offline mode, removals are explicitly suppressed since the recommendation set isn't authoritative.
+
+## [0.1.0] — 2026-03-11
+
+### Added
+- Initial release. `clud-bug init` CLI: detects repo signals, queries skills.sh, installs matching skills, generates a working `.github/workflows/clud-bug-review.yml`.
+- Three workflow templates (generic / TS / Python) with the `--allowedTools` whitelist needed for `gh pr comment` to actually post reviews.
+- Three baseline skills shipped in the package: `critical-issues-only`, `evidence-based-review`, `respect-existing-conventions`.
+- 28 unit tests, repo-level CI (test + actionlint).
+
+[0.2.0]: https://github.com/thrillmot/clud-bug/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/thrillmot/clud-bug/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "clud-bug",
-  "version": "0.1.0",
-  "description": "Claude Code PR review GitHub Action with project-aware skills auto-discovered from skills.sh",
+  "version": "0.2.0",
+  "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
+  "homepage": "https://cludbug.dev",
+  "bugs": "https://github.com/thrillmot/clud-bug/issues",
   "type": "module",
   "license": "MIT",
   "author": "thrillmot",
@@ -32,6 +34,7 @@
     "node": ">=20"
   },
   "scripts": {
-    "test": "node --test test/*.test.js"
+    "test": "node --test test/*.test.js",
+    "prepublishOnly": "npm test"
   }
 }


### PR DESCRIPTION
## Summary

v0.2 Workstream C. Prepares for the npm public release.

- Version: 0.1.0 → 0.2.0
- \`prepublishOnly: npm test\` — can't publish broken code
- \`.npmignore\` — belt-and-suspenders against accidental leaks
- \`CHANGELOG.md\` — 0.2.0 entry covers everything from Workstreams A + B + the parallel-review/thread-resolution PR
- \`homepage: https://cludbug.dev\` + \`bugs:\` URL in package.json

## \`npm pack --dry-run\` output

\`\`\`
clud-bug@0.2.0
Tarball Contents
   1.1kB LICENSE
   5.9kB README.md
  12.5kB bin/clud-bug.js
   7.8kB lib/detect.js
    708B lib/render.js
   8.3kB lib/skills.js
    865B package.json
   1.3kB templates/skills/baseline/critical-issues-only.md
   1.3kB templates/skills/baseline/evidence-based-review.md
   1.6kB templates/skills/baseline/respect-existing-conventions.md
   3.2kB templates/workflow-py.yml.tmpl
   3.2kB templates/workflow-ts.yml.tmpl
   2.9kB templates/workflow.yml.tmpl
package size:   15.8 kB
unpacked size:  50.8 kB
total files:    13
\`\`\`

Confirmed clean: no \`test/\`, no \`site/\`, no \`.github/\`, no \`.claude/\`.

## Post-merge steps (you run)

\`\`\`bash
git tag v0.2.0 && git push --tags
npm publish
\`\`\`

You'll need to \`npm login\` first if you haven't already.

## Test plan

- [x] \`npm test\` → 48/48 pass
- [x] \`npm pack --dry-run\` → tarball contents correct (13 files)
- [ ] CI green
- [ ] Both reviewers approve