### PR TITLE
Site: live data — version, downloads, latest review

### DIFF
--- a/site/app/apple-icon.tsx
+++ b/site/app/apple-icon.tsx
@@ -1,0 +1,27 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+export const size = { width: 180, height: 180 };
+export const contentType = 'image/png';
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          background: '#f3ecda',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 130,
+          lineHeight: 1,
+        }}
+      >
+        🐛
+      </div>
+    ),
+    { ...size, emoji: 'twemoji' },
+  );
+}

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -232,6 +232,35 @@ main { position: relative; z-index: 1; }
 .actions a:hover { color: var(--citrus); border-bottom-color: var(--citrus); }
 .actions .sep { color: var(--ink-faint); font-style: normal; font-family: var(--mono); }
 
+/* Live tally — small "ledger" beneath the install action row.
+   Each <div> wraps a dt/dd pair laid out vertically. */
+.ledger {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2.25rem;
+  margin-top: 2rem;
+  padding-top: 1.25rem;
+  border-top: 1px dotted var(--ink-faint);
+  max-width: 36rem;
+}
+.ledger > div { display: flex; flex-direction: column; }
+.ledger dt {
+  font-family: var(--mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin-bottom: 0.15rem;
+}
+.ledger dd {
+  font-family: var(--display);
+  font-style: italic;
+  font-size: 1.6rem;
+  font-weight: 300;
+  color: var(--leaf);
+  line-height: 1;
+}
+
 /* ─────────────────── SECTION SHELL ─────────────────── */
 
 .section { margin-bottom: 5rem; }

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -139,17 +139,25 @@ main { position: relative; z-index: 1; }
 
 .bug-pin {
   font-size: 3.5rem;
-  display: block;
+  display: inline-block;
   margin-top: 1.25rem;
-  transform: rotate(-12deg);
-  animation: scuttle 8s ease-in-out infinite;
-  transform-origin: center;
+  transform-origin: 60% 80%;
+  animation: scuttle 9s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+  /* Resting state — animation uses fill-mode 'both' (default behavior of
+     'forwards' + 'backwards' via the keyframe at 0%) so the bug always
+     renders at the resting tilt. */
 }
 
+/* A slow, symmetric scuttle: long rest → easy lean forward → easy lean back
+   → rest again. All keyframes share the same translateY, so the apparent
+   "down jump" the previous version had (sudden swap from 47% to 90%) is
+   gone. Each motion phase has matching duration to its mirror. */
 @keyframes scuttle {
-  0%, 90%, 100% { transform: rotate(-12deg) translateX(0); }
-  45% { transform: rotate(8deg) translateX(0.4rem); }
-  47% { transform: rotate(-4deg) translateX(0.6rem); }
+  0%,  35%, 100% { transform: rotate(-12deg) translateX(0); }
+  45% { transform: rotate(-2deg) translateX(0.25rem); }
+  50% { transform: rotate(6deg) translateX(0.45rem); }
+  55% { transform: rotate(-2deg) translateX(0.25rem); }
+  65% { transform: rotate(-12deg) translateX(0); }
 }
 
 /* Right column: title, subtitle, install */

--- a/site/app/icon.tsx
+++ b/site/app/icon.tsx
@@ -1,0 +1,27 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+export const size = { width: 32, height: 32 };
+export const contentType = 'image/png';
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          background: '#f3ecda',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 24,
+          lineHeight: 1,
+        }}
+      >
+        🐛
+      </div>
+    ),
+    { ...size, emoji: 'twemoji' },
+  );
+}

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -25,19 +25,20 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://cludbug.dev'),
   title: 'Clud Bug — Claude PR review with project-aware skills',
   description:
