### PR TITLE
v0.3.4: strict mode — fail check on critical findings (opt-in)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,7 +41,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
             Review this pull request. Start your comment with the line:
 

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -41,7 +41,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(touch:*),Bash(cat:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
           prompt: |
             This project is "clud-bug". Claude Code PR review GitHub Action with project-aware skills auto-discovered from skills.sh. It's primarily javascript.
 
@@ -71,16 +71,21 @@ jobs:
             If you genuinely cited none, list "[none]" and explain why no
             installed skill applied to this diff.
 
-            Strict mode (opt-in): if .claude/skills/.clud-bug.json contains
-            { "strictMode": true } at the top level, then after posting the
-            comment, IF you flagged any critical issue (bugs, security,
-            performance, missing test coverage), also write a marker file
-            in the workspace root:
-              touch .clud-bug-strict-fail
-            A post-step in this workflow detects that file and fails the
-            check, so the green-or-red status reflects actual findings
-            rather than just "did the bot run." Never write the marker
-            when reviewing was clean.
+            Strict-mode header (opt-in): if .claude/skills/.clud-bug.json
+            contains { "strictMode": true }, the comment header you post
+            MUST signal whether you flagged a critical issue:
+              IF you flagged any critical issue (bug, security,
+                  performance, missing test coverage):
+                  ## 🐛 Clud Bug review — critical findings
+              OTHERWISE:
+                  ## 🐛 Clud Bug review — clean
+            A post-step in this workflow greps your posted comment for
+            that header and fails the check on "critical findings." The
+            gate is deterministic on top of your judgment.
+
+            If strictMode is NOT set (or absent), keep the existing
+            "## 🐛 Clud Bug review" header — strict mode is opt-in and
+            other repos use the plain header.
 
             Tone: address the author conversationally. A concise field-naturalist
             voice is welcome (you are Clud Bug, examining specimens of code) but
@@ -115,13 +120,21 @@ jobs:
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
 
-      # Strict-mode gate (see workflow.yml.tmpl for rationale).
+      # Strict-mode gate — greps the posted comment for the critical-findings
+      # sentinel; deterministic on the actual comment, not bot memory.
       - name: Strict mode — fail check on critical findings
         if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [ -f .clud-bug-strict-fail ]; then
+          MANIFEST=".claude/skills/.clud-bug.json"
+          [ -f "$MANIFEST" ] || exit 0
+          STRICT=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$MANIFEST','utf8')).strictMode===true)}catch(e){console.log('false')}")
+          [ "$STRICT" = "true" ] || exit 0
+          BODIES=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?per_page=20" --jq '.[].body' 2>/dev/null || echo '')
+          if echo "$BODIES" | grep -q "Clud Bug review — critical findings"; then
             echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
             echo "::error::See the Clud Bug review comment for details."
-            rm -f .clud-bug-strict-fail
             exit 1
           fi

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0   # strict-mode gate reads base ref's manifest
 
       # Without this guard, claude-code-action silently exits 0 when the
       # secret is missing — the check turns green and the user thinks Clud
@@ -120,19 +122,22 @@ jobs:
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
 
-      # Strict-mode gate — see workflow.yml.tmpl for design notes.
+      # Strict-mode gate — see workflow.yml.tmpl for full design notes.
       - name: Strict mode — fail check on critical findings
-        if: always()
+        if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          BASE_MANIFEST=$(git show "origin/${{ github.base_ref }}:.claude/skills/.clud-bug.json" 2>/dev/null || echo '{}')
+          BASE_MANIFEST=$(git show "origin/${{ github.base_ref }}:.claude/skills/.clud-bug.json" 2>&1) || {
+            echo "::warning::Base manifest not found on ${{ github.base_ref }} — strict mode disabled for this run."
+            exit 0
+          }
           STRICT=$(echo "$BASE_MANIFEST" | node -e "let s='';process.stdin.on('data',c=>s+=c);process.stdin.on('end',()=>{try{console.log(JSON.parse(s).strictMode===true)}catch(e){console.log('false')}})")
           [ "$STRICT" = "true" ] || exit 0
           LATEST=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?sort=created&direction=desc&per_page=100" \
-            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | test("## 🐛 Clud Bug review")))][0].body // ""')
-          if echo "$LATEST" | grep -q "Clud Bug review — critical findings"; then
+            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | startswith("## 🐛 Clud Bug review")))][0].body // ""')
+          if echo "$LATEST" | head -n1 | grep -q "Clud Bug review — critical findings"; then
             echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
             echo "::error::See the latest Clud Bug review comment for details. Push a fix and the gate will clear on the next run."
             exit 1

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -41,7 +41,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(touch:*),Bash(cat:*)"
           prompt: |
             This project is "clud-bug". Claude Code PR review GitHub Action with project-aware skills auto-discovered from skills.sh. It's primarily javascript.
 
