### PR TITLE
Release 0.2.1: silence bin script-name publish warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] — 2026-05-15
+
+### Fixed
+- Silence `bin[clud-bug] script name was cleaned` publish warning by switching to the shorthand `"bin": "bin/clud-bug.js"` form (preferred when the binary name matches the package name).
+
 ## [0.2.0] — 2026-05-15
 
 ### Added
@@ -25,5 +30,6 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 - Three baseline skills shipped in the package: `critical-issues-only`, `evidence-based-review`, `respect-existing-conventions`.
 - 28 unit tests, repo-level CI (test + actionlint).
 
+[0.2.1]: https://github.com/thrillmot/clud-bug/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/thrillmot/clud-bug/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/thrillmot/clud-bug/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",
@@ -20,9 +20,7 @@
     "ai",
     "skills"
   ],
-  "bin": {
-    "clud-bug": "./bin/clud-bug.js"
-  },
+  "bin": "bin/clud-bug.js",
   "files": [
     "bin",
     "lib",


### PR DESCRIPTION
## Summary

Patch release. Silences the \`bin[clud-bug] script name was cleaned\` warning that npm emitted during the 0.2.0 publish.

The fix: switch from the object form to npm's preferred shorthand when the binary name matches the package name.

\`\`\`diff
- "bin": {
-   "clud-bug": "./bin/clud-bug.js"
- },
+ "bin": "bin/clud-bug.js",
\`\`\`

## Verification

\`npm pack --dry-run\` on this branch — no warnings, identical 13-file 15.8 kB tarball.

## Post-merge

\`\`\`bash
git tag v0.2.1 && git push --tags
npm publish
\`\`\`