### PR TITLE
v0.4.1: clud-bug edit-workflow + README callout for self-mod guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] — 2026-05-15
+
+### Added
+- **`clud-bug edit-workflow` CLI** — packages clud-bug-workflow edits into an isolated PR. `claude-code-action` refuses to run on PRs that modify its own workflow (a security guard); this command keeps the scope clean so non-workflow work isn't blocked alongside it. Refuses to run if the working tree has non-workflow changes.
+- **README "When you edit the workflow"** subsection — documents the upstream self-mod guard so the 401 error doesn't surprise users.
+
 ## [0.4.0] — 2026-05-15
 
 ### Changed (breaking)
@@ -11,6 +17,7 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 - **Bot-authored PRs are now handled gracefully.** PRs from `dependabot[bot]`, `renovate[bot]`, or forks (where GitHub deliberately doesn't pass repository secrets) used to fail loudly red — wrong signal. Now a guard step detects the case, posts a one-line advisory comment ("Clud Bug skipped — bot/fork PR cannot access secrets"), and exits 0. Check stays green; the skip is visible. Owner-authored PRs without the secret still fail loud.
 - **Site polish (carries over from the unreleased entry):** alive bug emoji (layered breathe + twitch + scuttle animations), Plate label gloss, thrillmot footer credit.
 
+[0.4.1]: https://github.com/thrillmot/clud-bug/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/thrillmot/clud-bug/compare/v0.3.4...v0.4.0
 
 ## [0.3.4] — 2026-05-15

--- a/README.md
+++ b/README.md
@@ -158,6 +158,19 @@ If you want clud-bug to review fork PRs too, you have two options:
 
 clud-bug's generated workflow uses `pull_request` by default. If you understand the trade-offs, edit the trigger yourself.
 
+## When you edit the workflow
+
+clud-bug uses [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action), which **refuses to run when the PR being reviewed modifies the action's own workflow file**. That's a security guard against PRs that try to neuter the reviewer or exfiltrate secrets via prompt injection. If you edit `.github/workflows/clud-bug-review.yml` (or any clud-bug workflow), expect this check to fail with a 401 — `App token exchange failed: Workflow validation failed`. That's the documented behavior, not a bug. Merge the workflow change in isolation, and subsequent PRs work normally.
+
+To make this easier, `clud-bug edit-workflow` packages the workflow change into a clean PR for you:
+
+```bash
+# Edit .github/workflows/clud-bug-*.yml as you like, then:
+clud-bug edit-workflow
+```
+
+The command refuses to run if your working tree has any non-workflow changes — keeping the PR scoped to just the workflow edit.
+
 ## Verifying it works
 
 After install:

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -14,6 +14,7 @@ import {
 } from '../lib/skills.js';
 import { computeAuditFileSet, renderAuditHeader } from '../lib/audit.js';
 import { runUpdate } from '../lib/update.js';
+import { getPendingWorkflowEdits, makeBranchName, git as gitCmd } from '../lib/edit-workflow.js';
 
 const PKG_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const TEMPLATES = join(PKG_ROOT, 'templates');
@@ -55,6 +56,8 @@ Commands:
                         Use --since / --changed-in / --scope to narrow.
   update                Re-render workflows + refresh baseline specimens to the latest shipped
                         templates. Custom and skills.sh-installed specimens left alone.
+  edit-workflow         Helper for editing .github/workflows/clud-bug-*.yml in an isolated
+                        PR (the action refuses to review PRs that modify its own workflow).
 
 Options:
   --offline             Skip skills.sh; pin only the bundled baseline specimens.
@@ -87,6 +90,7 @@ async function main() {
     case 'refresh': return runRefresh(args);
     case 'audit':   return runAudit(args);
     case 'update':  return runUpdateCmd(args);
+    case 'edit-workflow': return runEditWorkflow(args);
     default:
       process.stderr.write(`Unknown command: ${cmd || '(none)'}\n\n${HELP}`);
       process.exit(2);
@@ -376,6 +380,46 @@ async function runRefresh(args) {
   if (diff.add.length) await writeSkills(skillsDir, diff.add, client);
   for (const entry of diff.remove) await removeSkill(skillsDir, entry.slug);
   log('  ✓ collection updated. Commit + push to apply on the next PR.');
+}
+
+async function runEditWorkflow(_args) {
+  const cwd = process.cwd();
+
+  // Validate: must have pending changes, all scoped to clud-bug workflow files.
+  let pending;
+  try {
+    pending = getPendingWorkflowEdits(cwd);
+  } catch (err) {
+    process.stderr.write(`clud-bug edit-workflow: ${err.message}\n`);
+    process.exit(2);
+  }
+
+  if (pending.files.length === 0) {
+    log('Nothing to commit. Edit your .github/workflows/clud-bug-*.yml file(s) first, then re-run.');
+    return;
+  }
+  if (!pending.allWorkflow) {
+    process.stderr.write(`clud-bug edit-workflow: working tree contains non-workflow changes:\n`);
+    for (const f of pending.nonWorkflow) process.stderr.write(`  ${f}\n`);
+    process.stderr.write(`\nThis command is for isolated workflow-only PRs. Stash or commit the\nnon-workflow changes elsewhere first, then re-run.\n`);
+    process.exit(2);
+  }
+
+  log('🐛 Preparing an isolated PR for your workflow edit.');
+  const branch = makeBranchName();
+  log(`  branch: ${branch}`);
+  for (const f of pending.files) log(`    • ${f}`);
+
+  // Branch from current ref (whatever the user was on — usually main),
+  // commit the workflow files only, push, open PR.
+  gitCmd(cwd, ['checkout', '-b', branch]);
+  gitCmd(cwd, ['add', ...pending.files]);
+  gitCmd(cwd, ['commit', '-m', 'Edit clud-bug workflow']);
+  gitCmd(cwd, ['push', '-u', 'origin', branch]);
+
+  log('');
+  log('Done. Open the PR:');
+  log(`  gh pr create --title "Edit clud-bug workflow" --body "Workflow tweak. The clud-bug-review check on this PR will fail with a 401 (Anthropic's self-protection against PRs that modify the reviewer's own workflow); merge once and subsequent PRs work normally."`);
 }
 
 async function runUpdateCmd(_args) {

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -407,12 +407,27 @@ async function runEditWorkflow(_args) {
 
   log('🐛 Preparing an isolated PR for your workflow edit.');
   const branch = makeBranchName();
-  log(`  branch: ${branch}`);
+  log(`  branch: ${branch} (rooted at origin/main)`);
   for (const f of pending.files) log(`    • ${f}`);
 
-  // Branch from current ref (whatever the user was on — usually main),
-  // commit the workflow files only, push, open PR.
-  gitCmd(cwd, ['checkout', '-b', branch]);
+  // Stash the pending workflow changes, branch from origin/main explicitly
+  // (NOT from HEAD — if the user is on a feature branch with unrelated
+  // commits, those would otherwise leak into the "isolated" PR), then
+  // restore the changes onto the new branch and commit.
+  gitCmd(cwd, ['stash', 'push', '--include-untracked', '-m', 'clud-bug edit-workflow']);
+  try {
+    gitCmd(cwd, ['fetch', 'origin', 'main', '--depth=1']);
+    gitCmd(cwd, ['checkout', '-b', branch, 'origin/main']);
+  } catch (err) {
+    // Restore the user's stash before bubbling up.
+    gitCmd(cwd, ['stash', 'pop'], { allowFail: true });
+    throw err;
+  }
+  const popped = gitCmd(cwd, ['stash', 'pop'], { allowFail: true });
+  if (!popped.ok) {
+    process.stderr.write(`clud-bug edit-workflow: stash pop conflicted on origin/main — your edits are still in 'git stash'. Resolve manually:\n  git stash pop\n`);
+    process.exit(1);
+  }
   gitCmd(cwd, ['add', ...pending.files]);
   gitCmd(cwd, ['commit', '-m', 'Edit clud-bug workflow']);
   gitCmd(cwd, ['push', '-u', 'origin', branch]);

--- a/lib/edit-workflow.js
+++ b/lib/edit-workflow.js
@@ -1,0 +1,44 @@
+import { spawnSync } from 'node:child_process';
+
+// Validates that the working tree's pending changes are scoped to
+// .github/workflows/clud-bug-*.yml. If yes, creates a branch, commits,
+// pushes, and prints the gh command for opening a PR. Mixed changes are
+// refused — the whole point is to keep workflow edits in an isolated PR
+// so claude-code-action's workflow-self-mod guard doesn't bundle them
+// with other reviewable work.
+
+export function getPendingWorkflowEdits(cwd = process.cwd()) {
+  const r = spawnSync('git', ['status', '--porcelain'], { cwd, encoding: 'utf8' });
+  if (r.status !== 0) {
+    throw new Error(`git status failed: ${r.stderr.trim()}`);
+  }
+  const lines = r.stdout.split('\n').filter(Boolean);
+  if (lines.length === 0) return { allWorkflow: true, files: [], nonWorkflow: [] };
+
+  const files = [];
+  const nonWorkflow = [];
+  for (const line of lines) {
+    // porcelain format: XY <space> <path> ; rename: XY old -> new
+    const path = line.slice(3).split(' -> ').pop().trim();
+    files.push(path);
+    if (!isWorkflowFile(path)) nonWorkflow.push(path);
+  }
+  return { allWorkflow: nonWorkflow.length === 0, files, nonWorkflow };
+}
+
+export function isWorkflowFile(path) {
+  return /^\.github\/workflows\/clud-bug-.*\.ya?ml$/.test(path);
+}
+
+export function makeBranchName(date = new Date()) {
+  const stamp = date.toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  return `clud-bug/edit-workflow-${stamp}`;
+}
+
+export function git(cwd, args, opts = {}) {
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  if (r.status !== 0 && !opts.allowFail) {
+    throw new Error(`git ${args.join(' ')} failed (${r.status}): ${r.stderr.trim()}`);
+  }
+  return { ok: r.status === 0, stdout: r.stdout.trim(), stderr: r.stderr.trim() };
+}

--- a/lib/edit-workflow.js
+++ b/lib/edit-workflow.js
@@ -8,7 +8,10 @@ import { spawnSync } from 'node:child_process';
 // with other reviewable work.
 
 export function getPendingWorkflowEdits(cwd = process.cwd()) {
-  const r = spawnSync('git', ['status', '--porcelain'], { cwd, encoding: 'utf8' });
+  // --untracked-files=all so new files in new directories are reported as
+  // individual paths instead of being collapsed to the parent dir (default
+  // 'normal' mode would emit '.github/' for a brand-new clud-bug-review.yml).
+  const r = spawnSync('git', ['status', '--porcelain', '--untracked-files=all'], { cwd, encoding: 'utf8' });
   if (r.status !== 0) {
     throw new Error(`git status failed: ${r.stderr.trim()}`);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/test/edit-workflow.test.js
+++ b/test/edit-workflow.test.js
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { isWorkflowFile, makeBranchName } from '../lib/edit-workflow.js';
+
+test('isWorkflowFile: matches clud-bug-*.yml in .github/workflows', () => {
+  assert.equal(isWorkflowFile('.github/workflows/clud-bug-review.yml'), true);
+  assert.equal(isWorkflowFile('.github/workflows/clud-bug-audit.yml'), true);
+  assert.equal(isWorkflowFile('.github/workflows/clud-bug-self-update.yml'), true);
+  assert.equal(isWorkflowFile('.github/workflows/clud-bug-review.yaml'), true);
+});
+
+test('isWorkflowFile: does not match unrelated files', () => {
+  assert.equal(isWorkflowFile('.github/workflows/ci.yml'), false);
+  assert.equal(isWorkflowFile('.github/workflows/claude-code-review.yml'), false);
+  assert.equal(isWorkflowFile('templates/workflow.yml.tmpl'), false);
+  assert.equal(isWorkflowFile('package.json'), false);
+  assert.equal(isWorkflowFile('clud-bug-review.yml'), false);
+});
+
+test('makeBranchName: ISO timestamp slug', () => {
+  const branch = makeBranchName(new Date('2026-05-15T07:30:45Z'));
+  assert.equal(branch, 'clud-bug/edit-workflow-2026-05-15T07-30-45');
+});

--- a/test/edit-workflow.test.js
+++ b/test/edit-workflow.test.js
@@ -1,6 +1,28 @@
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { isWorkflowFile, makeBranchName } from '../lib/edit-workflow.js';
+import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { isWorkflowFile, makeBranchName, getPendingWorkflowEdits } from '../lib/edit-workflow.js';
+
+function git(cwd, ...args) {
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout;
+}
+
+async function makeRepo() {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-edit-wf-'));
+  git(dir, 'init', '-q', '-b', 'main');
+  git(dir, 'config', 'user.email', 'test@test');
+  git(dir, 'config', 'user.name', 'Test');
+  git(dir, 'config', 'commit.gpgsign', 'false');
+  await writeFile(join(dir, 'README.md'), 'baseline\n');
+  git(dir, 'add', '-A');
+  git(dir, 'commit', '-q', '-m', 'init');
+  return dir;
+}
 
 test('isWorkflowFile: matches clud-bug-*.yml in .github/workflows', () => {
   assert.equal(isWorkflowFile('.github/workflows/clud-bug-review.yml'), true);
@@ -20,4 +42,62 @@ test('isWorkflowFile: does not match unrelated files', () => {
 test('makeBranchName: ISO timestamp slug', () => {
   const branch = makeBranchName(new Date('2026-05-15T07:30:45Z'));
   assert.equal(branch, 'clud-bug/edit-workflow-2026-05-15T07-30-45');
+});
+
+test('getPendingWorkflowEdits: empty working tree', async () => {
+  const dir = await makeRepo();
+  try {
+    const r = getPendingWorkflowEdits(dir);
+    assert.equal(r.allWorkflow, true);
+    assert.equal(r.files.length, 0);
+    assert.equal(r.nonWorkflow.length, 0);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('getPendingWorkflowEdits: only workflow changes → allWorkflow true', async () => {
+  const dir = await makeRepo();
+  try {
+    await mkdir(join(dir, '.github/workflows'), { recursive: true });
+    await writeFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'name: x\n');
+    const r = getPendingWorkflowEdits(dir);
+    assert.equal(r.allWorkflow, true);
+    assert.deepEqual(r.files, ['.github/workflows/clud-bug-review.yml']);
+    assert.deepEqual(r.nonWorkflow, []);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('getPendingWorkflowEdits: mixed changes → allWorkflow false, nonWorkflow listed', async () => {
+  const dir = await makeRepo();
+  try {
+    await mkdir(join(dir, '.github/workflows'), { recursive: true });
+    await writeFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'name: x\n');
+    await writeFile(join(dir, 'src.ts'), 'export {};\n');
+    const r = getPendingWorkflowEdits(dir);
+    assert.equal(r.allWorkflow, false);
+    assert.deepEqual(r.nonWorkflow.sort(), ['src.ts']);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('getPendingWorkflowEdits: only non-workflow changes → allWorkflow false', async () => {
+  const dir = await makeRepo();
+  try {
+    await writeFile(join(dir, 'package.json'), '{}\n');
+    const r = getPendingWorkflowEdits(dir);
+    assert.equal(r.allWorkflow, false);
+    assert.deepEqual(r.nonWorkflow, ['package.json']);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('getPendingWorkflowEdits: ignores non-clud-bug workflow files', async () => {
+  // Editing .github/workflows/ci.yml is NOT a clud-bug workflow edit;
+  // the guard should treat it as non-workflow (so the user's mixed
+  // CI tweak doesn't get bundled with workflow-self-mod-protected files).
+  const dir = await makeRepo();
+  try {
+    await mkdir(join(dir, '.github/workflows'), { recursive: true });
+    await writeFile(join(dir, '.github/workflows/ci.yml'), 'name: ci\n');
+    const r = getPendingWorkflowEdits(dir);
+    assert.equal(r.allWorkflow, false);
+    assert.deepEqual(r.nonWorkflow, ['.github/workflows/ci.yml']);
+  } finally { await rm(dir, { recursive: true, force: true }); }
 });


### PR DESCRIPTION
v0.4 PR 21. Mitigates the 'workflow self-mod = 401' friction we've hit on every PR that touches clud-bug-review.yml. README callout documents the upstream behavior. New CLI command (clud-bug edit-workflow) packages workflow tweaks into an isolated branch + PR so non-workflow work isn't blocked alongside. 68 tests.