@@ -70,6 +70,17 @@ jobs:
               Skills referenced: [skill-name-1, skill-name-2, ...]
             If you genuinely cited none, list "[none]" and explain why no
             installed skill applied to this diff.
+
+            Strict mode (opt-in): if .claude/skills/.clud-bug.json contains
+            { "strictMode": true } at the top level, then after posting the
+            comment, IF you flagged any critical issue (bugs, security,
+            performance, missing test coverage), also write a marker file
+            in the workspace root:
+              touch .clud-bug-strict-fail
+            A post-step in this workflow detects that file and fails the
+            check, so the green-or-red status reflects actual findings
+            rather than just "did the bot run." Never write the marker
+            when reviewing was clean.
 
             Tone: address the author conversationally. A concise field-naturalist
             voice is welcome (you are Clud Bug, examining specimens of code) but
@@ -103,3 +114,14 @@ jobs:
             For line-specific issues, use the github_inline_comment MCP tool
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
+
+      # Strict-mode gate (see workflow.yml.tmpl for rationale).
+      - name: Strict mode — fail check on critical findings
+        if: always()
+        run: |
+          if [ -f .clud-bug-strict-fail ]; then
+            echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
+            echo "::error::See the Clud Bug review comment for details."
+            rm -f .clud-bug-strict-fail
+            exit 1
+          fi

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -120,21 +120,20 @@ jobs:
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
 
-      # Strict-mode gate — greps the posted comment for the critical-findings
-      # sentinel; deterministic on the actual comment, not bot memory.
+      # Strict-mode gate — see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          MANIFEST=".claude/skills/.clud-bug.json"
-          [ -f "$MANIFEST" ] || exit 0
-          STRICT=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$MANIFEST','utf8')).strictMode===true)}catch(e){console.log('false')}")
+          BASE_MANIFEST=$(git show "origin/${{ github.base_ref }}:.claude/skills/.clud-bug.json" 2>/dev/null || echo '{}')
+          STRICT=$(echo "$BASE_MANIFEST" | node -e "let s='';process.stdin.on('data',c=>s+=c);process.stdin.on('end',()=>{try{console.log(JSON.parse(s).strictMode===true)}catch(e){console.log('false')}})")
           [ "$STRICT" = "true" ] || exit 0
-          BODIES=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?per_page=20" --jq '.[].body' 2>/dev/null || echo '')
-          if echo "$BODIES" | grep -q "Clud Bug review — critical findings"; then
+          LATEST=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?sort=created&direction=desc&per_page=100" \
+            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | test("## 🐛 Clud Bug review")))][0].body // ""')
+          if echo "$LATEST" | grep -q "Clud Bug review — critical findings"; then
             echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
-            echo "::error::See the Clud Bug review comment for details."
+            echo "::error::See the latest Clud Bug review comment for details. Push a fix and the gate will clear on the next run."
             exit 1
           fi

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -43,7 +43,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
           prompt: |
             This project is "clud-bug". Claude Code PR review GitHub Action with project-aware skills auto-discovered from skills.sh. It's primarily javascript.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] — 2026-05-15
+
+### Added
+- **Strict mode (opt-in)** — set `strictMode: true` in `.claude/skills/.clud-bug.json` and the workflow check fails when Clud Bug flags any critical issue. Default behavior is unchanged: advisory (green check when the bot ran, regardless of findings). Pair with branch protection's required-status-checks for a real merge gate. Toggleable per-repo without rewriting any workflow.
+
 ## [0.3.3] — 2026-05-15
 
 ### Fixed
@@ -34,6 +39,7 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 - **Paragraph indent inconsistency on cludbug.dev.** Removed the `text-indent: 1.4em` rule on `.section-prose p + p`.
 - **Bug-pin scuttle animation** snap removed by replacing the 45/47%/90% keyframes with a symmetric 35→65% scuttle.
 
+[0.3.4]: https://github.com/thrillmot/clud-bug/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/thrillmot/clud-bug/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/thrillmot/clud-bug/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/thrillmot/clud-bug/compare/v0.3.0...v0.3.1

