### PR TITLE
v0.3.2: hard skill enforcement + skill citation footer

### DIFF
--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -41,8 +41,17 @@ jobs:
             Skip style suggestions, minor naming issues, or anything that
             doesn't affect correctness, security, or performance.
 
-            Any project-specific skills loaded from .claude/skills/ should
-            shape your review — defer to their guidance over generic advice.
+            Skills are not background context — they are review rules with
+            authority. Before flagging any finding, scan the loaded skills in
+            .claude/skills/ for relevant guidance. If a skill applies, your
+            review MUST reference it by name in the finding (e.g. "[evidence-
+            based-review]: this claim isn't anchored to a line"). Generic
+            advice that contradicts a project skill is wrong by definition.
+
+            At the end of every review, append a single-line footer:
+              Skills referenced: [skill-name-1, skill-name-2, ...]
+            If you genuinely cited none, list "[none]" and explain why no
+            installed skill applied to this diff.
 
             Tone: address the author conversationally. A concise field-naturalist
             voice is welcome (you are Clud Bug, examining specimens of code) but

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] — 2026-05-15
+
+### Changed
+- **Skill enforcement is now hard, not soft.** Workflow prompt previously said "skills should shape your review — defer to their guidance" (a nudge). Now it says "Skills are not background context — they are review rules with authority. Before flagging any finding, scan loaded skills... your review MUST reference them by name." Reviews are also required to end with a `Skills referenced: [...]` footer. Result: every review now produces an explicit audit trail showing which skills shaped which findings.
+- **`clud-bug init` warns when only baseline specimens get pinned.** Flag the case where the install gives users a generic Claude review instead of a project-aware one — points them at `clud-bug add` and custom skills.
+
 ## [0.3.1] — 2026-05-15
 
 ### Added
@@ -23,6 +29,7 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 - **Paragraph indent inconsistency on cludbug.dev.** Removed the `text-indent: 1.4em` rule on `.section-prose p + p`.
 - **Bug-pin scuttle animation** snap removed by replacing the 45/47%/90% keyframes with a symmetric 35→65% scuttle.
 
+[0.3.2]: https://github.com/thrillmot/clud-bug/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/thrillmot/clud-bug/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/thrillmot/clud-bug/compare/v0.2.2...v0.3.0
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ The CLI prepares an `audits/YYYY-MM-DD.md` stub. For findings, `clud-bug init` a
 
 The workflow ships with `workflow_dispatch` only (manual). The cron is in the file, commented — uncomment for weekly audits.
 
