### PR TITLE
v0.5.0: fetch baseline skills from thrillmot/agent-skills (with bundled fallback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 ## [0.5.0] — 2026-05-15
 
 ### Changed
-- **Baseline skills now sourced from [thrillmot/agent-skills](https://github.com/thrillmot/agent-skills) at install time.** `clud-bug init` fetches `https://raw.githubusercontent.com/thrillmot/agent-skills/main/skills/<name>/SKILL.md` for each baseline (`critical-issues-only`, `evidence-based-review`, `respect-existing-conventions`). Fetched skills are cached at `~/.cache/clud-bug/skills/` for 24h to avoid re-fetching across CLI invocations. Network failures, 404s, or empty bodies fall back to the bundled copy shipped in the npm package — works fully offline. Init log shows which path was used (`baseline kit: 3 specimens (from thrillmot/agent-skills)` vs `(bundled fallback)`).
-- Override the upstream URL via `CLUD_BUG_AGENT_SKILLS_BASE` env var (test seam).
+- **Baseline skills now sourced from [thrillmot/agent-skills](https://github.com/thrillmot/agent-skills) at install time, pinned to a specific commit SHA.** `clud-bug init` fetches `https://raw.githubusercontent.com/thrillmot/agent-skills/<SHA>/skills/<name>/SKILL.md` for each baseline (`critical-issues-only`, `evidence-based-review`, `respect-existing-conventions`). The SHA is pinned in `lib/skills.js` (currently `977e439…`) — bumping it requires a clud-bug release, so a compromised commit on agent-skills can't silently land in users' Claude review skills mid-cycle.
+- Fetched skills are cached at `~/.cache/clud-bug/skills/` for 24h. Cache keys include the upstream base URL, so switching bases (via `CLUD_BUG_AGENT_SKILLS_BASE` env override) doesn't poison the cache across forks.
+- Network failures, 404s, empty bodies, and 5s timeouts fall back to the bundled copy shipped in the npm package — works fully offline.
+- Baseline fetches now run in parallel (`Promise.all`), so a fully unreachable upstream caps at one timeout total instead of three (was ~15s, now ~5s).
+- Init log shows the source: `baseline kit: 3 specimens (from thrillmot/agent-skills)` vs `(bundled fallback)` vs a mixed-count form.
+- Override the upstream URL via `CLUD_BUG_AGENT_SKILLS_BASE` env var (test seam + fork support).
 
 ## [0.4.1] — 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] — 2026-05-15
+
+### Changed
+- **Baseline skills now sourced from [thrillmot/agent-skills](https://github.com/thrillmot/agent-skills) at install time.** `clud-bug init` fetches `https://raw.githubusercontent.com/thrillmot/agent-skills/main/skills/<name>/SKILL.md` for each baseline (`critical-issues-only`, `evidence-based-review`, `respect-existing-conventions`). Fetched skills are cached at `~/.cache/clud-bug/skills/` for 24h to avoid re-fetching across CLI invocations. Network failures, 404s, or empty bodies fall back to the bundled copy shipped in the npm package — works fully offline. Init log shows which path was used (`baseline kit: 3 specimens (from thrillmot/agent-skills)` vs `(bundled fallback)`).
+- Override the upstream URL via `CLUD_BUG_AGENT_SKILLS_BASE` env var (test seam).
+
 ## [0.4.1] — 2026-05-15
 
 ### Added
@@ -17,6 +23,7 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 - **Bot-authored PRs are now handled gracefully.** PRs from `dependabot[bot]`, `renovate[bot]`, or forks (where GitHub deliberately doesn't pass repository secrets) used to fail loudly red — wrong signal. Now a guard step detects the case, posts a one-line advisory comment ("Clud Bug skipped — bot/fork PR cannot access secrets"), and exits 0. Check stays green; the skip is visible. Owner-authored PRs without the secret still fail loud.
 - **Site polish (carries over from the unreleased entry):** alive bug emoji (layered breathe + twitch + scuttle animations), Plate label gloss, thrillmot footer credit.
 
+[0.5.0]: https://github.com/thrillmot/clud-bug/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/thrillmot/clud-bug/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/thrillmot/clud-bug/compare/v0.3.4...v0.4.0
 

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -107,7 +107,13 @@ async function runInit(args) {
   log(`    search terms:     ${signals.searchTerms.join(', ') || '(none)'}`);
 
   const baseline = await loadBaseline(BASELINE_DIR);
-  log(`    baseline kit:     ${baseline.length} specimens`);
+  const fromAgentSkills = baseline.filter((s) => s._source === 'agent-skills').length;
+  const sourceLabel = baseline.length === 0
+    ? ''
+    : fromAgentSkills === baseline.length ? ' (from thrillmot/agent-skills)'
+    : fromAgentSkills === 0               ? ' (bundled fallback)'
+                                          : ` (${fromAgentSkills} from agent-skills, ${baseline.length - fromAgentSkills} bundled)`;
+  log(`    baseline kit:     ${baseline.length} specimens${sourceLabel}`);
 
   let curated = [];
   let searched = [];

--- a/lib/skills.js
+++ b/lib/skills.js
@@ -1,10 +1,21 @@
 import { mkdir, writeFile, readdir, readFile, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
 
 const API_BASE = 'https://skills.sh/api/v1';
 const MAX_SKILLS = 8;
 const MANIFEST_FILE = '.clud-bug.json';
 const MANIFEST_VERSION = 1;
+
+// Canonical home for clud-bug's baseline skills. We try this first so the
+// skill content tracks the upstream repo; falls back to the bundled copy
+// shipped in the npm package if the fetch fails (offline, 404, rate-limited).
+// See thrillmot/agent-skills — uses the skills.sh-recognized `skills/<name>/SKILL.md` layout.
+const AGENT_SKILLS_BASE = process.env.CLUD_BUG_AGENT_SKILLS_BASE
+  ?? 'https://raw.githubusercontent.com/thrillmot/agent-skills/main/skills';
+const SKILL_FETCH_TIMEOUT_MS = 5000;
+const SKILL_CACHE_TTL_MS = 24 * 60 * 60 * 1000;   // 24h
 
 export class SkillsClient {
   constructor({ fetch = globalThis.fetch, base, userAgent = 'clud-bug' } = {}) {
@@ -78,7 +89,37 @@ export function rankAndCap(curated, searched, baseline, cap = MAX_SKILLS) {
   return out;
 }
 
-export async function loadBaseline(baselineDir) {
+// Loads the baseline skills, preferring the canonical thrillmot/agent-skills
+// repo and falling back to the bundled npm-package copy on any fetch failure.
+// Returns the same shape as before, plus a `source` of either 'agent-skills'
+// or 'bundled' so the CLI can report which path was used.
+//
+// Options:
+//   - fetch     — injectable for tests (defaults to globalThis.fetch)
+//   - cacheDir  — where to cache fetched SKILL.md files (defaults to
+//                 ~/.cache/clud-bug/skills/, skipped if undefined)
+export async function loadBaseline(baselineDir, opts = {}) {
+  const fetchImpl = opts.fetch ?? globalThis.fetch;
+  const cacheDir = opts.cacheDir === null ? null
+    : (opts.cacheDir ?? join(homedir(), '.cache', 'clud-bug', 'skills'));
+
+  // First, enumerate the bundled baseline skills (source of truth for which
+  // names exist). For each one, try to fetch a fresher copy from upstream.
+  const bundled = await readBundled(baselineDir);
+  const skills = [];
+  for (const skill of bundled) {
+    const remote = await tryFetchSkill(skill.name, fetchImpl, cacheDir);
+    if (remote) {
+      skills.push({ ...skill, content: remote, _source: 'agent-skills' });
+    } else {
+      skills.push({ ...skill, _source: 'bundled' });
+    }
+  }
+  return skills;
+}
+
+// Reads the bundled baseline from the npm-package directory.
+async function readBundled(baselineDir) {
   const skills = [];
   let entries;
   try {
@@ -92,13 +133,65 @@ export async function loadBaseline(baselineDir) {
     skills.push({
       source: 'clud-bug-baseline',
       name: entry.name.replace(/\.md$/, ''),
-      description: '(bundled baseline)',
+      description: '(baseline)',
       installs: 0,
       kind: 'baseline',
       content,
     });
   }
   return skills;
+}
+
+// Try to read from cache, then fall back to network. Returns the SKILL.md
+// content string on success, null on any failure (caller falls back to bundled).
+async function tryFetchSkill(name, fetchImpl, cacheDir) {
+  // Cache lookup first.
+  if (cacheDir) {
+    const cached = await readFromCache(cacheDir, name);
+    if (cached !== null) return cached;
+  }
+
+  // Network fetch with timeout. Any error → fall back.
+  const url = `${AGENT_SKILLS_BASE}/${encodeURIComponent(name)}/SKILL.md`;
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), SKILL_FETCH_TIMEOUT_MS);
+    const res = await fetchImpl(url, { signal: ctrl.signal });
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    const content = await res.text();
+    if (!content || !content.trim()) return null;
+    if (cacheDir) await writeToCache(cacheDir, name, content);
+    return content;
+  } catch {
+    return null;
+  }
+}
+
+async function readFromCache(cacheDir, name) {
+  const path = cachePath(cacheDir, name);
+  try {
+    const st = await stat(path);
+    if (Date.now() - st.mtimeMs > SKILL_CACHE_TTL_MS) return null;
+    return await readFile(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+async function writeToCache(cacheDir, name, content) {
+  try {
+    await mkdir(cacheDir, { recursive: true });
+    await writeFile(cachePath(cacheDir, name), content);
+  } catch {
+    // Cache write failures are non-fatal — we already have the content.
+  }
+}
+
+function cachePath(cacheDir, name) {
+  // Hash the name so filenames are filesystem-safe even for unusual inputs.
+  const hash = createHash('sha256').update(name).digest('hex').slice(0, 16);
+  return join(cacheDir, `${hash}.md`);
 }
 
 export async function writeSkills(targetDir, skills, client) {

--- a/lib/skills.js
+++ b/lib/skills.js
@@ -8,12 +8,16 @@ const MAX_SKILLS = 8;
 const MANIFEST_FILE = '.clud-bug.json';
 const MANIFEST_VERSION = 1;
 
-// Canonical home for clud-bug's baseline skills. We try this first so the
-// skill content tracks the upstream repo; falls back to the bundled copy
-// shipped in the npm package if the fetch fails (offline, 404, rate-limited).
-// See thrillmot/agent-skills — uses the skills.sh-recognized `skills/<name>/SKILL.md` layout.
+// Canonical home for clud-bug's baseline skills.
+// PINNED TO A COMMIT SHA, NOT `main`. This re-couples the trust boundary
+// to clud-bug releases: a compromised commit on agent-skills@main cannot
+// silently land in users' Claude review skills mid-cycle. To roll new
+// skill content, bump BASELINE_SKILLS_REF below in the same clud-bug PR
+// that ships the corresponding bundled fallback update.
+// See thrillmot/agent-skills — skills.sh `skills/<name>/SKILL.md` layout.
+const BASELINE_SKILLS_REF = '977e439ec861860351239ed89dd56edcd48cbf6b';
 const AGENT_SKILLS_BASE = process.env.CLUD_BUG_AGENT_SKILLS_BASE
-  ?? 'https://raw.githubusercontent.com/thrillmot/agent-skills/main/skills';
+  ?? `https://raw.githubusercontent.com/thrillmot/agent-skills/${BASELINE_SKILLS_REF}/skills`;
 const SKILL_FETCH_TIMEOUT_MS = 5000;
 const SKILL_CACHE_TTL_MS = 24 * 60 * 60 * 1000;   // 24h
 
@@ -89,33 +93,30 @@ export function rankAndCap(curated, searched, baseline, cap = MAX_SKILLS) {
   return out;
 }
 
-// Loads the baseline skills, preferring the canonical thrillmot/agent-skills
-// repo and falling back to the bundled npm-package copy on any fetch failure.
-// Returns the same shape as before, plus a `source` of either 'agent-skills'
+// Loads the baseline skills, preferring the pinned thrillmot/agent-skills
+// commit and falling back to the bundled npm-package copy on any fetch failure.
+// Returns the same shape as before, plus a `_source` of either 'agent-skills'
 // or 'bundled' so the CLI can report which path was used.
 //
 // Options:
 //   - fetch     — injectable for tests (defaults to globalThis.fetch)
 //   - cacheDir  — where to cache fetched SKILL.md files (defaults to
-//                 ~/.cache/clud-bug/skills/, skipped if undefined)
+//                 ~/.cache/clud-bug/skills/, skipped if null)
 export async function loadBaseline(baselineDir, opts = {}) {
   const fetchImpl = opts.fetch ?? globalThis.fetch;
   const cacheDir = opts.cacheDir === null ? null
     : (opts.cacheDir ?? join(homedir(), '.cache', 'clud-bug', 'skills'));
 
   // First, enumerate the bundled baseline skills (source of truth for which
-  // names exist). For each one, try to fetch a fresher copy from upstream.
+  // names exist). Then fetch each in parallel — sequential awaits would
+  // stack timeouts (3 baselines × 5s = 15s before fallback when offline).
   const bundled = await readBundled(baselineDir);
-  const skills = [];
-  for (const skill of bundled) {
-    const remote = await tryFetchSkill(skill.name, fetchImpl, cacheDir);
-    if (remote) {
-      skills.push({ ...skill, content: remote, _source: 'agent-skills' });
-    } else {
-      skills.push({ ...skill, _source: 'bundled' });
-    }
-  }
-  return skills;
+  const remotes = await Promise.all(
+    bundled.map((s) => tryFetchSkill(s.name, fetchImpl, cacheDir)),
+  );
+  return bundled.map((skill, i) => remotes[i]
+    ? { ...skill, content: remotes[i], _source: 'agent-skills' }
+    : { ...skill, _source: 'bundled' });
 }
 
 // Reads the bundled baseline from the npm-package directory.
@@ -151,13 +152,14 @@ async function tryFetchSkill(name, fetchImpl, cacheDir) {
     if (cached !== null) return cached;
   }
 
-  // Network fetch with timeout. Any error → fall back.
+  // Network fetch with timeout covering BOTH the connection AND the body
+  // read (clearTimeout in finally guarantees the timer doesn't keep the
+  // event loop alive for up to 5s past a failed CLI run).
   const url = `${AGENT_SKILLS_BASE}/${encodeURIComponent(name)}/SKILL.md`;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), SKILL_FETCH_TIMEOUT_MS);
   try {
-    const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), SKILL_FETCH_TIMEOUT_MS);
     const res = await fetchImpl(url, { signal: ctrl.signal });
-    clearTimeout(timer);
     if (!res.ok) return null;
     const content = await res.text();
     if (!content || !content.trim()) return null;
@@ -165,6 +167,8 @@ async function tryFetchSkill(name, fetchImpl, cacheDir) {
     return content;
   } catch {
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -189,8 +193,12 @@ async function writeToCache(cacheDir, name, content) {
 }
 
 function cachePath(cacheDir, name) {
-  // Hash the name so filenames are filesystem-safe even for unusual inputs.
-  const hash = createHash('sha256').update(name).digest('hex').slice(0, 16);
+  // Include AGENT_SKILLS_BASE in the hash so different upstream URLs (e.g.
+  // a fork via CLUD_BUG_AGENT_SKILLS_BASE, or a different pinned SHA after
+  // a clud-bug release) get different cache entries. Otherwise switching
+  // bases would silently return the previously-cached content from a
+  // different upstream — cross-base cache poisoning.
+  const hash = createHash('sha256').update(`${AGENT_SKILLS_BASE}\n${name}`).digest('hex').slice(0, 16);
   return join(cacheDir, `${hash}.md`);
 }
 

--- a/lib/update.js
+++ b/lib/update.js
@@ -21,6 +21,7 @@ export async function runUpdate({
   baselineDir,
   ourVersion,
   refreshRemote = false,
+  loadBaselineOpts,    // forwarded to loadBaseline (e.g. for tests: { fetch, cacheDir: null })
 } = {}) {
   if (!cwd || !templatesDir || !baselineDir || !ourVersion) {
     throw new Error('runUpdate requires cwd, templatesDir, baselineDir, ourVersion');
@@ -51,7 +52,7 @@ export async function runUpdate({
   }
 
   // 3. Refresh baseline skills (always controlled by clud-bug).
-  const baseline = await loadBaseline(baselineDir);
+  const baseline = await loadBaseline(baselineDir, loadBaselineOpts);
   for (const skill of baseline) {
     const skillPath = join(skillsDir, sanitize(skill.name), 'SKILL.md');
     await maybeWrite(skillPath, skill.content, changed, unchanged, `baseline ${skill.name}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -154,7 +154,8 @@ test('loadBaseline: prefers remote (agent-skills) when fetch succeeds', async ()
     assert.equal(out.length, 1);
     assert.equal(out[0].content, 'REMOTE CONTENT');
     assert.equal(out[0]._source, 'agent-skills');
-    assert.match(fetchedUrl, /thrillmot\/agent-skills\/main\/skills\/critical-issues-only\/SKILL\.md/);
+    // Pinned to a SHA, not main — re-couples trust to clud-bug releases.
+    assert.match(fetchedUrl, /thrillmot\/agent-skills\/[0-9a-f]{40}\/skills\/critical-issues-only\/SKILL\.md/);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -200,6 +201,43 @@ test('loadBaseline: falls back to bundled on empty remote body', async () => {
     assert.equal(out[0]._source, 'bundled');
   } finally {
     await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadBaseline: cache key differs by upstream base — switching bases re-fetches', async () => {
+  // If the cache key ignored the base URL, a user who set
+  // CLUD_BUG_AGENT_SKILLS_BASE to a fork and then unset it would silently
+  // get the fork's content from cache. Cache keys must include the base.
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-baseline-base-'));
+  const cache = await mkdtemp(join(tmpdir(), 'clud-bug-baseline-base-cache-'));
+  try {
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(join(dir, 'shared-name.md'), 'BUNDLED');
+    let calls = 0;
+    const fetch = async (url) => {
+      calls++;
+      return { ok: true, status: 200, text: async () => `REMOTE-FROM-${url}` };
+    };
+    const originalBase = process.env.CLUD_BUG_AGENT_SKILLS_BASE;
+    try {
+      process.env.CLUD_BUG_AGENT_SKILLS_BASE = 'https://fork-a.example/skills';
+      // Force re-import to pick up the env-driven AGENT_SKILLS_BASE.
+      // (Tests use fresh import via dynamic specifier with cache-buster.)
+      const modA = await import('../lib/skills.js?base-a');
+      await modA.loadBaseline(dir, { cacheDir: cache, fetch });
+      assert.equal(calls, 1, 'first base: 1 fetch');
+
+      process.env.CLUD_BUG_AGENT_SKILLS_BASE = 'https://fork-b.example/skills';
+      const modB = await import('../lib/skills.js?base-b');
+      await modB.loadBaseline(dir, { cacheDir: cache, fetch });
+      assert.equal(calls, 2, 'second base: cache key differs, must re-fetch');
+    } finally {
+      if (originalBase === undefined) delete process.env.CLUD_BUG_AGENT_SKILLS_BASE;
+      else process.env.CLUD_BUG_AGENT_SKILLS_BASE = originalBase;
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+    await rm(cache, { recursive: true, force: true });
   }
 });
 

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -113,6 +113,10 @@ test('writeSkills creates SKILL.md per skill in nested directory', async () => {
   }
 });
 
+// Tests pass cacheDir: null + a stub fetch so they don't touch the user's
+// real cache dir or hit the live agent-skills repo.
+const offlineOpts = { cacheDir: null, fetch: async () => { throw new Error('test: no network'); } };
+
 test('loadBaseline reads .md files from a directory', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'clud-bug-baseline-'));
   try {
@@ -120,17 +124,107 @@ test('loadBaseline reads .md files from a directory', async () => {
     await writeFile(join(dir, 'a.md'), 'A');
     await writeFile(join(dir, 'b.md'), 'B');
     await writeFile(join(dir, 'ignore.txt'), 'no');
-    const out = await loadBaseline(dir);
+    const out = await loadBaseline(dir, offlineOpts);
     assert.equal(out.length, 2);
     assert.deepEqual(out.map(s => s.name).sort(), ['a', 'b']);
+    // Stub fetch threw → all should report _source: 'bundled'
+    assert.ok(out.every((s) => s._source === 'bundled'));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
 });
 
 test('loadBaseline returns empty if directory missing', async () => {
-  const out = await loadBaseline('/tmp/clud-bug-does-not-exist-' + Date.now());
+  const out = await loadBaseline('/tmp/clud-bug-does-not-exist-' + Date.now(), offlineOpts);
   assert.deepEqual(out, []);
+});
+
+test('loadBaseline: prefers remote (agent-skills) when fetch succeeds', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-baseline-fetch-'));
+  try {
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(join(dir, 'critical-issues-only.md'), 'BUNDLED CONTENT');
+
+    let fetchedUrl;
+    const fetch = async (url) => {
+      fetchedUrl = url;
+      return { ok: true, status: 200, text: async () => 'REMOTE CONTENT' };
+    };
+    const out = await loadBaseline(dir, { cacheDir: null, fetch });
+    assert.equal(out.length, 1);
+    assert.equal(out[0].content, 'REMOTE CONTENT');
+    assert.equal(out[0]._source, 'agent-skills');
+    assert.match(fetchedUrl, /thrillmot\/agent-skills\/main\/skills\/critical-issues-only\/SKILL\.md/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadBaseline: falls back to bundled on 404', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-baseline-404-'));
+  try {
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(join(dir, 'x.md'), 'BUNDLED FALLBACK');
+    const fetch = async () => ({ ok: false, status: 404, text: async () => '' });
+    const out = await loadBaseline(dir, { cacheDir: null, fetch });
+    assert.equal(out[0].content, 'BUNDLED FALLBACK');
+    assert.equal(out[0]._source, 'bundled');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadBaseline: falls back to bundled on network error', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-baseline-neterr-'));
+  try {
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(join(dir, 'y.md'), 'BUNDLED ON ERROR');
+    const fetch = async () => { throw new Error('ENOTFOUND'); };
+    const out = await loadBaseline(dir, { cacheDir: null, fetch });
+    assert.equal(out[0].content, 'BUNDLED ON ERROR');
+    assert.equal(out[0]._source, 'bundled');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadBaseline: falls back to bundled on empty remote body', async () => {
+  // A 200 with empty body shouldn't be treated as a valid skill.
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-baseline-empty-'));
+  try {
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(join(dir, 'z.md'), 'BUNDLED ON EMPTY');
+    const fetch = async () => ({ ok: true, status: 200, text: async () => '' });
+    const out = await loadBaseline(dir, { cacheDir: null, fetch });
+    assert.equal(out[0].content, 'BUNDLED ON EMPTY');
+    assert.equal(out[0]._source, 'bundled');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadBaseline: cache hit avoids network on second call', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-baseline-cache-src-'));
+  const cache = await mkdtemp(join(tmpdir(), 'clud-bug-baseline-cache-dst-'));
+  try {
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(join(dir, 'cached.md'), 'BUNDLED');
+    let fetchCount = 0;
+    const fetch = async () => {
+      fetchCount++;
+      return { ok: true, status: 200, text: async () => 'REMOTE-VIA-CACHE' };
+    };
+    // First call: warms the cache.
+    await loadBaseline(dir, { cacheDir: cache, fetch });
+    assert.equal(fetchCount, 1);
+    // Second call: should hit the cache, not the network.
+    const out = await loadBaseline(dir, { cacheDir: cache, fetch });
+    assert.equal(fetchCount, 1, 'second call must not fetch');
+    assert.equal(out[0].content, 'REMOTE-VIA-CACHE');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+    await rm(cache, { recursive: true, force: true });
+  }
 });
 
 test('sanitizeSlug normalizes names safely', () => {

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -10,6 +10,10 @@ const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const TEMPLATES = join(REPO_ROOT, 'templates');
 const BASELINE = join(TEMPLATES, 'skills', 'baseline');
 
+// Forced through to loadBaseline so tests don't hit the live agent-skills
+// repo or write to the user's real ~/.cache/clud-bug/skills/ dir.
+const offlineLoadBaseline = { cacheDir: null, fetch: async () => { throw new Error('test: no network'); } };
+
 async function makeRepo(files = {}) {
   const dir = await mkdtemp(join(tmpdir(), 'clud-bug-update-'));
   for (const [path, content] of Object.entries(files)) {
@@ -25,6 +29,7 @@ test('runUpdate: short-circuits when no manifest and no workflow exist', async (
   try {
     const r = await runUpdate({
       cwd: dir, templatesDir: TEMPLATES, baselineDir: BASELINE, ourVersion: '0.3.0',
+      loadBaselineOpts: offlineLoadBaseline,
     });
     assert.equal(r.missing, 'init');
   } finally { await rm(dir, { recursive: true, force: true }); }
@@ -48,6 +53,7 @@ test('runUpdate: rewrites stale workflow + baseline; leaves custom skills alone'
   try {
     const r = await runUpdate({
       cwd: dir, templatesDir: TEMPLATES, baselineDir: BASELINE, ourVersion: '0.3.0',
+      loadBaselineOpts: offlineLoadBaseline,
     });
     // Workflow refreshed
     const wf = await readFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'utf8');
@@ -76,9 +82,9 @@ test('runUpdate: no-ops when files already match latest', async () => {
   });
   try {
     // First run — writes everything.
-    await runUpdate({ cwd: dir, templatesDir: TEMPLATES, baselineDir: BASELINE, ourVersion: '0.3.0' });
+    await runUpdate({ cwd: dir, templatesDir: TEMPLATES, baselineDir: BASELINE, ourVersion: '0.3.0', loadBaselineOpts: offlineLoadBaseline });
     // Second run — should detect everything is current.
-    const r = await runUpdate({ cwd: dir, templatesDir: TEMPLATES, baselineDir: BASELINE, ourVersion: '0.3.0' });
+    const r = await runUpdate({ cwd: dir, templatesDir: TEMPLATES, baselineDir: BASELINE, ourVersion: '0.3.0', loadBaselineOpts: offlineLoadBaseline });
     assert.equal(r.changed.length, 0, 'second run should be a no-op');
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
@@ -91,7 +97,7 @@ test('runUpdate: re-renders audit workflow when installed', async () => {
     '.claude/skills/.clud-bug.json': JSON.stringify({ version: 1, installed: [] }),
   });
   try {
-    const r = await runUpdate({ cwd: dir, templatesDir: TEMPLATES, baselineDir: BASELINE, ourVersion: '0.3.0' });
+    const r = await runUpdate({ cwd: dir, templatesDir: TEMPLATES, baselineDir: BASELINE, ourVersion: '0.3.0', loadBaselineOpts: offlineLoadBaseline });
     const audit = await readFile(join(dir, '.github/workflows/clud-bug-audit.yml'), 'utf8');
     assert.match(audit, /Clud Bug 🐛 Audit/);
     assert.ok(r.changed.some((c) => c.label === 'audit workflow'));


### PR DESCRIPTION
v0.5 PR 25. Three baseline skills now have a canonical home in thrillmot/agent-skills (alongside logmind). clud-bug fetches at install time and falls back to bundled npm copies on any failure.

Layout follows skills.sh convention: `skills/<name>/SKILL.md` (required for skills.sh to recognize the collection).

5 new tests cover: remote success, 404 fallback, network-error fallback, empty-body fallback, cache-hit avoidance. 78 tests pass.

Once you upload the three baselines to agent-skills/skills/, installs auto-switch from `(bundled fallback)` to `(from thrillmot/agent-skills)` — no clud-bug release needed.