### PR TITLE
v0.4.0: strict default + bot-PR graceful degradation

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"db096c9c-ac3c-404d-b3a7-e02e711fea7d","pid":30480,"procStart":"Fri May 15 02:09:28 2026","acquiredAt":1778831749494}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"db096c9c-ac3c-404d-b3a7-e02e711fea7d","pid":30480,"procStart":"Fri May 15 02:09:28 2026","acquiredAt":1778831749494}

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -33,8 +33,12 @@ jobs:
           IS_BOT=false; case "$PR_AUTHOR" in *\[bot\]) IS_BOT=true ;; esac
           if $IS_FORK || $IS_BOT; then
             REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
-            BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
-            gh pr comment "$PR_NUMBER" --body "$BODY" || true
+            EXISTING=$(gh api "repos/${BASE_REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
+              --jq '[.[] | select(.user.login == "claude[bot]" and (.body | startswith("## 🐛 Clud Bug skipped")))] | length')
+            if [ "${EXISTING:-0}" = "0" ]; then
+              BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
+              gh pr comment "$PR_NUMBER" --body "$BODY" || true
+            fi
             echo "::warning title=Clud Bug 🐛::Skipped — $REASON cannot access repository secrets."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -33,9 +33,8 @@ jobs:
           IS_BOT=false; case "$PR_AUTHOR" in *\[bot\]) IS_BOT=true ;; esac
           if $IS_FORK || $IS_BOT; then
             REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
-            gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug skipped
-
-This PR is from a $REASON. GitHub deliberately doesn't pass repository secrets to such workflows, so Clud Bug couldn't authenticate against Anthropic. Review the diff manually." || true
+            BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
+            gh pr comment "$PR_NUMBER" --body "$BODY" || true
             echo "::warning title=Clud Bug 🐛::Skipped — $REASON cannot access repository secrets."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -17,25 +17,35 @@ jobs:
         with:
           fetch-depth: 0   # strict-mode gate reads base ref's manifest
 
-      # Without this guard, claude-code-action silently exits 0 when the
-      # secret is missing — the check turns green and the user thinks Clud
-      # Bug is working when it's a no-op. Fail loud unless this is a fork PR
-      # (where GitHub deliberately withholds secrets — that's by design).
+      # Three-way guard — see workflow.yml.tmpl for full design notes.
       - name: Guard — require ANTHROPIC_API_KEY
+        id: guard
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
-          if [ -n "$ANTHROPIC_API_KEY" ]; then exit 0; fi
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
-            echo "::warning title=Clud Bug 🐛::Fork PR — GitHub doesn't pass repo secrets to fork-triggered workflows. Clud Bug review skipped by design."
+          if [ -n "$ANTHROPIC_API_KEY" ]; then echo "skip=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          IS_FORK=false; [ "$HEAD_REPO" != "$BASE_REPO" ] && IS_FORK=true
+          IS_BOT=false; case "$PR_AUTHOR" in *\[bot\]) IS_BOT=true ;; esac
+          if $IS_FORK || $IS_BOT; then
+            REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
+            gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug skipped
+
+This PR is from a $REASON. GitHub deliberately doesn't pass repository secrets to such workflows, so Clud Bug couldn't authenticate against Anthropic. Review the diff manually." || true
+            echo "::warning title=Clud Bug 🐛::Skipped — $REASON cannot access repository secrets."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "::error title=Clud Bug 🐛::ANTHROPIC_API_KEY secret is not set on this repository."
           echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
-          echo "::error::Without it, Clud Bug review is a silent no-op."
           exit 1
 
       - uses: anthropics/claude-code-action@v1
+        if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ site/next-env.d.ts
 # Editor
 .vscode/
 .idea/
+
+# Local Claude Code session state
+.claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — site-only
+## [0.4.0] — 2026-05-15
+
+### Changed (breaking)
+- **Strict mode is now the default for new installs.** `clud-bug init` writes `{ "strictMode": true }` to `.claude/skills/.clud-bug.json`. Reviews that flag critical issues fail the workflow check — pair with branch protection's required status checks for a real merge gate. Existing installs are NOT auto-flipped (the field is only set when missing); your prior advisory behavior is preserved unless you add the field. To opt new installs into advisory, set `strictMode: false`.
 
 ### Added
