### PR TITLE
Site terminal: match actual CLI voice + leaf/citrus highlights

### DIFF
--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -435,8 +435,10 @@ main { position: relative; z-index: 1; }
 }
 
 .terminal .cmd::before { content: '$ '; color: var(--citrus); }
-.terminal .comment { color: var(--ink-faint); font-style: italic; }
+.terminal .comment { color: var(--leaf-soft); font-style: italic; }
 .terminal .out { color: var(--ink-faint); }
+.terminal .path { color: var(--leaf-soft); }
+.terminal .num  { color: var(--citrus); font-weight: 600; }
 
 /* ─────────────────── COLOPHON / FOOTER ─────────────────── */
 

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -139,13 +139,15 @@ export default function Home() {
           </aside>
           <div>
             <pre className="terminal">
-              <span className="comment"># 1. Detect, install skills, write workflow.</span>{'\n'}
+              <span className="comment"># 1. Survey the habitat, pin specimens, draft the field kit.</span>{'\n'}
               <span className="cmd">npx clud-bug init</span>{'\n'}
-              <span className="out">  baseline skills:  3</span>{'\n'}
-              <span className="out">  installing skills into .claude/skills/...</span>{'\n'}
-              <span className="out">  wrote .github/workflows/clud-bug-review.yml</span>{'\n\n'}
+              <span className="out">  🐛 Field season opens in <span className="path">~/your-repo</span>.</span>{'\n'}
+              <span className="out">    baseline kit:     <span className="num">3</span> specimens</span>{'\n'}
+              <span className="out">  pinning specimens to <span className="path">.claude/skills/</span>...</span>{'\n'}
+              <span className="out">    pinned <span className="num">3</span> specimens</span>{'\n'}
+              <span className="out">  wrote <span className="path">.github/workflows/clud-bug-review.yml</span></span>{'\n\n'}
               <span className="comment"># 2. Commit the field kit and push.</span>{'\n'}
-              <span className="cmd">git add .claude .github/workflows/clud-bug-review.yml</span>{'\n'}
+              <span className="cmd">git add <span className="path">.claude .github/workflows/clud-bug-review.yml</span></span>{'\n'}
               <span className="cmd">git commit -m &quot;Add clud-bug&quot; && git push</span>{'\n'}
             </pre>
           </div>


### PR DESCRIPTION
Quick site fix per your screenshot. Terminal block on the install section had stale text ("installing skills into" instead of "pinning specimens to") and was visually monochromatic — only the $ prompt carried any color. Updated text to match the actual current CLI output, plus added two new color classes for paths/filenames (leaf-soft) and counts (citrus). The # comment markers now also carry leaf-soft instead of dim sepia.

Test plan:
- [x] `npm run build` clean
- [ ] CI green, both bots cleared
- [ ] After merge: cludbug.dev shows the new colored terminal