--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ The CLI prepares an `audits/YYYY-MM-DD.md` stub. For findings, `clud-bug init` a
 
 The workflow ships with `workflow_dispatch` only (manual). The cron is in the file, commented — uncomment for weekly audits.
 
+## Strict mode (opt-in)
+
+By default, Clud Bug is **advisory** — the workflow check turns green when the bot ran successfully, regardless of what it found. Inline comments flag issues; merging is your call.
+
+For repos that want the check status to reflect actual findings, opt into **strict mode** by adding `strictMode: true` to `.claude/skills/.clud-bug.json`:
+
+```json
+{ "strictMode": true, ... }
+```
+
+In strict mode, when Clud Bug flags a critical issue (bug, security, performance, missing test coverage), the workflow fails. Add `clud-bug-review` to your branch protection's required status checks and merging is blocked until findings are addressed.
+
+Toggle off by removing the `strictMode` field. No workflow rewrite needed.
+
 ## How skills shape reviews
 
 Skills aren't background reading material for the bot — they're rules with authority. The workflow prompt now requires Clud Bug to:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -42,7 +42,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(touch:*),Bash(cat:*)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 
@@ -70,6 +70,17 @@ jobs:
               Skills referenced: [skill-name-1, skill-name-2, ...]
             If you genuinely cited none, list "[none]" and explain why no
             installed skill applied to this diff.
+
+            Strict mode (opt-in): if .claude/skills/.clud-bug.json contains
+            { "strictMode": true } at the top level, then after posting the
+            comment, IF you flagged any critical issue (bugs, security,
+            performance, missing test coverage), also write a marker file
+            in the workspace root:
+              touch .clud-bug-strict-fail
+            A post-step in this workflow detects that file and fails the
+            check, so the green-or-red status reflects actual findings
+            rather than just "did the bot run." Never write the marker
+            when reviewing was clean.
 
             Tone: address the author conversationally. A concise field-naturalist
             voice is welcome (you are Clud Bug, examining specimens of code) but
@@ -103,3 +114,14 @@ jobs:
             For line-specific issues, use the github_inline_comment MCP tool
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
+
+      # Strict-mode gate (see workflow.yml.tmpl for details).
+      - name: Strict mode — fail check on critical findings
+        if: always()
+        run: |
+          if [ -f .clud-bug-strict-fail ]; then
+            echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
+            echo "::error::See the Clud Bug review comment for details, or disable strict mode by removing 'strictMode' from .claude/skills/.clud-bug.json."
+            rm -f .clud-bug-strict-fail
+            exit 1
+          fi

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0   # strict-mode gate reads base ref's manifest
 
       # Without this guard, claude-code-action silently exits 0 when the
       # secret is missing — the check turns green and the user thinks Clud
@@ -120,19 +122,22 @@ jobs:
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
 
-      # Strict-mode gate — see workflow.yml.tmpl for design notes.
+      # Strict-mode gate — see workflow.yml.tmpl for full design notes.
       - name: Strict mode — fail check on critical findings
-        if: always()
+        if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          BASE_MANIFEST=$(git show "origin/${{ github.base_ref }}:.claude/skills/.clud-bug.json" 2>/dev/null || echo '{}')
+          BASE_MANIFEST=$(git show "origin/${{ github.base_ref }}:.claude/skills/.clud-bug.json" 2>&1) || {
+            echo "::warning::Base manifest not found on ${{ github.base_ref }} — strict mode disabled for this run."
+            exit 0
+          }
           STRICT=$(echo "$BASE_MANIFEST" | node -e "let s='';process.stdin.on('data',c=>s+=c);process.stdin.on('end',()=>{try{console.log(JSON.parse(s).strictMode===true)}catch(e){console.log('false')}})")
           [ "$STRICT" = "true" ] || exit 0
           LATEST=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?sort=created&direction=desc&per_page=100" \
-            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | test("## 🐛 Clud Bug review")))][0].body // ""')
-          if echo "$LATEST" | grep -q "Clud Bug review — critical findings"; then
+            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | startswith("## 🐛 Clud Bug review")))][0].body // ""')
+          if echo "$LATEST" | head -n1 | grep -q "Clud Bug review — critical findings"; then
             echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
             echo "::error::See the latest Clud Bug review comment for details. Push a fix and the gate will clear on the next run."
             exit 1

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -120,21 +120,20 @@ jobs:
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
 