-- **Bug emoji is alive.** Hero bug pin now layers three independent animations (breathe + twitch + scuttle) using individual `rotate`/`scale`/`translate` properties so they actually compose instead of overriding each other. Continuous gentle "breathing," rare head tilts, and the existing slow traverse — but each on its own clock so the motion never feels mechanical. Honors `prefers-reduced-motion`.
-- **Plate label gloss.** "Plate I — Frontispiece" was on-brand vintage-naturalist convention but opaque to first-time visitors. Added a small dotted-divider gloss explaining the term: *"Plate: a labeled illustration in a field guide. Frontispiece: the cover plate."* Cool intact, meaning unlocked.
-- **Thrillmot credit in the colophon.** Small italic *"a thrillmot project"* in the footer linking to thrillmot.com, between the MIT line and the GitHub link.
+- **Bot-authored PRs are now handled gracefully.** PRs from `dependabot[bot]`, `renovate[bot]`, or forks (where GitHub deliberately doesn't pass repository secrets) used to fail loudly red — wrong signal. Now a guard step detects the case, posts a one-line advisory comment ("Clud Bug skipped — bot/fork PR cannot access secrets"), and exits 0. Check stays green; the skip is visible. Owner-authored PRs without the secret still fail loud.
+- **Site polish (carries over from the unreleased entry):** alive bug emoji (layered breathe + twitch + scuttle animations), Plate label gloss, thrillmot footer credit.
+
+[0.4.0]: https://github.com/thrillmot/clud-bug/compare/v0.3.4...v0.4.0
 
 ## [0.3.4] — 2026-05-15
 

--- a/README.md
+++ b/README.md
@@ -77,19 +77,27 @@ The CLI prepares an `audits/YYYY-MM-DD.md` stub. For findings, `clud-bug init` a
 
 The workflow ships with `workflow_dispatch` only (manual). The cron is in the file, commented — uncomment for weekly audits.
 
-## Strict mode (opt-in)
+## Strict mode (default since v0.4.0)
 
-By default, Clud Bug is **advisory** — the workflow check turns green when the bot ran successfully, regardless of what it found. Inline comments flag issues; merging is your call.
+Clud Bug runs in **strict mode by default** for new installs. The workflow check fails when Clud Bug flags a critical issue (bug, security, performance, missing test coverage) — green means clean, red means the bot found something to address. Add `clud-bug-review` to your branch protection's required status checks and merging is blocked until findings are addressed.
 
-For repos that want the check status to reflect actual findings, opt into **strict mode** by adding `strictMode: true` to `.claude/skills/.clud-bug.json`:
+`clud-bug init` writes `{ "strictMode": true }` to `.claude/skills/.clud-bug.json`. To opt out into advisory mode (the bot still reviews; the check stays green regardless of findings), set `strictMode: false`:
 
 ```json
-{ "strictMode": true, ... }
+{ "strictMode": false, ... }
 ```
 
-In strict mode, when Clud Bug flags a critical issue (bug, security, performance, missing test coverage), the workflow fails. Add `clud-bug-review` to your branch protection's required status checks and merging is blocked until findings are addressed.
+The toggle takes effect on PRs opened *after* the new value lands on the base branch (the gate reads the manifest from the base ref so PRs can't disable strict on themselves).
 
-Toggle off by removing the `strictMode` field. No workflow rewrite needed.
+**Existing installs upgrading to v0.4.0:** strictMode is only set when missing — your prior advisory configuration is preserved. To enable strict mode in an existing repo, add the field manually.
+
+## Bot-authored PRs (Dependabot, Renovate, fork PRs)
+
+GitHub deliberately doesn't pass repository secrets to workflows triggered by bot-authored PRs (`dependabot[bot]`, `renovate[bot]`) or PRs from forks. The action can't authenticate against Anthropic, so Clud Bug can't review.
+
+Rather than failing red (wrong signal), the workflow detects this case, posts a one-line advisory comment to the PR explaining the skip, and exits 0. The check stays green; the comment makes the skip visible. Reviews are your responsibility on those PRs.
+
+To enable real reviews on Dependabot PRs, [add ANTHROPIC_API_KEY to Dependabot's secret scope](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot).
 
 ## How skills shape reviews
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Clud Bug runs in **strict mode by default** for new installs. The workflow check
 
 The toggle takes effect on PRs opened *after* the new value lands on the base branch (the gate reads the manifest from the base ref so PRs can't disable strict on themselves).
 
-**Existing installs upgrading to v0.4.0:** strictMode is only set when missing — your prior advisory configuration is preserved. To enable strict mode in an existing repo, add the field manually.
+**Existing installs upgrading to v0.4.0:** the new default only fires on fresh installs (manifests that have never been touched by `init` or `update`). Existing repos — including v0.3.x advisory installs that never set `strictMode` — keep their prior behavior on re-init. To enable strict mode in an existing repo, add `"strictMode": true` to `.claude/skills/.clud-bug.json` manually.
 
 ## Bot-authored PRs (Dependabot, Renovate, fork PRs)
 

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -178,13 +178,17 @@ async function runInit(args) {
   await writeFile(selfUpdatePath, selfUpdateTmpl);
   log(`    wrote ${rel(cwd, selfUpdatePath)}`);
 
-  // Stamp the manifest with the version that did the install so the
-  // self-update workflow can compare. (writeSkills only writes installed
-  // entries; we add a separate stamp here.)
+  // Stamp the manifest. Sets strictMode: true by default — clud-bug is
+  // designed to be a merge gate, not advisory. Existing installs (manifests
+  // already present without strictMode) are NOT auto-flipped; only fresh
+  // inits get the new default. Users opt out by setting strictMode: false.
   const skillsDirPath = join(cwd, '.claude', 'skills');
   const manifest = await readManifest(skillsDirPath);
   manifest.lastUpdateVersion = await readPkgVersion();
   manifest.lastUpdate = new Date().toISOString();
+  if (manifest.strictMode === undefined) {
+    manifest.strictMode = true;
+  }
   await writeManifest(skillsDirPath, manifest);
 
   if (args.commit) {
@@ -207,6 +211,10 @@ async function runInit(args) {
   log('Drop your own .claude/skills/<name>/SKILL.md files anytime — they get pinned automatically.');
   log('For a whole-repo walk: Actions tab → Clud Bug 🐛 Audit → Run workflow.');
   log('Self-update is on (weekly Mondays 12:00 UTC). Pin via "pinVersion" in .claude/skills/.clud-bug.json.');
+  log('');
+  log('Strict mode is ON by default (clud-bug-review fails the check on critical findings).');
+  log('  • Add `clud-bug-review` to your branch protection required checks for full enforcement.');
+  log('  • Opt out by setting "strictMode": false in .claude/skills/.clud-bug.json.');
 }
 
 async function promptForSkills(recommended) {

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -178,15 +178,18 @@ async function runInit(args) {
   await writeFile(selfUpdatePath, selfUpdateTmpl);
   log(`    wrote ${rel(cwd, selfUpdatePath)}`);
 
-  // Stamp the manifest. Sets strictMode: true by default — clud-bug is
-  // designed to be a merge gate, not advisory. Existing installs (manifests
-  // already present without strictMode) are NOT auto-flipped; only fresh
-  // inits get the new default. Users opt out by setting strictMode: false.
+  // Stamp the manifest. Sets strictMode: true ONLY on fresh installs —
+  // a manifest that's never been touched by clud-bug init/update has no
+  // lastUpdate field. Existing v0.3.x advisory installs (where strictMode
+  // was never written and so == undefined) keep their advisory behavior
+  // because lastUpdate IS set; the strictMode default only fires on truly
+  // fresh inits. Users opt out by setting strictMode: false.
   const skillsDirPath = join(cwd, '.claude', 'skills');
   const manifest = await readManifest(skillsDirPath);
+  const isFreshInstall = manifest.lastUpdate === undefined;
   manifest.lastUpdateVersion = await readPkgVersion();
   manifest.lastUpdate = new Date().toISOString();
-  if (manifest.strictMode === undefined) {
+  if (isFreshInstall && manifest.strictMode === undefined) {
     manifest.strictMode = true;
   }
   await writeManifest(skillsDirPath, manifest);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -33,8 +33,12 @@ jobs:
           IS_BOT=false; case "$PR_AUTHOR" in *\[bot\]) IS_BOT=true ;; esac
           if $IS_FORK || $IS_BOT; then
             REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
-            BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
-            gh pr comment "$PR_NUMBER" --body "$BODY" || true
+            EXISTING=$(gh api "repos/${BASE_REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
+              --jq '[.[] | select(.user.login == "claude[bot]" and (.body | startswith("## 🐛 Clud Bug skipped")))] | length')
+            if [ "${EXISTING:-0}" = "0" ]; then
+              BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
+              gh pr comment "$PR_NUMBER" --body "$BODY" || true
+            fi
             echo "::warning title=Clud Bug 🐛::Skipped — $REASON cannot access repository secrets."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -33,9 +33,8 @@ jobs:
           IS_BOT=false; case "$PR_AUTHOR" in *\[bot\]) IS_BOT=true ;; esac
           if $IS_FORK || $IS_BOT; then
             REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
-            gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug skipped
-
-This PR is from a $REASON. GitHub deliberately doesn't pass repository secrets to such workflows, so Clud Bug couldn't authenticate against Anthropic. Review the diff manually." || true
+            BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
+            gh pr comment "$PR_NUMBER" --body "$BODY" || true
             echo "::warning title=Clud Bug 🐛::Skipped — $REASON cannot access repository secrets."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -17,26 +17,35 @@ jobs:
         with:
           fetch-depth: 0   # strict-mode gate reads base ref's manifest
 
-      # Without this guard, claude-code-action silently exits 0 when the
-      # secret is missing — the check turns green and the user thinks Clud
-      # Bug is working when it's a no-op. Fail loud unless this is a fork PR
-      # (where GitHub deliberately withholds secrets — that's by design and
-      # documented in the README's "Fork PR caveat" section).
+      # Three-way guard — see workflow.yml.tmpl for full design notes.
       - name: Guard — require ANTHROPIC_API_KEY
+        id: guard
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
-          if [ -n "$ANTHROPIC_API_KEY" ]; then exit 0; fi
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
-            echo "::warning title=Clud Bug 🐛::Fork PR — GitHub doesn't pass repo secrets to fork-triggered workflows. Clud Bug review skipped by design."
+          if [ -n "$ANTHROPIC_API_KEY" ]; then echo "skip=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          IS_FORK=false; [ "$HEAD_REPO" != "$BASE_REPO" ] && IS_FORK=true
+          IS_BOT=false; case "$PR_AUTHOR" in *\[bot\]) IS_BOT=true ;; esac
+          if $IS_FORK || $IS_BOT; then
+            REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
+            gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug skipped
+
+This PR is from a $REASON. GitHub deliberately doesn't pass repository secrets to such workflows, so Clud Bug couldn't authenticate against Anthropic. Review the diff manually." || true
+            echo "::warning title=Clud Bug 🐛::Skipped — $REASON cannot access repository secrets."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "::error title=Clud Bug 🐛::ANTHROPIC_API_KEY secret is not set on this repository."
           echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
-          echo "::error::Without it, Clud Bug review is a silent no-op."
           exit 1
 
       - uses: anthropics/claude-code-action@v1
+        if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -33,8 +33,12 @@ jobs:
           IS_BOT=false; case "$PR_AUTHOR" in *\[bot\]) IS_BOT=true ;; esac
           if $IS_FORK || $IS_BOT; then
             REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
-            BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
-            gh pr comment "$PR_NUMBER" --body "$BODY" || true
+            EXISTING=$(gh api "repos/${BASE_REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
+              --jq '[.[] | select(.user.login == "claude[bot]" and (.body | startswith("## 🐛 Clud Bug skipped")))] | length')
+            if [ "${EXISTING:-0}" = "0" ]; then
+              BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
+              gh pr comment "$PR_NUMBER" --body "$BODY" || true
+            fi
             echo "::warning title=Clud Bug 🐛::Skipped — $REASON cannot access repository secrets."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -33,9 +33,8 @@ jobs:
           IS_BOT=false; case "$PR_AUTHOR" in *\[bot\]) IS_BOT=true ;; esac
           if $IS_FORK || $IS_BOT; then
             REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
-            gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug skipped
-
-This PR is from a $REASON. GitHub deliberately doesn't pass repository secrets to such workflows, so Clud Bug couldn't authenticate against Anthropic. Review the diff manually." || true
+            BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
+            gh pr comment "$PR_NUMBER" --body "$BODY" || true
             echo "::warning title=Clud Bug 🐛::Skipped — $REASON cannot access repository secrets."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -17,26 +17,35 @@ jobs:
         with:
           fetch-depth: 0   # strict-mode gate reads base ref's manifest
 
-      # Without this guard, claude-code-action silently exits 0 when the
-      # secret is missing — the check turns green and the user thinks Clud
-      # Bug is working when it's a no-op. Fail loud unless this is a fork PR
-      # (where GitHub deliberately withholds secrets — that's by design and
-      # documented in the README's "Fork PR caveat" section).
+      # Three-way guard — see workflow.yml.tmpl for full design notes.
       - name: Guard — require ANTHROPIC_API_KEY
+        id: guard
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
-          if [ -n "$ANTHROPIC_API_KEY" ]; then exit 0; fi
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
-            echo "::warning title=Clud Bug 🐛::Fork PR — GitHub doesn't pass repo secrets to fork-triggered workflows. Clud Bug review skipped by design."
+          if [ -n "$ANTHROPIC_API_KEY" ]; then echo "skip=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          IS_FORK=false; [ "$HEAD_REPO" != "$BASE_REPO" ] && IS_FORK=true
+          IS_BOT=false; case "$PR_AUTHOR" in *\[bot\]) IS_BOT=true ;; esac
+          if $IS_FORK || $IS_BOT; then
+            REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
+            gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug skipped
+
+This PR is from a $REASON. GitHub deliberately doesn't pass repository secrets to such workflows, so Clud Bug couldn't authenticate against Anthropic. Review the diff manually." || true
+            echo "::warning title=Clud Bug 🐛::Skipped — $REASON cannot access repository secrets."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "::error title=Clud Bug 🐛::ANTHROPIC_API_KEY secret is not set on this repository."
           echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
-          echo "::error::Without it, Clud Bug review is a silent no-op."
           exit 1
 
       - uses: anthropics/claude-code-action@v1
+        if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -51,9 +51,8 @@ jobs:
 
           if $IS_FORK || $IS_BOT; then
             REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
-            gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug skipped
-
-This PR is from a $REASON. GitHub deliberately doesn't pass repository secrets to such workflows, so Clud Bug couldn't authenticate against Anthropic. Review the diff manually — or, for recurring Dependabot / Renovate PRs, [enable secrets for Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events) so reviews run for real." || true
+            BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
+            gh pr comment "$PR_NUMBER" --body "$BODY" || true
             echo "::warning title=Clud Bug 🐛::Skipped — $REASON cannot access repository secrets. Advisory comment posted."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -51,9 +51,16 @@ jobs:
 
           if $IS_FORK || $IS_BOT; then
             REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
-            BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
-            gh pr comment "$PR_NUMBER" --body "$BODY" || true
-            echo "::warning title=Clud Bug 🐛::Skipped — $REASON cannot access repository secrets. Advisory comment posted."
+            # Dedup: don't post the advisory comment if one already exists.
+            # pull_request: synchronize on a long-running Dependabot PR would
+            # otherwise stack one identical comment per rebase.
+            EXISTING=$(gh api "repos/${BASE_REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
+              --jq '[.[] | select(.user.login == "claude[bot]" and (.body | startswith("## 🐛 Clud Bug skipped")))] | length')
+            if [ "${EXISTING:-0}" = "0" ]; then
+              BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
+              gh pr comment "$PR_NUMBER" --body "$BODY" || true
+            fi
+            echo "::warning title=Clud Bug 🐛::Skipped — $REASON cannot access repository secrets."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -21,26 +21,52 @@ jobs:
           # and the gate would silently fall back to advisory.
           fetch-depth: 0
 
-      # Without this guard, claude-code-action silently exits 0 when the
-      # secret is missing — the check turns green and the user thinks Clud
-      # Bug is working when it's a no-op. Fail loud unless this is a fork PR
-      # (where GitHub deliberately withholds secrets — that's by design and
-      # documented in the README's "Fork PR caveat" section).
+      # Three-way guard around the Claude action:
+      #   1. Secret present → no-op pass-through, action runs normally.
+      #   2. Secret missing AND PR is bot-authored or from a fork → post an
+      #      advisory comment explaining the skip, then exit 0 (green check).
+      #      GitHub deliberately withholds secrets from such PRs by design;
+      #      failing red is the wrong signal.
+      #   3. Secret missing AND PR is owner-authored → fail loud with an
+      #      actionable error so the maintainer knows to set the secret.
       - name: Guard — require ANTHROPIC_API_KEY
+        id: guard
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
-          if [ -n "$ANTHROPIC_API_KEY" ]; then exit 0; fi
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
-            echo "::warning title=Clud Bug 🐛::Fork PR — GitHub doesn't pass repo secrets to fork-triggered workflows. Clud Bug review skipped by design."
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          IS_FORK=false
+          [ "$HEAD_REPO" != "$BASE_REPO" ] && IS_FORK=true
+          IS_BOT=false
+          case "$PR_AUTHOR" in *\[bot\]) IS_BOT=true ;; esac
+
+          if $IS_FORK || $IS_BOT; then
+            REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
+            gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug skipped
+
+This PR is from a $REASON. GitHub deliberately doesn't pass repository secrets to such workflows, so Clud Bug couldn't authenticate against Anthropic. Review the diff manually — or, for recurring Dependabot / Renovate PRs, [enable secrets for Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events) so reviews run for real." || true
+            echo "::warning title=Clud Bug 🐛::Skipped — $REASON cannot access repository secrets. Advisory comment posted."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "::error title=Clud Bug 🐛::ANTHROPIC_API_KEY secret is not set on this repository."
           echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
           echo "::error::Without it, Clud Bug review is a silent no-op."
           exit 1
 
       - uses: anthropics/claude-code-action@v1
+        # Skip the action when guard already posted the bot/fork advisory.
+        if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -62,6 +62,49 @@ test('init --offline --accept-all in a fresh repo writes workflow + manifest', a
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 
+test('init: fresh install gets strictMode: true (v0.4 default)', async () => {
+  const dir = await makeRepo({ 'package.json': '{}' });
+  try {
+    run(dir, ['init', '--offline', '--accept-all']);
+    const manifest = JSON.parse(await readFile(join(dir, '.claude/skills/.clud-bug.json'), 'utf8'));
+    assert.equal(manifest.strictMode, true, 'fresh install should default to strict mode');
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('init: existing v0.3 advisory install (no strictMode field, has lastUpdate) is NOT auto-flipped', async () => {
+  const dir = await makeRepo({ 'package.json': '{}' });
+  try {
+    // Pre-seed a v0.3-era manifest: lastUpdate set, strictMode never written.
+    await mkdir(join(dir, '.claude/skills'), { recursive: true });
+    await writeFile(
+      join(dir, '.claude/skills/.clud-bug.json'),
+      JSON.stringify({
+        version: 1,
+        installed: [],
+        lastUpdate: '2026-04-01T00:00:00Z',
+        lastUpdateVersion: '0.3.4',
+      }, null, 2),
+    );
+    run(dir, ['init', '--offline', '--accept-all']);
+    const manifest = JSON.parse(await readFile(join(dir, '.claude/skills/.clud-bug.json'), 'utf8'));
+    assert.equal(manifest.strictMode, undefined, 'pre-existing advisory install must keep advisory behavior');
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('init: existing install with explicit strictMode: false stays false', async () => {
+  const dir = await makeRepo({ 'package.json': '{}' });
+  try {
+    await mkdir(join(dir, '.claude/skills'), { recursive: true });
+    await writeFile(
+      join(dir, '.claude/skills/.clud-bug.json'),
+      JSON.stringify({ version: 1, installed: [], strictMode: false }, null, 2),
+    );
+    run(dir, ['init', '--offline', '--accept-all']);
+    const manifest = JSON.parse(await readFile(join(dir, '.claude/skills/.clud-bug.json'), 'utf8'));
+    assert.equal(manifest.strictMode, false, 'explicit opt-out must be preserved');
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
 test('list shows baseline + custom after init + hand-authored skill', async () => {
   const dir = await makeRepo({ 'package.json': '{}' });
   try {


### PR DESCRIPTION
## Summary

v0.4 PR 20. Two related behavior changes that warrant a minor bump.

### Strict mode is now the default for new installs

`clud-bug init` writes `{ strictMode: true }`. Workflow check fails when Clud Bug flags a critical finding. Pair with branch protection's required status checks → real merge gate.

**Existing installs are not auto-flipped.** `init` only sets `strictMode` when the field is undefined, so prior advisory configurations are preserved.

### Bot-authored PRs (Dependabot/Renovate/forks) handled gracefully

Per the external agent's report: GitHub deliberately doesn't pass repo secrets to bot- or fork-authored PRs. Previous behavior failed those PRs red — wrong signal. The new three-way guard:

1. Secret present → pass-through.
2. Secret missing + bot/fork PR → advisory comment + exit 0 (green).
3. Secret missing + owner PR → loud red (unchanged).

## Test plan
- [x] `npm test` 62/62 pass
- [x] Site rebuilds clean
- [ ] CI green
- [ ] Reviewers approve (bots will likely self-skip due to workflow self-mod guard — known)