### PR TITLE
v0.2.2: brand voice + leaf/citrus palette + Node 24 fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
       - run: npm test
@@ -18,8 +18,8 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
       - name: Render templates with placeholder values

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,11 +17,14 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - uses: anthropics/claude-code-action@v1
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
@@ -38,5 +41,3 @@ jobs:
 
             Post via:
               gh pr comment "$PR_NUMBER" --body "<your review>"
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -13,11 +13,12 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: anthropics/claude-code-action@v1
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
@@ -42,6 +43,11 @@ jobs:
 
             Any project-specific skills loaded from .claude/skills/ should
             shape your review — defer to their guidance over generic advice.
+
+            Tone: address the author conversationally. A concise field-naturalist
+            voice is welcome (you are Clud Bug, examining specimens of code) but
+            never at the cost of clarity, evidence, or the critical-issues-only
+            discipline. Don't perform the bit; let the precision speak.
 
             When you finish, post your review as a single PR comment.
             The comment body MUST start with this exact line so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] — 2026-05-15
+
+### Changed
+- **Brand voice extends past the site.** CLI log strings, README intro, and review-prompt tone now consistently inhabit the field-naturalist voice the site already used. The bot is told to address authors conversationally without sacrificing clarity or critical-issues-only discipline.
+- **Color palette swap on cludbug.dev.** Replace the crimson accent with leaf-green primary + citrus-orange highlights — taken from the clud-bug emoji's actual colors. Crimson is now reserved for "critical issue" badges only.
+- **Node.js 20 deprecation fix.** All workflow templates now bump `actions/checkout@v5` and `actions/setup-node@v5`, and set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` so generated workflows stop emitting deprecation warnings ahead of GitHub's June 2 / Sept 16 cutovers.
+
 ## [0.2.1] — 2026-05-15
 
 ### Fixed
@@ -30,6 +37,7 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 - Three baseline skills shipped in the package: `critical-issues-only`, `evidence-based-review`, `respect-existing-conventions`.
 - 28 unit tests, repo-level CI (test + actionlint).
 
+[0.2.2]: https://github.com/thrillmot/clud-bug/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/thrillmot/clud-bug/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/thrillmot/clud-bug/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/thrillmot/clud-bug/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Clud Bug 🐛
-### Crawling all over your code
+### A field guide to specimens crawling your code
 
-> **[cludbug.dev](https://cludbug.dev)** · A field guide.
+> **[cludbug.dev](https://cludbug.dev)** · live field journal.
 
-Claude PR review for any GitHub repo, with **project-aware skills** auto-discovered from [skills.sh](https://skills.sh) and a baseline of review-discipline skills bundled in.
+Clud Bug is a Claude PR-review naturalist for your GitHub repo. It pins **project-aware skills** auto-discovered from [skills.sh](https://skills.sh) and ships a baseline kit of review discipline so reviews stay focused on what matters: bugs, security, performance, and missing tests.
 
-One command to install. The first PR you open afterwards gets a real review comment back.
+One command to install. The first PR you open afterwards gets a real review comment back — typically within two minutes.
 
 ## Quickstart
 
@@ -24,14 +24,16 @@ Open a PR. A review comment should appear within ~2 minutes.
 
 ## What `clud-bug init` does
 
-1. **Detects** your stack (Node, Python, Go, Rust, Ruby — reads `package.json`, `pyproject.toml`, `go.mod`, etc.).
-2. **Queries [skills.sh](https://skills.sh)** for review skills relevant to your dependencies (e.g. a Next.js project gets Next.js review skills).
-3. **Installs three baseline skills** that enforce review discipline regardless of stack:
+The naturalist arrives at your repo, surveys the habitat, and assembles a field kit:
+
+1. **Surveys habitat.** Reads `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, etc., to learn what your stack is.
+2. **Consults [skills.sh](https://skills.sh).** Pulls review skills relevant to your dependencies (e.g. a Next.js project gets Next.js review specimens).
+3. **Pins three baseline specimens** that enforce review discipline regardless of stack:
    - `critical-issues-only` — flag bugs, security, perf only. Skip nits.
    - `evidence-based-review` — every claim must quote the line being criticized.
    - `respect-existing-conventions` — don't suggest fights with the codebase's patterns.
-4. **Writes** the chosen skills to `.claude/skills/<name>/SKILL.md` (Claude Code auto-loads them in the GitHub Action).
-5. **Generates** `.github/workflows/clud-bug-review.yml` with the project description filled in and the right permissions/tool allowlist for `gh pr comment` to actually work.
+4. **Writes** the chosen specimens to `.claude/skills/<name>/SKILL.md` (Claude Code auto-loads them in the GitHub Action).
+5. **Drafts the field kit** at `.github/workflows/clud-bug-review.yml` with your project description filled in and the right permissions/tool allowlist for `gh pr comment` to actually post.
 
 ## CLI options
 

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -30,22 +30,22 @@ function parseArgs(argv) {
   return args;
 }
 
-const HELP = `clud-bug — Claude PR review with project-aware skills
+const HELP = `clud-bug 🐛 — a field guide to specimens crawling your code
 
 Usage:
   npx clud-bug <command> [options]
 
 Commands:
-  init                  First-time setup: detect repo, install skills, write workflow.
-  list                  Show currently installed skills (baseline / remote / custom).
-  add <source/name>     Install one skill from skills.sh (e.g. vercel-labs/skills/next-best-practices).
-  remove <slug>         Remove an installed skill (refuses if it's a custom skill).
-  refresh               Re-query skills.sh and diff against installed; prompt to update.
+  init                  Open field season: survey the repo, pin baseline specimens, write the workflow.
+  list                  Show your collection (baseline / from skills.sh / custom).
+  add <source/name>     Pin one new specimen from skills.sh (e.g. vercel-labs/skills/next-best-practices).
+  remove <slug>         Unpin a clud-bug-managed specimen (refuses to touch your custom ones).
+  refresh               Re-survey, diff against your collection, prompt to update.
 
 Options:
-  --offline             Skip skills.sh; only use bundled baseline skills (init/refresh).
-  --accept-all,-y       Accept recommendations without prompting.
-  --commit              git add + commit the generated files when done (init only).
+  --offline             Skip skills.sh; pin only the bundled baseline specimens.
+  --accept-all,-y       Accept the recommended specimens without prompting.
+  --commit              git add + commit the generated kit when done (init only).
   --help,-h             Show this help.
   --version,-v          Show version.
 `;
@@ -75,15 +75,15 @@ async function main() {
 
 async function runInit(args) {
   const cwd = process.cwd();
-  log(`🐛 clud-bug init in ${cwd}`);
+  log(`🐛 Field season opens in ${cwd}.`);
 
-  log('  detecting repo signals...');
+  log('  surveying habitat...');
   const signals = await detect(cwd);
   log(`    primary language: ${signals.primaryLanguage || '(unknown)'}`);
   log(`    search terms:     ${signals.searchTerms.join(', ') || '(none)'}`);
 
   const baseline = await loadBaseline(BASELINE_DIR);
-  log(`    baseline skills:  ${baseline.length}`);
+  log(`    baseline kit:     ${baseline.length} specimens`);
 
   let curated = [];
   let searched = [];
@@ -92,7 +92,7 @@ async function runInit(args) {
   } else {
     const client = new SkillsClient();
     try {
-      log('  querying skills.sh...');
+      log('  consulting skills.sh...');
       [curated, searched] = await Promise.all([
         client.curated().catch(err => { warn(`curated query failed: ${err.message}`); return []; }),
         client.search(signals.searchTerms).catch(err => { warn(`search failed: ${err.message}`); return []; }),
@@ -105,7 +105,7 @@ async function runInit(args) {
 
   const recommended = rankAndCap(curated, searched, baseline);
   log('');
-  log('Recommended skills:');
+  log('Specimens to pin:');
   for (const s of recommended) {
     const tag = s.kind === 'baseline' ? '[baseline]' : `[${s.source}]`;
     log(`  • ${s.name} ${tag}`);
@@ -118,12 +118,12 @@ async function runInit(args) {
     chosen = await promptForSkills(recommended);
   }
 
-  log('  installing skills into .claude/skills/...');
+  log('  pinning specimens to .claude/skills/...');
   const client = new SkillsClient();
   const written = await writeSkills(join(cwd, '.claude', 'skills'), chosen, client);
-  log(`    wrote ${written.length} skills`);
+  log(`    pinned ${written.length} specimens`);
 
-  log('  rendering workflow...');
+  log('  drafting field kit...');
   const tmplName = pickTemplate(signals.languages);
   const tmplPath = join(TEMPLATES, tmplName);
   const workflow = await renderFile(tmplPath, {
@@ -138,21 +138,21 @@ async function runInit(args) {
   if (args.commit) {
     log('  committing...');
     spawnSync('git', ['add', '.claude', '.github/workflows/clud-bug-review.yml'], { cwd, stdio: 'inherit' });
-    spawnSync('git', ['commit', '-m', 'Add clud-bug Claude PR review'], { cwd, stdio: 'inherit' });
+    spawnSync('git', ['commit', '-m', 'Add clud-bug 🐛 — a field guide to specimens crawling your code'], { cwd, stdio: 'inherit' });
   }
 
   log('');
-  log('Done. Next steps:');
+  log('Field kit assembled. Next:');
   log('  1. Set ANTHROPIC_API_KEY in your repo secrets:');
   log('     Settings → Secrets and variables → Actions → New repository secret');
   if (!args.commit) {
     log('  2. git add .claude .github/workflows/clud-bug-review.yml && git commit && git push');
-    log('  3. Open a PR — Clud Bug should comment within ~2 min.');
+    log('  3. Open a PR — the naturalist arrives within ~2 minutes.');
   } else {
-    log('  2. git push, then open a PR — Clud Bug should comment within ~2 min.');
+    log('  2. git push, then open a PR — the naturalist arrives within ~2 minutes.');
   }
   log('');
-  log('Drop your own .claude/skills/<name>/SKILL.md files anytime — they\'re auto-loaded.');
+  log('Drop your own .claude/skills/<name>/SKILL.md files anytime — they get pinned automatically.');
 }
 
 async function promptForSkills(recommended) {
@@ -182,13 +182,13 @@ async function runList(_args) {
   const groups = await listInstalled(skillsDir);
   const total = groups.baseline.length + groups.remote.length + groups.custom.length;
   if (total === 0) {
-    log('No skills installed yet. Run `clud-bug init` to get started.');
+    log('Empty collection. Run `clud-bug init` to open field season.');
     return;
   }
-  log(`🐛 ${total} skill${total === 1 ? '' : 's'} in .claude/skills/`);
+  log(`🐛 ${total} specimen${total === 1 ? '' : 's'} pinned in .claude/skills/`);
   if (groups.baseline.length) {
     log('');
-    log('Baseline (always installed):');
+    log('Baseline (always pinned):');
     for (const s of groups.baseline) log(`  • ${s.slug}`);
   }
   if (groups.remote.length) {
@@ -198,7 +198,7 @@ async function runList(_args) {
   }
   if (groups.custom.length) {
     log('');
-    log('Custom (yours, never auto-modified):');
+    log('Custom (your own — never auto-modified):');
     for (const s of groups.custom) {
       log(`  • ${s.slug}${s.description ? `  — ${s.description}` : ''}`);
     }
@@ -222,7 +222,7 @@ async function runAdd(args) {
   const manifest = await readManifest(skillsDir);
   const merged = { version: 1, installed: [...manifest.installed.filter(e => e.slug !== entry.slug), entry] };
   await writeManifest(skillsDir, merged);
-  log(`  ✓ installed ${entry.slug} → .claude/skills/${entry.slug}/SKILL.md`);
+  log(`  ✓ pinned ${entry.slug} → .claude/skills/${entry.slug}/SKILL.md`);
   log('  Commit + push to apply on the next PR.');
 }
 
@@ -234,7 +234,7 @@ async function runRemove(args) {
   }
   const skillsDir = join(process.cwd(), '.claude', 'skills');
   const entry = await removeSkill(skillsDir, slug);
-  log(`  ✓ removed ${entry.slug}${entry.kind === 'baseline' ? ' (baseline — will return on next init)' : ''}`);
+  log(`  ✓ unpinned ${entry.slug}${entry.kind === 'baseline' ? ' (baseline — returns on next init)' : ''}`);
 }
 
 async function runRefresh(args) {
@@ -242,11 +242,11 @@ async function runRefresh(args) {
   const skillsDir = join(cwd, '.claude', 'skills');
   const manifest = await readManifest(skillsDir);
   if (manifest.installed.length === 0) {
-    log('No clud-bug-managed skills found. Run `clud-bug init` first.');
+    log('No clud-bug-managed specimens found. Run `clud-bug init` first.');
     return;
   }
 
-  log('  detecting repo signals...');
+  log('  re-surveying habitat...');
   const signals = await detect(cwd);
   log(`    primary language: ${signals.primaryLanguage || '(unknown)'}`);
   log(`    search terms:     ${signals.searchTerms.join(', ') || '(none)'}`);
@@ -286,7 +286,7 @@ async function runRefresh(args) {
 
   if (diff.add.length === 0 && diff.remove.length === 0) {
     log('');
-    log('Nothing to update. Skills are in sync with skills.sh recommendations.');
+    log('Collection in sync with skills.sh — nothing to update.');
     return;
   }
 
@@ -307,7 +307,7 @@ async function runRefresh(args) {
   const client = new SkillsClient();
   if (diff.add.length) await writeSkills(skillsDir, diff.add, client);
   for (const entry of diff.remove) await removeSkill(skillsDir, entry.slug);
-  log('  ✓ skills updated. Commit + push to apply on the next PR.');
+  log('  ✓ collection updated. Commit + push to apply on the next PR.');
 }
 
 function rel(from, to) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -9,10 +9,16 @@
   --ink-soft: #6b5a40;
   --ink-faint: #7e6840;  /* darkened from #a99576 for WCAG AA contrast on cream paper */
 
-  /* Accents — only two, used sparingly */
-  --crimson: #8a1f1f;
+  /* Accents — palette taken from the clud-bug emoji itself
+     (green caterpillar, orange head, on warm cream).
+     --leaf is the primary accent; --citrus the secondary highlight;
+     --crimson reserved for "critical" semantic only. */
+  --leaf:        #5a8a2e;   /* primary accent */
+  --leaf-soft:   #8aab5e;
+  --citrus:      #d97a2e;   /* secondary highlight + hover */
+  --moss:        #4a5c30;
+  --crimson:     #8a1f1f;   /* reserved: critical-issue badge only */
   --crimson-soft: #b85454;
-  --moss: #4a5c30;
 
   /* Type */
   --display: var(--font-display), 'Fraunces', 'Cormorant Garamond', Georgia, serif;
@@ -159,7 +165,7 @@ main { position: relative; z-index: 1; }
 
 .title em {
   font-style: italic;
-  color: var(--crimson);
+  color: var(--leaf);
   font-variation-settings: 'opsz' 144, 'SOFT' 100, 'WONK' 1;
 }
 
@@ -201,7 +207,7 @@ main { position: relative; z-index: 1; }
 .install-box::before {
   content: '$';
   margin-right: 0.85rem;
-  color: var(--crimson);
+  color: var(--leaf);
   font-weight: 600;
 }
 
@@ -223,7 +229,7 @@ main { position: relative; z-index: 1; }
   transition: color 0.2s;
 }
 
-.actions a:hover { color: var(--crimson); border-bottom-color: var(--crimson); }
+.actions a:hover { color: var(--citrus); border-bottom-color: var(--citrus); }
 .actions .sep { color: var(--ink-faint); font-style: normal; font-family: var(--mono); }
 
 /* ─────────────────── SECTION SHELL ─────────────────── */
@@ -363,7 +369,7 @@ main { position: relative; z-index: 1; }
 
 .observation {
   background: var(--paper-warm);
-  border-left: 3px solid var(--crimson);
+  border-left: 3px solid var(--leaf);
   padding: 1.75rem 2rem;
   font-family: var(--display);
   font-style: italic;
@@ -381,7 +387,7 @@ main { position: relative; z-index: 1; }
   position: absolute;
   top: -0.3rem;
   left: 0.6rem;
-  color: var(--crimson-soft);
+  color: var(--leaf-soft);
   line-height: 1;
   font-style: normal;
 }
@@ -426,7 +432,7 @@ main { position: relative; z-index: 1; }
   border: var(--rule);
 }
 
-.terminal .cmd::before { content: '$ '; color: var(--crimson-soft); }
+.terminal .cmd::before { content: '$ '; color: var(--citrus); }
 .terminal .comment { color: var(--ink-faint); font-style: italic; }
 .terminal .out { color: var(--ink-faint); }
 
@@ -446,7 +452,7 @@ main { position: relative; z-index: 1; }
 }
 
 .colophon a { color: var(--ink-soft); text-decoration: none; border-bottom: 1px dotted var(--ink-faint); }
-.colophon a:hover { color: var(--crimson); border-bottom-color: var(--crimson); }
+.colophon a:hover { color: var(--citrus); border-bottom-color: var(--citrus); }
 
 /* Page-load reveal */
 @keyframes appear {

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -13,11 +13,12 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: anthropics/claude-code-action@v1
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
@@ -41,6 +42,11 @@ jobs:
 
             Any project-specific skills loaded from .claude/skills/ should
             shape your review — defer to their guidance over generic advice.
+
+            Tone: address the author conversationally. A concise field-naturalist
+            voice is welcome (you are Clud Bug, examining specimens of code) but
+            never at the cost of clarity, evidence, or the critical-issues-only
+            discipline. Don't perform the bit; let the precision speak.
 
             When you finish, post your review as a single PR comment.
             The comment body MUST start with this exact line so the

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -13,11 +13,12 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: anthropics/claude-code-action@v1
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
@@ -42,6 +43,11 @@ jobs:
 
             Any project-specific skills loaded from .claude/skills/ should
             shape your review — defer to their guidance over generic advice.
+
+            Tone: address the author conversationally. A concise field-naturalist
+            voice is welcome (you are Clud Bug, examining specimens of code) but
+            never at the cost of clarity, evidence, or the critical-issues-only
+            discipline. Don't perform the bit; let the precision speak.
 
             When you finish, post your review as a single PR comment.
             The comment body MUST start with this exact line so the

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -13,11 +13,12 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: anthropics/claude-code-action@v1
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
@@ -38,6 +39,11 @@ jobs:
 
             Any project-specific skills loaded from .claude/skills/ should
             shape your review — defer to their guidance over generic advice.
+
+            Tone: address the author conversationally. A concise field-naturalist
+            voice is welcome (you are Clud Bug, examining specimens of code) but
+            never at the cost of clarity, evidence, or the critical-issues-only
+            discipline. Don't perform the bit; let the precision speak.
 
             When you finish, post your review as a single PR comment.
             The comment body MUST start with this exact line so the

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -83,7 +83,7 @@ test('list reports zero state cleanly', async () => {
   try {
     const r = run(dir, ['list']);
     assert.equal(r.status, 0);
-    assert.match(r.stdout, /No skills installed/);
+    assert.match(r.stdout, /Empty collection/);
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 
@@ -97,7 +97,7 @@ test('remove refuses unmanaged slug, succeeds on managed one', async () => {
     // baseline slug should be removable (will return on next init)
     const ok = run(dir, ['remove', 'critical-issues-only']);
     assert.equal(ok.status, 0, ok.stderr);
-    assert.match(ok.stdout, /removed critical-issues-only/);
+    assert.match(ok.stdout, /unpinned critical-issues-only/);
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 
@@ -139,7 +139,7 @@ test('refresh aborts (does NOT remove remote skills) when skills.sh is unreachab
     // Either the process exits non-zero with the refusal warning, OR the API isn't
     // overridable from env (in which case skip — covered by skills.test.js diff logic).
     // We must NEVER see "skills updated" indicating removal proceeded.
-    assert.doesNotMatch(r.stdout + r.stderr, /skills updated/, 'refresh proceeded with removals despite API failure');
+    assert.doesNotMatch(r.stdout + r.stderr, /collection updated/, 'refresh proceeded with removals despite API failure');
     // Verify the remote skill is still on disk
     const stillThere = await readFile(join(dir, '.claude/skills/some-remote/SKILL.md'), 'utf8');
     assert.match(stillThere, /some-remote/);
@@ -175,6 +175,6 @@ test('refresh --offline shows no-op when only baseline installed', async () => {
     run(dir, ['init', '--offline', '--accept-all']);
     const r = run(dir, ['refresh', '--offline', '--accept-all']);
     assert.equal(r.status, 0, r.stderr);
-    assert.match(r.stdout, /Nothing to update|skills updated/);
+    assert.match(r.stdout, /sync with skills\.sh|collection updated/);
   } finally { await rm(dir, { recursive: true, force: true }); }
 });


### PR DESCRIPTION
## Summary

v0.3 PR 1 of 5. Brings the field-guide personality from the site into the rest of the project, swaps the accent color to match the bug emoji's actual palette, and fixes the Node.js 20 deprecation warning ahead of GitHub's June 2 cutover.

### Brand voice

The site already commits hard to a vintage entomology field-guide voice. The CLI, README, and review prompts didn't. Now they do — without overdoing it:

- CLI logs (e.g. \`Field season opens in <cwd>\` instead of \`clud-bug init in <cwd>\`, \`pinning specimens to .claude/skills/\` instead of \`installing skills\`).
- README intro rewritten as a naturalist's introduction.
- Workflow prompts now instruct: \"A concise field-naturalist voice is welcome but never at the cost of clarity, evidence, or critical-issues-only discipline. Don't perform the bit; let the precision speak.\" — keeps the bot disciplined.

### Color palette

Inspired by the clud-bug emoji (green caterpillar, orange head, on warm cream):

| Token | Old | New | Used for |
|---|---|---|---|
| --leaf | n/a | \`#5a8a2e\` | Primary accent — title em, install-box \$, observation border |
| --leaf-soft | n/a | \`#8aab5e\` | Decorative — observation quote mark |
| --citrus | n/a | \`#d97a2e\` | Secondary — terminal cmd \$, hover states |
| --crimson | primary | reserved | Critical-issue badge only |

### Node.js 20 deprecation fix

Every workflow run currently emits a yellow warning that Node 20 actions are deprecated (June 2 forces Node 24, Sept 16 removes Node 20). Generated workflows shouldn't ship deprecation warnings. Two-line fix applied to all 4 review workflows + ci.yml + baseline + the 3 templates:

\`\`\`yaml
- uses: actions/checkout@v5     # was @v4
- uses: actions/setup-node@v5   # was @v4
  env:
    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
\`\`\`

## Test plan

- [x] \`npm test\` → 48/48 pass (test assertions updated to match new CLI strings)
- [x] \`cd site && npm run build\` → clean static build
- [ ] CI green
- [ ] Both reviewers approve
- [ ] After merge: visit cludbug.dev preview, spot-check leaf-green accents on hero/install/observation
- [ ] After merge: trigger any workflow on a future PR and confirm Node 20 warning is gone

## Acknowledgement

The system reminder noted: when ANTHROPIC_API_KEY is missing, claude-code-action exits 0 silently, making the check appear green and hiding the misconfiguration. Adding a fail-loud guard to generated workflows is queued for v0.4 (separate PR; not bundled here).