-      # Strict-mode gate — see workflow.yml.tmpl for details. Greps the
-      # posted PR comment for the critical-findings sentinel; deterministic.
+      # Strict-mode gate — see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          MANIFEST=".claude/skills/.clud-bug.json"
-          [ -f "$MANIFEST" ] || exit 0
-          STRICT=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$MANIFEST','utf8')).strictMode===true)}catch(e){console.log('false')}")
+          BASE_MANIFEST=$(git show "origin/${{ github.base_ref }}:.claude/skills/.clud-bug.json" 2>/dev/null || echo '{}')
+          STRICT=$(echo "$BASE_MANIFEST" | node -e "let s='';process.stdin.on('data',c=>s+=c);process.stdin.on('end',()=>{try{console.log(JSON.parse(s).strictMode===true)}catch(e){console.log('false')}})")
           [ "$STRICT" = "true" ] || exit 0
-          BODIES=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?per_page=20" --jq '.[].body' 2>/dev/null || echo '')
-          if echo "$BODIES" | grep -q "Clud Bug review — critical findings"; then
+          LATEST=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?sort=created&direction=desc&per_page=100" \
+            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | test("## 🐛 Clud Bug review")))][0].body // ""')
+          if echo "$LATEST" | grep -q "Clud Bug review — critical findings"; then
             echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
-            echo "::error::See the Clud Bug review comment for details."
+            echo "::error::See the latest Clud Bug review comment for details. Push a fix and the gate will clear on the next run."
             exit 1
           fi

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -42,7 +42,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(touch:*),Bash(cat:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 
@@ -71,16 +71,21 @@ jobs:
             If you genuinely cited none, list "[none]" and explain why no
             installed skill applied to this diff.
 
-            Strict mode (opt-in): if .claude/skills/.clud-bug.json contains
-            { "strictMode": true } at the top level, then after posting the
-            comment, IF you flagged any critical issue (bugs, security,
-            performance, missing test coverage), also write a marker file
-            in the workspace root:
-              touch .clud-bug-strict-fail
-            A post-step in this workflow detects that file and fails the
-            check, so the green-or-red status reflects actual findings
-            rather than just "did the bot run." Never write the marker
-            when reviewing was clean.
+            Strict-mode header (opt-in): if .claude/skills/.clud-bug.json
+            contains { "strictMode": true }, the comment header you post
+            MUST signal whether you flagged a critical issue:
+              IF you flagged any critical issue (bug, security,
+                  performance, missing test coverage):
+                  ## 🐛 Clud Bug review — critical findings
+              OTHERWISE:
+                  ## 🐛 Clud Bug review — clean
+            A post-step in this workflow greps your posted comment for
+            that header and fails the check on "critical findings." The
+            gate is deterministic on top of your judgment.
+
+            If strictMode is NOT set (or absent), keep the existing
+            "## 🐛 Clud Bug review" header — strict mode is opt-in and
+            other repos use the plain header.
 
             Tone: address the author conversationally. A concise field-naturalist
             voice is welcome (you are Clud Bug, examining specimens of code) but
@@ -115,13 +120,21 @@ jobs:
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
 
-      # Strict-mode gate (see workflow.yml.tmpl for details).
+      # Strict-mode gate — see workflow.yml.tmpl for details. Greps the
+      # posted PR comment for the critical-findings sentinel; deterministic.
       - name: Strict mode — fail check on critical findings
         if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [ -f .clud-bug-strict-fail ]; then
+          MANIFEST=".claude/skills/.clud-bug.json"
+          [ -f "$MANIFEST" ] || exit 0
+          STRICT=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$MANIFEST','utf8')).strictMode===true)}catch(e){console.log('false')}")
+          [ "$STRICT" = "true" ] || exit 0
+          BODIES=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?per_page=20" --jq '.[].body' 2>/dev/null || echo '')
+          if echo "$BODIES" | grep -q "Clud Bug review — critical findings"; then
             echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
-            echo "::error::See the Clud Bug review comment for details, or disable strict mode by removing 'strictMode' from .claude/skills/.clud-bug.json."
-            rm -f .clud-bug-strict-fail
+            echo "::error::See the Clud Bug review comment for details."
             exit 1
           fi

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -44,7 +44,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0   # strict-mode gate reads base ref's manifest
 
       # Without this guard, claude-code-action silently exits 0 when the
       # secret is missing — the check turns green and the user thinks Clud
@@ -121,19 +123,22 @@ jobs:
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
 
-      # Strict-mode gate — see workflow.yml.tmpl for design notes.
+      # Strict-mode gate — see workflow.yml.tmpl for full design notes.
       - name: Strict mode — fail check on critical findings
-        if: always()
+        if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          BASE_MANIFEST=$(git show "origin/${{ github.base_ref }}:.claude/skills/.clud-bug.json" 2>/dev/null || echo '{}')
+          BASE_MANIFEST=$(git show "origin/${{ github.base_ref }}:.claude/skills/.clud-bug.json" 2>&1) || {
+            echo "::warning::Base manifest not found on ${{ github.base_ref }} — strict mode disabled for this run."
+            exit 0
+          }
           STRICT=$(echo "$BASE_MANIFEST" | node -e "let s='';process.stdin.on('data',c=>s+=c);process.stdin.on('end',()=>{try{console.log(JSON.parse(s).strictMode===true)}catch(e){console.log('false')}})")
           [ "$STRICT" = "true" ] || exit 0
           LATEST=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?sort=created&direction=desc&per_page=100" \
-            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | test("## 🐛 Clud Bug review")))][0].body // ""')
-          if echo "$LATEST" | grep -q "Clud Bug review — critical findings"; then
+            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | startswith("## 🐛 Clud Bug review")))][0].body // ""')
+          if echo "$LATEST" | head -n1 | grep -q "Clud Bug review — critical findings"; then
             echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
             echo "::error::See the latest Clud Bug review comment for details. Push a fix and the gate will clear on the next run."
             exit 1

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -42,7 +42,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(touch:*),Bash(cat:*)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 
@@ -71,6 +71,17 @@ jobs:
               Skills referenced: [skill-name-1, skill-name-2, ...]
             If you genuinely cited none, list "[none]" and explain why no
             installed skill applied to this diff.
