### PR TITLE
v0.3.3: fail loudly when ANTHROPIC_API_KEY is missing

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,6 +21,18 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Guard — require ANTHROPIC_API_KEY
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then exit 0; fi
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "::warning::Fork PR — secrets not passed. Baseline review skipped."
+            exit 0
+          fi
+          echo "::error::ANTHROPIC_API_KEY not set."
+          exit 1
+
       - uses: anthropics/claude-code-action@v1
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -15,6 +15,24 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Without this guard, claude-code-action silently exits 0 when the
+      # secret is missing — the check turns green and the user thinks Clud
+      # Bug is working when it's a no-op. Fail loud unless this is a fork PR
+      # (where GitHub deliberately withholds secrets — that's by design).
+      - name: Guard — require ANTHROPIC_API_KEY
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then exit 0; fi
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "::warning title=Clud Bug 🐛::Fork PR — GitHub doesn't pass repo secrets to fork-triggered workflows. Clud Bug review skipped by design."
+            exit 0
+          fi
+          echo "::error title=Clud Bug 🐛::ANTHROPIC_API_KEY secret is not set on this repository."
+          echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
+          echo "::error::Without it, Clud Bug review is a silent no-op."
+          exit 1
+
       - uses: anthropics/claude-code-action@v1
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] — 2026-05-15
+
+### Fixed
+- **No more silently-green checks when `ANTHROPIC_API_KEY` is missing.** All review + audit + baseline workflows now have a guard step that fails the job with an actionable `::error::` message when the secret is empty. Fork PRs (where GitHub deliberately withholds secrets) get a `::warning::` and exit 0 — the documented by-design behavior. Eliminates the footgun where users thought Clud Bug was reviewing when it wasn't even running.
+
 ## [0.3.2] — 2026-05-15
 
 ### Changed
@@ -29,6 +34,7 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 - **Paragraph indent inconsistency on cludbug.dev.** Removed the `text-indent: 1.4em` rule on `.section-prose p + p`.
 - **Bug-pin scuttle animation** snap removed by replacing the 45/47%/90% keyframes with a symmetric 35→65% scuttle.
 
+[0.3.3]: https://github.com/thrillmot/clud-bug/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/thrillmot/clud-bug/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/thrillmot/clud-bug/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/thrillmot/clud-bug/compare/v0.2.2...v0.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/templates/audit.yml.tmpl
+++ b/templates/audit.yml.tmpl
@@ -43,6 +43,18 @@ jobs:
         with:
           node-version: '20'
 
+      # Audit runs on workflow_dispatch / schedule — no PR context, so the
+      # fork-PR carve-out doesn't apply. Just fail loud if the secret is missing.
+      - name: Guard — require ANTHROPIC_API_KEY
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::error title=Clud Bug 🐛::ANTHROPIC_API_KEY secret is not set."
+            echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
+            exit 1
+          fi
+
       - name: Compute audit scope and create branch
         id: prep
         env:

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -15,6 +15,25 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Without this guard, claude-code-action silently exits 0 when the
+      # secret is missing — the check turns green and the user thinks Clud
+      # Bug is working when it's a no-op. Fail loud unless this is a fork PR
+      # (where GitHub deliberately withholds secrets — that's by design and
+      # documented in the README's "Fork PR caveat" section).
+      - name: Guard — require ANTHROPIC_API_KEY
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then exit 0; fi
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "::warning title=Clud Bug 🐛::Fork PR — GitHub doesn't pass repo secrets to fork-triggered workflows. Clud Bug review skipped by design."
+            exit 0
+          fi
+          echo "::error title=Clud Bug 🐛::ANTHROPIC_API_KEY secret is not set on this repository."
+          echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
+          echo "::error::Without it, Clud Bug review is a silent no-op."
+          exit 1
+
       - uses: anthropics/claude-code-action@v1
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -15,6 +15,25 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Without this guard, claude-code-action silently exits 0 when the
+      # secret is missing — the check turns green and the user thinks Clud
+      # Bug is working when it's a no-op. Fail loud unless this is a fork PR
+      # (where GitHub deliberately withholds secrets — that's by design and
+      # documented in the README's "Fork PR caveat" section).
+      - name: Guard — require ANTHROPIC_API_KEY
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then exit 0; fi
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "::warning title=Clud Bug 🐛::Fork PR — GitHub doesn't pass repo secrets to fork-triggered workflows. Clud Bug review skipped by design."
+            exit 0
+          fi
+          echo "::error title=Clud Bug 🐛::ANTHROPIC_API_KEY secret is not set on this repository."
+          echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
+          echo "::error::Without it, Clud Bug review is a silent no-op."
+          exit 1
+
       - uses: anthropics/claude-code-action@v1
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -15,6 +15,25 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Without this guard, claude-code-action silently exits 0 when the
+      # secret is missing — the check turns green and the user thinks Clud
+      # Bug is working when it's a no-op. Fail loud unless this is a fork PR
+      # (where GitHub deliberately withholds secrets — that's by design and
+      # documented in the README's "Fork PR caveat" section).
+      - name: Guard — require ANTHROPIC_API_KEY
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then exit 0; fi
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "::warning title=Clud Bug 🐛::Fork PR — GitHub doesn't pass repo secrets to fork-triggered workflows. Clud Bug review skipped by design."
+            exit 0
+          fi
+          echo "::error title=Clud Bug 🐛::ANTHROPIC_API_KEY secret is not set on this repository."
+          echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
+          echo "::error::Without it, Clud Bug review is a silent no-op."
+          exit 1
+
       - uses: anthropics/claude-code-action@v1
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
v0.3 PR 7/9. Per your reporulez observation. claude-code-action silently exits 0 when the secret is missing — green check, no review, user has no idea. Now every Claude-using workflow has a guard step that fails the job with an actionable error annotation. Fork PRs (where GitHub legitimately withholds secrets) get a warning and exit 0 instead of a noisy red.