+## How skills shape reviews
+
+Skills aren't background reading material for the bot — they're rules with authority. The workflow prompt now requires Clud Bug to:
+
+1. **Cite the skill by name** when applying its guidance: e.g. `[evidence-based-review]: this claim isn't anchored to a line`.
+2. **End every review with a footer** listing which skills shaped the findings: `Skills referenced: [critical-issues-only, next-best-practices, my-team-rules]`.
+
+The footer is your audit trail. If a review's footer is `[none]`, either the bot found nothing relevant in your installed skills (and should explain why), or your skill set isn't covering the kinds of changes you actually ship — a signal to add or write new specimens.
+
+`clud-bug init` warns when it would install only baseline specimens. Pair with at least one project-aware skill from skills.sh, or your own — that's where the wedge over stock Claude review comes from.
+
 ## Managing skills
 
 After `init`, four commands let you evolve the skill set without re-running the whole setup:

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -148,8 +148,7 @@ async function runInit(args) {
   // generic; flag this so users notice.
   const remoteCount = written.filter((w) => w.kind !== 'baseline').length;
   if (remoteCount === 0) {
-    warn('Only baseline specimens pinned. clud-bug works best with project-specific skills.');
-    warn('Try: clud-bug add vercel-labs/skills/<name>, or drop your own .claude/skills/<name>/SKILL.md.');
+    warn('Only baseline specimens pinned. Add project-specific skills via `clud-bug add vercel-labs/skills/<name>` or drop your own `.claude/skills/<name>/SKILL.md`.');
   }
 
   log('  drafting field kit...');

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -143,6 +143,15 @@ async function runInit(args) {
   const written = await writeSkills(join(cwd, '.claude', 'skills'), chosen, client);
   log(`    pinned ${written.length} specimens`);
 
+  // Empty-skills warning: clud-bug shines when paired with project-specific
+  // skills. Reviews that load only the three baselines are functional but
+  // generic; flag this so users notice.
+  const remoteCount = written.filter((w) => w.kind !== 'baseline').length;
+  if (remoteCount === 0) {
+    warn('Only baseline specimens pinned. clud-bug works best with project-specific skills.');
+    warn('Try: clud-bug add vercel-labs/skills/<name>, or drop your own .claude/skills/<name>/SKILL.md.');
+  }
+
   log('  drafting field kit...');
   const tmplName = pickTemplate(signals.languages);
   const tmplPath = join(TEMPLATES, tmplName);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -40,8 +40,17 @@ jobs:
             Skip style suggestions, minor naming issues, or anything that
             doesn't affect correctness, security, or performance.
 
-            Any project-specific skills loaded from .claude/skills/ should
-            shape your review — defer to their guidance over generic advice.
+            Skills are not background context — they are review rules with
+            authority. Before flagging any finding, scan the loaded skills in
+            .claude/skills/ for relevant guidance. If a skill applies, your
+            review MUST reference it by name in the finding (e.g. "[evidence-
+            based-review]: this claim isn't anchored to a line"). Generic
+            advice that contradicts a project skill is wrong by definition.
+
+            At the end of every review, append a single-line footer:
+              Skills referenced: [skill-name-1, skill-name-2, ...]
+            If you genuinely cited none, list "[none]" and explain why no
+            installed skill applied to this diff.
 
             Tone: address the author conversationally. A concise field-naturalist
             voice is welcome (you are Clud Bug, examining specimens of code) but

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -41,8 +41,17 @@ jobs:
             Skip style suggestions, minor naming issues, or anything that
             doesn't affect correctness, security, or performance.
 
-            Any project-specific skills loaded from .claude/skills/ should
-            shape your review — defer to their guidance over generic advice.
+            Skills are not background context — they are review rules with
+            authority. Before flagging any finding, scan the loaded skills in
+            .claude/skills/ for relevant guidance. If a skill applies, your
+            review MUST reference it by name in the finding (e.g. "[evidence-
+            based-review]: this claim isn't anchored to a line"). Generic
+            advice that contradicts a project skill is wrong by definition.
+
+            At the end of every review, append a single-line footer:
+              Skills referenced: [skill-name-1, skill-name-2, ...]
+            If you genuinely cited none, list "[none]" and explain why no
+            installed skill applied to this diff.
 
             Tone: address the author conversationally. A concise field-naturalist
             voice is welcome (you are Clud Bug, examining specimens of code) but

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -37,8 +37,17 @@ jobs:
             Skip style suggestions, minor naming issues, or anything that
             doesn't affect correctness, security, or performance.
 
-            Any project-specific skills loaded from .claude/skills/ should
-            shape your review — defer to their guidance over generic advice.
+            Skills are not background context — they are review rules with
+            authority. Before flagging any finding, scan the loaded skills in
+            .claude/skills/ for relevant guidance. If a skill applies, your
+            review MUST reference it by name in the finding (e.g. "[evidence-
+            based-review]: this claim isn't anchored to a line"). Generic
+            advice that contradicts a project skill is wrong by definition.
+
+            At the end of every review, append a single-line footer:
+              Skills referenced: [skill-name-1, skill-name-2, ...]
+            If you genuinely cited none, list "[none]" and explain why no
+            installed skill applied to this diff.
 
             Tone: address the author conversationally. A concise field-naturalist
             voice is welcome (you are Clud Bug, examining specimens of code) but


### PR DESCRIPTION
v0.3 PR 6/9. Skills go from soft nudge to hard rule. Reviews must cite the skill they applied (e.g. `[evidence-based-review]: this claim isn't anchored`) and end with `Skills referenced: [list]` so there's an audit trail. Plus init warns when only baseline gets pinned (the case where users get generic Claude review instead of the project-aware wedge).

This is the central UX fix from the post-PR-9 conversation about whether skills were getting the leverage they should. Tests still 62/62.