+
+            Strict mode (opt-in): if .claude/skills/.clud-bug.json contains
+            { "strictMode": true } at the top level, then after posting the
+            comment, IF you flagged any critical issue (bugs, security,
+            performance, missing test coverage), also write a marker file
+            in the workspace root:
+              touch .clud-bug-strict-fail
+            A post-step in this workflow detects that file and fails the
+            check, so the green-or-red status reflects actual findings
+            rather than just "did the bot run." Never write the marker
+            when reviewing was clean.
 
             Tone: address the author conversationally. A concise field-naturalist
             voice is welcome (you are Clud Bug, examining specimens of code) but
@@ -104,3 +115,14 @@ jobs:
             For line-specific issues, use the github_inline_comment MCP tool
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
+
+      # Strict-mode gate (see workflow.yml.tmpl for details).
+      - name: Strict mode — fail check on critical findings
+        if: always()
+        run: |
+          if [ -f .clud-bug-strict-fail ]; then
+            echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
+            echo "::error::See the Clud Bug review comment for details, or disable strict mode by removing 'strictMode' from .claude/skills/.clud-bug.json."
+            rm -f .clud-bug-strict-fail
+            exit 1
+          fi

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -42,7 +42,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(touch:*),Bash(cat:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 
@@ -72,16 +72,21 @@ jobs:
             If you genuinely cited none, list "[none]" and explain why no
             installed skill applied to this diff.
 
-            Strict mode (opt-in): if .claude/skills/.clud-bug.json contains
-            { "strictMode": true } at the top level, then after posting the
-            comment, IF you flagged any critical issue (bugs, security,
-            performance, missing test coverage), also write a marker file
-            in the workspace root:
-              touch .clud-bug-strict-fail
-            A post-step in this workflow detects that file and fails the
-            check, so the green-or-red status reflects actual findings
-            rather than just "did the bot run." Never write the marker
-            when reviewing was clean.
+            Strict-mode header (opt-in): if .claude/skills/.clud-bug.json
+            contains { "strictMode": true }, the comment header you post
+            MUST signal whether you flagged a critical issue:
+              IF you flagged any critical issue (bug, security,
+                  performance, missing test coverage):
+                  ## 🐛 Clud Bug review — critical findings
+              OTHERWISE:
+                  ## 🐛 Clud Bug review — clean
+            A post-step in this workflow greps your posted comment for
+            that header and fails the check on "critical findings." The
+            gate is deterministic on top of your judgment.
+
+            If strictMode is NOT set (or absent), keep the existing
+            "## 🐛 Clud Bug review" header — strict mode is opt-in and
+            other repos use the plain header.
 
             Tone: address the author conversationally. A concise field-naturalist
             voice is welcome (you are Clud Bug, examining specimens of code) but
@@ -116,13 +121,21 @@ jobs:
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
 
-      # Strict-mode gate (see workflow.yml.tmpl for details).
+      # Strict-mode gate — see workflow.yml.tmpl for details. Greps the
+      # posted PR comment for the critical-findings sentinel; deterministic.
       - name: Strict mode — fail check on critical findings
         if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [ -f .clud-bug-strict-fail ]; then
+          MANIFEST=".claude/skills/.clud-bug.json"
+          [ -f "$MANIFEST" ] || exit 0
+          STRICT=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$MANIFEST','utf8')).strictMode===true)}catch(e){console.log('false')}")
+          [ "$STRICT" = "true" ] || exit 0
+          BODIES=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?per_page=20" --jq '.[].body' 2>/dev/null || echo '')
+          if echo "$BODIES" | grep -q "Clud Bug review — critical findings"; then
             echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
-            echo "::error::See the Clud Bug review comment for details, or disable strict mode by removing 'strictMode' from .claude/skills/.clud-bug.json."
-            rm -f .clud-bug-strict-fail
+            echo "::error::See the Clud Bug review comment for details."
             exit 1
           fi

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -121,21 +121,20 @@ jobs:
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
 
-      # Strict-mode gate — see workflow.yml.tmpl for details. Greps the
-      # posted PR comment for the critical-findings sentinel; deterministic.
+      # Strict-mode gate — see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          MANIFEST=".claude/skills/.clud-bug.json"
-          [ -f "$MANIFEST" ] || exit 0
-          STRICT=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$MANIFEST','utf8')).strictMode===true)}catch(e){console.log('false')}")
+          BASE_MANIFEST=$(git show "origin/${{ github.base_ref }}:.claude/skills/.clud-bug.json" 2>/dev/null || echo '{}')
+          STRICT=$(echo "$BASE_MANIFEST" | node -e "let s='';process.stdin.on('data',c=>s+=c);process.stdin.on('end',()=>{try{console.log(JSON.parse(s).strictMode===true)}catch(e){console.log('false')}})")
           [ "$STRICT" = "true" ] || exit 0
-          BODIES=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?per_page=20" --jq '.[].body' 2>/dev/null || echo '')
-          if echo "$BODIES" | grep -q "Clud Bug review — critical findings"; then
+          LATEST=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?sort=created&direction=desc&per_page=100" \
+            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | test("## 🐛 Clud Bug review")))][0].body // ""')
+          if echo "$LATEST" | grep -q "Clud Bug review — critical findings"; then
             echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
-            echo "::error::See the Clud Bug review comment for details."
+            echo "::error::See the latest Clud Bug review comment for details. Push a fix and the gate will clear on the next run."
             exit 1
           fi

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -44,7 +44,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -117,27 +117,30 @@ jobs:
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
 
-      # Strict-mode gate: fails the check when both
-      #   (a) .claude/skills/.clud-bug.json has { "strictMode": true }, AND
-      #   (b) the comment Claude just posted starts with the
-      #       "critical findings" header sentinel.
-      # The gate is deterministic on the actual posted comment — not on the
-      # bot remembering to set a marker.
+      # Strict-mode gate. Fails the check when both
+      #   (a) the BASE ref's .claude/skills/.clud-bug.json has
+      #       { "strictMode": true } — read from base, not the PR head, so a
+      #       PR can't opt itself out of strict mode by editing its own
+      #       manifest, AND
+      #   (b) the LATEST clud-bug review comment on this PR starts with
+      #       "## 🐛 Clud Bug review — critical findings".
+      # We read the latest comment (sort=desc, take [0]) to avoid stale
+      # historical critical-findings comments locking the gate forever
+      # after the author has fixed the issues.
       - name: Strict mode — fail check on critical findings
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          MANIFEST=".claude/skills/.clud-bug.json"
-          [ -f "$MANIFEST" ] || exit 0
-          STRICT=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$MANIFEST','utf8')).strictMode===true)}catch(e){console.log('false')}")
+          BASE_MANIFEST=$(git show "origin/${{ github.base_ref }}:.claude/skills/.clud-bug.json" 2>/dev/null || echo '{}')
+          STRICT=$(echo "$BASE_MANIFEST" | node -e "let s='';process.stdin.on('data',c=>s+=c);process.stdin.on('end',()=>{try{console.log(JSON.parse(s).strictMode===true)}catch(e){console.log('false')}})")
           [ "$STRICT" = "true" ] || exit 0
 
-          # Look at recent comments on this PR for our critical-findings sentinel.
-          BODIES=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?per_page=20" --jq '.[].body' 2>/dev/null || echo '')
-          if echo "$BODIES" | grep -q "Clud Bug review — critical findings"; then
+          LATEST=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?sort=created&direction=desc&per_page=100" \
+            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | test("## 🐛 Clud Bug review")))][0].body // ""')
+          if echo "$LATEST" | grep -q "Clud Bug review — critical findings"; then
             echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
-            echo "::error::See the Clud Bug review comment for details, or disable strict mode by removing 'strictMode' from .claude/skills/.clud-bug.json."
+            echo "::error::See the latest Clud Bug review comment for details. Push a fix and the gate will clear on the next run."
             exit 1
           fi

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -48,7 +48,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -42,7 +42,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(touch:*),Bash(cat:*)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 
@@ -67,6 +67,17 @@ jobs:
               Skills referenced: [skill-name-1, skill-name-2, ...]
             If you genuinely cited none, list "[none]" and explain why no
             installed skill applied to this diff.
+
+            Strict mode (opt-in): if .claude/skills/.clud-bug.json contains
+            { "strictMode": true } at the top level, then after posting the
+            comment, IF you flagged any critical issue (bugs, security,
+            performance, missing test coverage), also write a marker file
+            in the workspace root:
+              touch .clud-bug-strict-fail
+            A post-step in this workflow detects that file and fails the
+            check, so the green-or-red status reflects actual findings
+            rather than just "did the bot run." Never write the marker
+            when reviewing was clean.
 
             Tone: address the author conversationally. A concise field-naturalist
             voice is welcome (you are Clud Bug, examining specimens of code) but
@@ -100,3 +111,16 @@ jobs:
             For line-specific issues, use the github_inline_comment MCP tool
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
+
+      # Strict-mode gate: fails the check when Clud Bug flagged critical
+      # issues AND the user opted into strict via .claude/skills/.clud-bug.json.
+      # The Claude step writes .clud-bug-strict-fail when both conditions hold.
+      - name: Strict mode — fail check on critical findings
+        if: always()
+        run: |
+          if [ -f .clud-bug-strict-fail ]; then
+            echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
+            echo "::error::See the Clud Bug review comment for details, or disable strict mode by removing 'strictMode' from .claude/skills/.clud-bug.json."
+            rm -f .clud-bug-strict-fail
+            exit 1
+          fi

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -14,6 +14,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          # fetch-depth: 0 so the strict-mode gate can `git show
+          # origin/<base_ref>:.claude/skills/.clud-bug.json` to read the base
+          # ref's manifest. Default depth=1 doesn't set up origin/<base_ref>
+          # and the gate would silently fall back to advisory.
+          fetch-depth: 0
 
       # Without this guard, claude-code-action silently exits 0 when the
       # secret is missing — the check turns green and the user thinks Clud
@@ -119,27 +125,40 @@ jobs:
 
       # Strict-mode gate. Fails the check when both
       #   (a) the BASE ref's .claude/skills/.clud-bug.json has
-      #       { "strictMode": true } — read from base, not the PR head, so a
-      #       PR can't opt itself out of strict mode by editing its own
-      #       manifest, AND
-      #   (b) the LATEST clud-bug review comment on this PR starts with
-      #       "## 🐛 Clud Bug review — critical findings".
-      # We read the latest comment (sort=desc, take [0]) to avoid stale
-      # historical critical-findings comments locking the gate forever
-      # after the author has fixed the issues.
+      #       { "strictMode": true } — read from base so a PR can't opt
+      #       itself out of strict mode by editing its own manifest, AND
+      #   (b) the LATEST clud-bug review comment on this PR has a body
+      #       whose FIRST LINE is "## 🐛 Clud Bug review — critical findings".
+      #
+      # if: success() — only run when claude-code-action succeeded. If the
+      # action errored, no new comment was posted for this run; falling back
+      # to a prior run's comment would fail open or fail on stale data.
+      # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
-        if: always()
+        if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          BASE_MANIFEST=$(git show "origin/${{ github.base_ref }}:.claude/skills/.clud-bug.json" 2>/dev/null || echo '{}')
+          # Loud failure if the base manifest can't be read — silently falling
+          # back to advisory would silently disable strict mode for every
+          # opted-in repo. (Requires fetch-depth: 0 on the checkout above.)
+          BASE_MANIFEST=$(git show "origin/${{ github.base_ref }}:.claude/skills/.clud-bug.json" 2>&1) || {
+            echo "::warning::Base manifest not found on ${{ github.base_ref }} — strict mode disabled for this run."
+            exit 0
+          }
           STRICT=$(echo "$BASE_MANIFEST" | node -e "let s='';process.stdin.on('data',c=>s+=c);process.stdin.on('end',()=>{try{console.log(JSON.parse(s).strictMode===true)}catch(e){console.log('false')}})")
           [ "$STRICT" = "true" ] || exit 0
 
+          # Use startswith (not regex contains) so comments that *quote* the
+          # sentinel header (other reviews, @claude responses, meta-PRs about
+          # strict mode itself) don't get picked up as "the latest review."
           LATEST=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?sort=created&direction=desc&per_page=100" \
-            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | test("## 🐛 Clud Bug review")))][0].body // ""')
-          if echo "$LATEST" | grep -q "Clud Bug review — critical findings"; then
+            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | startswith("## 🐛 Clud Bug review")))][0].body // ""')
+
+          # Scope the critical-findings match to the FIRST LINE so quoted
+          # sentinels deeper in the review can't trip the gate.
+          if echo "$LATEST" | head -n1 | grep -q "Clud Bug review — critical findings"; then
             echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
             echo "::error::See the latest Clud Bug review comment for details. Push a fix and the gate will clear on the next run."
             exit 1

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -42,7 +42,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(touch:*),Bash(cat:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 
@@ -68,16 +68,21 @@ jobs:
             If you genuinely cited none, list "[none]" and explain why no
             installed skill applied to this diff.
 
-            Strict mode (opt-in): if .claude/skills/.clud-bug.json contains
-            { "strictMode": true } at the top level, then after posting the
-            comment, IF you flagged any critical issue (bugs, security,
-            performance, missing test coverage), also write a marker file
-            in the workspace root:
-              touch .clud-bug-strict-fail
-            A post-step in this workflow detects that file and fails the
-            check, so the green-or-red status reflects actual findings
-            rather than just "did the bot run." Never write the marker
-            when reviewing was clean.
+            Strict-mode header (opt-in): if .claude/skills/.clud-bug.json
+            contains { "strictMode": true }, the comment header you post
+            MUST signal whether you flagged a critical issue:
+              IF you flagged any critical issue (bug, security,
+                  performance, missing test coverage):
+                  ## 🐛 Clud Bug review — critical findings
+              OTHERWISE:
+                  ## 🐛 Clud Bug review — clean
+            A post-step in this workflow greps your posted comment for
+            that header and fails the check on "critical findings." The
+            gate is deterministic on top of your judgment.
+
+            If strictMode is NOT set (or absent), keep the existing
+            "## 🐛 Clud Bug review" header — strict mode is opt-in and
+            other repos use the plain header.
 
             Tone: address the author conversationally. A concise field-naturalist
             voice is welcome (you are Clud Bug, examining specimens of code) but
@@ -112,15 +117,27 @@ jobs:
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
 
-      # Strict-mode gate: fails the check when Clud Bug flagged critical
-      # issues AND the user opted into strict via .claude/skills/.clud-bug.json.
-      # The Claude step writes .clud-bug-strict-fail when both conditions hold.
+      # Strict-mode gate: fails the check when both
+      #   (a) .claude/skills/.clud-bug.json has { "strictMode": true }, AND
+      #   (b) the comment Claude just posted starts with the
+      #       "critical findings" header sentinel.
+      # The gate is deterministic on the actual posted comment — not on the
+      # bot remembering to set a marker.
       - name: Strict mode — fail check on critical findings
         if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [ -f .clud-bug-strict-fail ]; then
+          MANIFEST=".claude/skills/.clud-bug.json"
+          [ -f "$MANIFEST" ] || exit 0
+          STRICT=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$MANIFEST','utf8')).strictMode===true)}catch(e){console.log('false')}")
+          [ "$STRICT" = "true" ] || exit 0
+
+          # Look at recent comments on this PR for our critical-findings sentinel.
+          BODIES=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?per_page=20" --jq '.[].body' 2>/dev/null || echo '')
+          if echo "$BODIES" | grep -q "Clud Bug review — critical findings"; then
             echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
             echo "::error::See the Clud Bug review comment for details, or disable strict mode by removing 'strictMode' from .claude/skills/.clud-bug.json."
-            rm -f .clud-bug-strict-fail
             exit 1
           fi


### PR DESCRIPTION
v0.3 PR 8/9. Default unchanged: Clud Bug is advisory. Opt-in via { strictMode: true } in .clud-bug.json — workflow check then turns red on critical findings. Pair with required status checks for a real merge gate. No workflow rewrite needed to toggle.