-    'A field naturalist for your codebase. Claude PR review tuned to your stack, with skills auto-curated from skills.sh. Open source.',
+    'Clud Bug pins skills auto-curated from skills.sh and ships a Claude PR-review workflow that actually posts comments. A field naturalist for your codebase. Open source.',
   openGraph: {
-    title: 'Clud Bug — Claude PR review with project-aware skills',
+    title: 'Clud Bug — a field guide to specimens crawling your code',
     description:
-      'A field naturalist for your codebase. Claude PR review tuned to your stack.',
+      'Claude PR review tuned to your stack, with skills auto-curated from skills.sh and a baseline kit of review discipline. Reviews land within two minutes.',
     url: 'https://cludbug.dev',
     siteName: 'Clud Bug',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Clud Bug — Claude PR review with project-aware skills',
-    description: 'A field naturalist for your codebase.',
+    title: 'Clud Bug — a field guide to specimens crawling your code',
+    description:
+      'Claude PR review tuned to your stack, with skills auto-curated from skills.sh and a baseline kit of review discipline. Reviews land within two minutes.',
   },
 };
 

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -48,7 +48,7 @@ export default async function Home() {
                 </>
               )}
               {repo && (
-                <div><dt>PRs reviewed</dt><dd>{formatCount(repo.recentMergedCount + repo.openPRs)}</dd></div>
+                <div><dt>PRs reviewed</dt><dd>{formatCount(repo.recentMergedCount)}</dd></div>
               )}
             </dl>
           )}

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -1,9 +1,19 @@
-export default function Home() {
+import { getNpmStats, getRepoStats, getLatestPublicReview, formatCount } from '../lib/data';
+
+export default async function Home() {
+  // Public-only sources, server-fetched and cached for 1h. Failures degrade
+  // gracefully — sections hide rather than break the page.
+  const [npm, repo, latest] = await Promise.all([
+    getNpmStats(),
+    getRepoStats(),
+    getLatestPublicReview(),
+  ]);
+
   return (
     <main className="page">
       <header className="folio">
         <span>A Field Guide to Code Specimens</span>
-        <span>Vol. 0 · No. 2 · MMXXVI</span>
+        <span>Vol. 0 · {npm ? `v${npm.version}` : 'No. 2'} · MMXXVI</span>
       </header>
 
       {/* ─────────── FRONTISPIECE ─────────── */}
@@ -29,6 +39,19 @@ export default function Home() {
             <span className="sep">·</span>
             <a href="#how-to-collect">How to collect</a>
           </div>
+          {(npm || repo) && (
+            <dl className="ledger appear-4" aria-label="Live field tally">
+              {npm && (
+                <>
+                  <div><dt>Edition</dt><dd>v{npm.version}</dd></div>
+                  <div><dt>Downloads / wk</dt><dd>{formatCount(npm.weeklyDownloads)}</dd></div>
+                </>
+              )}
+              {repo && (
+                <div><dt>PRs reviewed</dt><dd>{formatCount(repo.recentMergedCount + repo.openPRs)}</dd></div>
+              )}
+            </dl>
+          )}
         </div>
       </section>
 
@@ -116,12 +139,24 @@ export default function Home() {
             A single PR review on a fixture file with four planted defects. The naturalist
             also flagged a fifth issue the author had not intended.
           </aside>
-          <blockquote className="observation">
-            Found all four planted bugs plus a fifth bonus problem (command injection via
-            <code style={{ background: 'transparent', border: 0, padding: 0, fontStyle: 'normal' }}> sh -c + rm -rf</code>{' '}
-            — worse than the SQL injection — RCE). Inline comments posted at each site.
-            <footer>Specimen review · 53 seconds · PR #2</footer>
-          </blockquote>
+          {latest ? (
+            <blockquote className="observation">
+              {latest.headline}
+              <footer>
+                Latest field note ·{' '}
+                <a href={latest.prUrl} style={{ color: 'inherit' }}>
+                  PR #{latest.prNumber}: {latest.prTitle}
+                </a>
+              </footer>
+            </blockquote>
+          ) : (
+            <blockquote className="observation">
+              Found all four planted bugs plus a fifth bonus problem (command injection via
+              <code style={{ background: 'transparent', border: 0, padding: 0, fontStyle: 'normal' }}> sh -c + rm -rf</code>{' '}
+              — worse than the SQL injection — RCE). Inline comments posted at each site.
+              <footer>Specimen review · 53 seconds · PR #2</footer>
+            </blockquote>
+          )}
         </div>
       </section>
 

--- a/site/lib/data.ts
+++ b/site/lib/data.ts
@@ -1,0 +1,123 @@
+// Server-side data fetchers for cludbug.dev. All public-only sources.
+// Cached + revalidated hourly so the page stays fully static between rebuilds.
+
+const REVALIDATE_SECONDS = 3600;
+const REPO = 'thrillmot/clud-bug';
+
+export type NpmStats = {
+  version: string;
+  weeklyDownloads: number;
+} | null;
+
+export type RepoStats = {
+  recentMergedCount: number;
+  openPRs: number;
+} | null;
+
+export type LatestReview = {
+  prNumber: number;
+  prTitle: string;
+  prUrl: string;
+  headline: string; // first non-empty findings line, plain text
+} | null;
+
+async function safeFetch(url: string, init?: RequestInit) {
+  try {
+    const res = await fetch(url, {
+      ...init,
+      next: { revalidate: REVALIDATE_SECONDS },
+      headers: { accept: 'application/json', ...(init?.headers || {}) },
+    });
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function getNpmStats(): Promise<NpmStats> {
+  const [latest, downloads] = await Promise.all([
+    safeFetch('https://registry.npmjs.org/clud-bug/latest'),
+    safeFetch('https://api.npmjs.org/downloads/point/last-week/clud-bug'),
+  ]);
+  if (!latest?.version) return null;
+  return {
+    version: latest.version,
+    weeklyDownloads: typeof downloads?.downloads === 'number' ? downloads.downloads : 0,
+  };
+}
+
+export async function getRepoStats(): Promise<RepoStats> {
+  const data = await safeFetch(`https://api.github.com/repos/${REPO}/pulls?state=all&per_page=30`);
+  if (!Array.isArray(data)) return null;
+  const merged = data.filter((p) => p.merged_at).length;
+  const open = data.filter((p) => p.state === 'open').length;
+  return { recentMergedCount: merged, openPRs: open };
+}
+
+export async function getLatestPublicReview(): Promise<LatestReview> {
+  // Pull recent issue comments and find the latest one authored by claude[bot]
+  // that starts with our review header. Only inspect this public repo for now.
+  const comments = await safeFetch(
+    `https://api.github.com/repos/${REPO}/issues/comments?per_page=50&sort=created&direction=desc`,
+  );
+  if (!Array.isArray(comments)) return null;
+
+  for (const c of comments) {
+    if (c.user?.login !== 'claude' && c.user?.login !== 'claude[bot]') continue;
+    const body: string = c.body || '';
+    if (!body.includes('🐛 Clud Bug review')) continue;
+
+    // Pull the first findings line — strip "## 🐛 Clud Bug review", checkboxes,
+    // and headers, then take the first content sentence.
+    const headline = extractHeadline(body);
+    if (!headline) continue;
+
+    // Resolve the parent PR
+    const issueUrl: string = c.issue_url || '';
+    const prNumberMatch = issueUrl.match(/\/issues\/(\d+)$/);
+    if (!prNumberMatch) continue;
+    const prNumber = Number(prNumberMatch[1]);
+    const pr = await safeFetch(`https://api.github.com/repos/${REPO}/pulls/${prNumber}`);
+    if (!pr || pr.draft) continue;
+
+    return {
+      prNumber,
+      prTitle: pr.title,
+      prUrl: pr.html_url,
+      headline,
+    };
+  }
+  return null;
+}
+
+function extractHeadline(body: string): string | null {
+  // Skip the first H2 (## 🐛 Clud Bug review) and any checklist/divider lines,
+  // grab the first prose paragraph.
+  const lines = body.split('\n').map((l) => l.trim());
+  for (const line of lines) {
+    if (!line) continue;
+    if (line.startsWith('**Claude finished')) continue;
+    if (line.startsWith('---')) continue;
+    if (line.startsWith('##')) continue;
+    if (line.startsWith('- [')) continue;
+    if (line.startsWith('|')) continue;
+    if (line.startsWith('>')) continue;
+    if (line.startsWith('·')) continue;
+    if (line.startsWith('### ')) continue;
+    // Strip simple markdown emphasis
+    const plain = line
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      .replace(/`([^`]+)`/g, '$1')
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+    if (plain.length < 30) continue;
+    return plain.length > 220 ? plain.slice(0, 217).trimEnd() + '…' : plain;
+  }
+  return null;
+}
+
+export function formatCount(n: number | undefined | null): string {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return '—';
+  if (n >= 1000) return (n / 1000).toFixed(n >= 10000 ? 0 : 1) + 'k';
+  return String(n);
+}

--- a/site/lib/data.ts
+++ b/site/lib/data.ts
@@ -29,7 +29,10 @@ async function safeFetch(url: string, init?: RequestInit) {
       headers: { accept: 'application/json', ...(init?.headers || {}) },
     });
     if (!res.ok) return null;
-    return res.json();
+    // Must await inside the try so JSON parse failures (truncated stream,
+    // HTML CDN error page returned with 200, etc.) are caught here instead
+    // of escaping to the caller and crashing the Server Component render.
+    return await res.json();
   } catch {
     return null;
   }
@@ -48,11 +51,20 @@ export async function getNpmStats(): Promise<NpmStats> {
 }
 
 export async function getRepoStats(): Promise<RepoStats> {
-  const data = await safeFetch(`https://api.github.com/repos/${REPO}/pulls?state=all&per_page=30`);
-  if (!Array.isArray(data)) return null;
-  const merged = data.filter((p) => p.merged_at).length;
-  const open = data.filter((p) => p.state === 'open').length;
-  return { recentMergedCount: merged, openPRs: open };
+  // Use the search API which returns a real total_count, instead of
+  // /pulls?per_page=30 which would silently cap at 30 forever.
+  // Counts PRs that Clud Bug has actually commented on (its review surface).
+  const reviewed = await safeFetch(
+    `https://api.github.com/search/issues?q=${encodeURIComponent(`repo:${REPO} is:pr commenter:claude[bot]`)}&per_page=1`,
+  );
+  const open = await safeFetch(
+    `https://api.github.com/search/issues?q=${encodeURIComponent(`repo:${REPO} is:pr is:open`)}&per_page=1`,
+  );
+  if (!reviewed || typeof reviewed.total_count !== 'number') return null;
+  return {
+    recentMergedCount: reviewed.total_count,
+    openPRs: open?.total_count ?? 0,
+  };
 }
 
 export async function getLatestPublicReview(): Promise<LatestReview> {


### PR DESCRIPTION
## Summary

v0.3 PR 3/9. cludbug.dev now reflects reality instead of a frozen snapshot.

### What's live

- **Folio header** shows the npm-published version
- **\`<dl class=\"ledger\">\`** beneath the install row: Edition · Downloads / wk · PRs reviewed
- **Recorded-Observation section** renders the latest public Clud Bug review with a deep link (falls back to the hardcoded fixture quote if no recent public review found)

### How it works

- All fetches go through \`safeFetch\` with \`{ next: { revalidate: 3600 } }\`. The page stays \`○ Static\` with \`Revalidate 1h\`.
- Public-only sources: npm registry + GitHub public API (no token needed for public-repo reads).
- Failures degrade gracefully — null returned, section hides, page still renders.
- No client JS added.

### Build evidence

\`\`\`
Route (app)           Revalidate  Expire
┌ ○ /                         1h      1y
├ ○ /_not-found
├ ƒ /opengraph-image
└ ƒ /twitter-image
\`\`\`

## Test plan

- [x] \`npm run build\` clean, page static with 1h revalidate
- [ ] CI green, both bots cleared
- [ ] After deploy: cludbug.dev shows real version + downloads
- [ ] Recorded-Observation block shows a real recent PR review