### PR TITLE
v0.5.1: brief other agents in AGENTS.md / CLAUDE.md + clud-bug-collaboration skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] — 2026-05-15
+
+### Added
+- **`clud-bug init` now briefs other agents.** A self-contained `<!-- clud-bug-start -->` block (mirroring the well-established logmind pattern) is added to `AGENTS.md` (created if missing — it's the canonical cross-tool home) and idempotently appended to `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules`, `.windsurfrules`, `.clinerules`, `.continuerules`, and any `.md` files under `.cursor/rules/` — but only where those files already exist (no proliferating stubs the user didn't ask for). The block documents how to coexist with the bot's review threads, where the skills live, the strict-mode toggle, and the workflow-self-mod gotcha. Re-runs replace the prior block in place; running with a new clud-bug version updates it.
+- **New baseline skill `clud-bug-collaboration`.** Higher-fidelity guidance for Claude Code agents working in a clud-bug-installed repo: when to defer to bot thread resolution, how to read the `clud-bug-review` check status, why `claude-code-action` rejects PRs that modify its own workflow, how to disable strict mode safely (read from base ref so a PR can't disable on itself). Ships in the baseline kit alongside the existing three; canonical home will be `thrillmot/agent-skills/skills/clud-bug-collaboration/SKILL.md` on the next agent-skills SHA bump.
+- `clud-bug update` also refreshes the AGENTS.md / CLAUDE.md block so the embedded version + strict-mode line stay current after subsequent updates.
+
 ## [0.5.0] — 2026-05-15
 
 ### Changed
@@ -27,6 +34,7 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 - **Bot-authored PRs are now handled gracefully.** PRs from `dependabot[bot]`, `renovate[bot]`, or forks (where GitHub deliberately doesn't pass repository secrets) used to fail loudly red — wrong signal. Now a guard step detects the case, posts a one-line advisory comment ("Clud Bug skipped — bot/fork PR cannot access secrets"), and exits 0. Check stays green; the skip is visible. Owner-authored PRs without the secret still fail loud.
 - **Site polish (carries over from the unreleased entry):** alive bug emoji (layered breathe + twitch + scuttle animations), Plate label gloss, thrillmot footer credit.
 
+[0.5.1]: https://github.com/thrillmot/clud-bug/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/thrillmot/clud-bug/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/thrillmot/clud-bug/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/thrillmot/clud-bug/compare/v0.3.4...v0.4.0

--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ The naturalist arrives at your repo, surveys the habitat, and assembles a field 
 
 1. **Surveys habitat.** Reads `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, etc., to learn what your stack is.
 2. **Consults [skills.sh](https://skills.sh).** Pulls review skills relevant to your dependencies (e.g. a Next.js project gets Next.js review specimens).
-3. **Pins three baseline specimens** that enforce review discipline regardless of stack:
+3. **Pins baseline specimens** that enforce review discipline regardless of stack:
    - `critical-issues-only` — flag bugs, security, perf only. Skip nits.
    - `evidence-based-review` — every claim must quote the line being criticized.
    - `respect-existing-conventions` — don't suggest fights with the codebase's patterns.
+   - `clud-bug-collaboration` — guidance for any other Claude Code agents working in your repo: how to coexist with bot review threads, how to read the gate, why workflow self-mods break the action, etc.
 4. **Writes** the chosen specimens to `.claude/skills/<name>/SKILL.md` (Claude Code auto-loads them in the GitHub Action).
 5. **Drafts the field kit** at `.github/workflows/clud-bug-review.yml` with your project description filled in and the right permissions/tool allowlist for `gh pr comment` to actually post.
+6. **Briefs other agents** by adding a `<!-- clud-bug-start -->` block to `AGENTS.md` (creating it if missing — it's the cross-tool canonical), and idempotently to `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules`, `.windsurfrules`, `.clinerules`, `.continuerules`, and `.cursor/rules/*.md` where they already exist. Re-runs replace the prior block in place. Files you didn't already have are left uncreated — no proliferating stubs.
 
 ## CLI options
 

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -15,6 +15,7 @@ import {
 import { computeAuditFileSet, renderAuditHeader } from '../lib/audit.js';
 import { runUpdate } from '../lib/update.js';
 import { getPendingWorkflowEdits, makeBranchName, git as gitCmd } from '../lib/edit-workflow.js';
+import { applyToRepo as applyAgentDocs } from '../lib/agents-md.js';
 
 const PKG_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const TEMPLATES = join(PKG_ROOT, 'templates');
@@ -204,9 +205,30 @@ async function runInit(args) {
   }
   await writeManifest(skillsDirPath, manifest);
 
+  // Tell other agents what's installed and how to coexist with the bot.
+  // Idempotent — re-runs replace the prior block in place. AGENTS.md is the
+  // canonical home (cross-tool); CLAUDE.md / GEMINI.md / Cursor / Windsurf
+  // / Cline / Continue rules files get the same block appended IF they
+  // already exist (we don't proliferate stubs the user didn't ask for).
+  log('  briefing other agents (AGENTS.md / CLAUDE.md)...');
+  const agentDocs = await applyAgentDocs(cwd, {
+    version: manifest.lastUpdateVersion,
+    strictMode: manifest.strictMode !== false,
+  });
+  for (const p of agentDocs.created) log(`    created ${p}`);
+  for (const p of agentDocs.touched) log(`    updated ${p}`);
+
   if (args.commit) {
     log('  committing...');
-    spawnSync('git', ['add', '.claude', '.github/workflows/clud-bug-review.yml', '.github/workflows/clud-bug-audit.yml', '.github/workflows/clud-bug-self-update.yml'], { cwd, stdio: 'inherit' });
+    const toAdd = [
+      '.claude',
+      '.github/workflows/clud-bug-review.yml',
+      '.github/workflows/clud-bug-audit.yml',
+      '.github/workflows/clud-bug-self-update.yml',
+      ...agentDocs.created,
+      ...agentDocs.touched,
+    ];
+    spawnSync('git', ['add', ...toAdd], { cwd, stdio: 'inherit' });
     spawnSync('git', ['commit', '-m', 'Add clud-bug 🐛 — a field guide to specimens crawling your code'], { cwd, stdio: 'inherit' });
   }
 

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -211,9 +211,13 @@ async function runInit(args) {
   // / Cline / Continue rules files get the same block appended IF they
   // already exist (we don't proliferate stubs the user didn't ask for).
   log('  briefing other agents (AGENTS.md / CLAUDE.md)...');
+  // Pass `=== true` (not `!== false`) so the rendered block matches the
+  // workflow's gate predicate exactly. A v0.3 advisory upgrade where
+  // strictMode is undefined renders "off" — which is what the workflow
+  // actually does on that manifest.
   const agentDocs = await applyAgentDocs(cwd, {
     version: manifest.lastUpdateVersion,
-    strictMode: manifest.strictMode !== false,
+    strictMode: manifest.strictMode === true,
   });
   for (const p of agentDocs.created) log(`    created ${p}`);
   for (const p of agentDocs.touched) log(`    updated ${p}`);

--- a/docs/decisions-branches/feat__agent-collab.md
+++ b/docs/decisions-branches/feat__agent-collab.md
@@ -1,0 +1,12 @@
+## 2026-05-15 11:59 - Brief other agents in AGENTS.md/CLAUDE.md via a clud-bug block, mirror logmind's pattern
+
+**Reasoning:** Idempotent re-write on init/update so the embedded version + strict-mode line stay current as the repo's clud-bug install ages. Block content lives in lib/agents-md.js bundled with the CLI rather than a template file because it embeds dynamic state.
+
+**Alternatives considered:** Document only in README — rejected because users don't read READMEs of dependencies; the brief needs to live where agents look (AGENTS.md)., Append-only, no marker block — rejected because re-runs would stack duplicates, and version/strict-mode line would go stale., Create CLAUDE.md/GEMINI.md/.cursorrules unconditionally — rejected because we'd proliferate stubs the user didn't ask for; logmind already creates the canonical set when present, we just append where they exist.
+
+**Implications:**
+- Block embeds the version + strict-mode state, so clud-bug update rewrites it; tested for idempotency in test/agents-md.test.js.
+- AGENTS.md is the only file we'll create-if-missing (canonical cross-tool home). Tool-specific files (CLAUDE.md, GEMINI.md, .cursorrules, .windsurfrules, .clinerules, .continuerules, .cursor/rules/*.md) we only touch when present.
+- New baseline skill clud-bug-collaboration ships in templates/skills/baseline/ for now; canonical home moves to thrillmot/agent-skills/skills/clud-bug-collaboration/SKILL.md once user uploads it and we bump the SHA pin.
+
+---

--- a/docs/decisions-branches/feat__agent-collab.md
+++ b/docs/decisions-branches/feat__agent-collab.md
@@ -10,3 +10,15 @@
 - New baseline skill clud-bug-collaboration ships in templates/skills/baseline/ for now; canonical home moves to thrillmot/agent-skills/skills/clud-bug-collaboration/SKILL.md once user uploads it and we bump the SHA pin.
 
 ---
+## 2026-05-15 12:05 - Align AGENTS.md strict-mode render with workflow gate predicate
+
+**Reasoning:** Fixed by mirroring the workflow predicate exactly: renderBlock now uses strictMode === true, and both call sites (init and update) pass manifest.strictMode === true. The block predicate and the gate predicate are now identical, so they cannot disagree.
+
+**Alternatives considered:** Render 'unknown' / 'check the manifest' for the undefined case — rejected because it obscures the user's actual state from agents; advisory is the *real* state, that's what should be reported., Default-on at the render layer and let users opt out by writing the field — rejected because it would conflict with bin/clud-bug.js#runInit's intentional preservation of v0.3 advisory installs (gated on manifest.lastUpdate === undefined).
+
+**Implications:**
+- renderBlock is now defensive against the footgun: it will only ever render 'on' for an explicit true, even if a future call site forgets to translate manifest state correctly.
+- Three regression tests added in test/agents-md.test.js: undefined → off, null → off, v0.3-shaped manifest → off.
+- Found by clud-bug-review on PR #25 (thread PRRT_kwDORj7Hfc6CaSK9). The bot's strict-mode-gate didn't fire (header sentinel didn't match the body's 'Critical findings' section), but the inline review surfaced the issue cleanly — exactly what the parallel review setup is for.
+
+---

--- a/lib/agents-md.js
+++ b/lib/agents-md.js
@@ -1,0 +1,171 @@
+import { readFile, writeFile, stat, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+// Manages a clud-bug-owned section inside AGENTS.md / CLAUDE.md and adjacent
+// agent-instruction files. Mirrors the well-established `<!-- logmind-start -->`
+// pattern: a marked block that other agents can read for collaboration rules,
+// idempotently rewritten on each `clud-bug init` so the content stays current.
+
+const START_MARKER = '<!-- clud-bug-start -->';
+const END_MARKER   = '<!-- clud-bug-end -->';
+const BLOCK_VERSION = 'v1';
+
+// Files we'll touch when present, plus files we'll create if missing.
+// AGENTS.md is the cross-tool canonical (logmind made it canonical too).
+// CLAUDE.md, GEMINI.md, .cursorrules, .windsurfrules etc. are tool-specific
+// stubs/instructions; we append the same block where they exist but don't
+// create them (logmind already creates the ones it knows about).
+const ALWAYS_TOUCH = ['AGENTS.md'];                         // create if missing
+const TOUCH_IF_PRESENT = [
+  'CLAUDE.md',
+  'GEMINI.md',
+  '.github/copilot-instructions.md',
+  '.cursorrules',
+  '.windsurfrules',
+  '.clinerules',
+  '.continuerules',
+];
+
+// Render the clud-bug block. Bundled here rather than in a template file so
+// updates ship with the CLI itself.
+export function renderBlock({ version, strictMode } = {}) {
+  const versionLine = version ? `_Installed at clud-bug v${version}._` : '';
+  const strictNote = strictMode === false
+    ? 'Strict mode is **off** in this repo (advisory only).'
+    : 'Strict mode is **on** in this repo (workflow check fails on critical findings).';
+  return `${START_MARKER}
+<!-- clud-bug-block-version: ${BLOCK_VERSION} -->
+## clud-bug — Claude PR review
+
+This repository uses [clud-bug](https://cludbug.dev) to review pull requests
+automatically. Three things matter when other agents (or future-you) work
+in this repo:
+
+### When you push fixes addressing prior Clud Bug review threads
+
+The bot resolves its own prior review threads on the next pass when it can
+verify the fix in the diff. You don't need to manually resolve threads it
+opened — push the fix, wait ~2 minutes, and check the PR. If a thread it
+left isn't auto-resolved after a fix, the bot judged the issue still open;
+read its latest review comment for what it's still flagging.
+
+### Strict mode
+
+${strictNote} Toggle by editing \`.claude/skills/.clud-bug.json\`:
+
+\`\`\`json
+{ "strictMode": true | false, ... }
+\`\`\`
+
+The setting is read from the **base ref** of any open PR, so PRs cannot
+disable strict mode on themselves. Changes take effect on PRs opened after
+they merge to the base branch.
+
+### Where the skills live
+
+Project-aware review rules live in \`.claude/skills/<name>/SKILL.md\`. A
+small baseline kit ships with every install — see
+\`.claude/skills/.clud-bug.json\` for the current set. Add more via
+\`clud-bug add <source/name>\` (from skills.sh) or by dropping your own
+\`.md\` files there. They auto-load into the reviewer.
+
+### Editing the workflow
+
+Anthropic's \`claude-code-action\` refuses to run on PRs that modify its own
+workflow file. Use \`clud-bug edit-workflow\` to bundle workflow tweaks into
+their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
+
+${versionLine}
+${END_MARKER}`;
+}
+
+// Replace an existing clud-bug block in `content`, OR append if absent.
+// Idempotent: running multiple times leaves a single block.
+export function upsertBlock(content, block) {
+  const startRe = new RegExp(escapeRe(START_MARKER));
+  const endRe   = new RegExp(escapeRe(END_MARKER));
+  if (startRe.test(content) && endRe.test(content)) {
+    // Replace from START_MARKER through END_MARKER (greedy multi-line).
+    const re = new RegExp(`${escapeRe(START_MARKER)}[\\s\\S]*?${escapeRe(END_MARKER)}`);
+    return content.replace(re, block);
+  }
+  // Append with a separating blank line, no trailing newline duplication.
+  const sep = content.endsWith('\n') ? '\n' : '\n\n';
+  return `${content}${sep}${block}\n`;
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Touches all relevant agent-instruction files in `cwd`.
+// Creates AGENTS.md if it doesn't exist (it's the canonical home).
+// Updates other files only if they already exist (don't proliferate stubs;
+// logmind or the user owns those creation decisions).
+//
+// Returns { touched: string[], created: string[] } for the caller to log.
+export async function applyToRepo(cwd, blockOpts = {}) {
+  const block = renderBlock(blockOpts);
+  const touched = [];
+  const created = [];
+
+  for (const path of ALWAYS_TOUCH) {
+    const full = join(cwd, path);
+    const existed = await fileExists(full);
+    const prior = existed ? await readFile(full, 'utf8') : seedFile(path);
+    const next = upsertBlock(prior, block);
+    if (next !== prior) {
+      await writeFile(full, next);
+      (existed ? touched : created).push(path);
+    }
+  }
+
+  for (const path of TOUCH_IF_PRESENT) {
+    const full = join(cwd, path);
+    if (!(await fileExists(full))) continue;
+    const prior = await readFile(full, 'utf8');
+    const next = upsertBlock(prior, block);
+    if (next !== prior) {
+      await writeFile(full, next);
+      touched.push(path);
+    }
+  }
+
+  // .cursor/rules/*.md — append to every file that exists.
+  const cursorRulesDir = join(cwd, '.cursor', 'rules');
+  if (await fileExists(cursorRulesDir)) {
+    let entries = [];
+    try { entries = await readdir(cursorRulesDir); } catch {}
+    for (const name of entries) {
+      if (!name.endsWith('.md')) continue;
+      const full = join(cursorRulesDir, name);
+      const prior = await readFile(full, 'utf8');
+      const next = upsertBlock(prior, block);
+      if (next !== prior) {
+        await writeFile(full, next);
+        touched.push(`.cursor/rules/${name}`);
+      }
+    }
+  }
+
+  return { touched, created };
+}
+
+function seedFile(name) {
+  // When AGENTS.md doesn't exist (no logmind, no prior tooling), seed with a
+  // minimal canonical header so the clud-bug block has context.
+  if (name === 'AGENTS.md') {
+    return `# AGENTS.md
+
+This file is the canonical instruction file for AI coding agents working in
+this repository. Tools that understand AGENTS.md (Cursor, Codex, Windsurf,
+Claude Code, Cline, Continue, Aider, ...) read it directly.
+
+`;
+  }
+  return '';
+}
+
+async function fileExists(path) {
+  try { await stat(path); return true; } catch { return false; }
+}

--- a/lib/agents-md.js
+++ b/lib/agents-md.js
@@ -28,11 +28,23 @@ const TOUCH_IF_PRESENT = [
 
 // Render the clud-bug block. Bundled here rather than in a template file so
 // updates ship with the CLI itself.
+//
+// `strictMode` MUST match the workflow's gate predicate exactly so the block
+// can't lie about repo state. The workflow at `templates/workflow*.yml.tmpl`
+// reads the manifest with `JSON.parse(s).strictMode === true` — meaning the
+// gate fires ONLY on an explicit `true`, and anything else (missing field,
+// `false`, `null`) is advisory. Mirror that here: render "on" only when the
+// caller explicitly passes `true`. Anything else is "off".
+//
+// Why this matters: a v0.3-era install (no `strictMode` field, `lastUpdate`
+// set) is a documented advisory upgrade path — `clud-bug init` deliberately
+// preserves that state. If the block rendered "on" for that case, other
+// agents reading AGENTS.md would get a wrong model of the gate.
 export function renderBlock({ version, strictMode } = {}) {
   const versionLine = version ? `_Installed at clud-bug v${version}._` : '';
-  const strictNote = strictMode === false
-    ? 'Strict mode is **off** in this repo (advisory only).'
-    : 'Strict mode is **on** in this repo (workflow check fails on critical findings).';
+  const strictNote = strictMode === true
+    ? 'Strict mode is **on** in this repo (workflow check fails on critical findings).'
+    : 'Strict mode is **off** in this repo (advisory only).';
   return `${START_MARKER}
 <!-- clud-bug-block-version: ${BLOCK_VERSION} -->
 ## clud-bug — Claude PR review

--- a/lib/update.js
+++ b/lib/update.js
@@ -3,6 +3,7 @@ import { join, dirname } from 'node:path';
 import { renderFile, pickTemplate } from './render.js';
 import { detect, buildDescriptionLine } from './detect.js';
 import { loadBaseline, readManifest, writeManifest } from './skills.js';
+import { applyToRepo as applyAgentDocs } from './agents-md.js';
 
 // Re-render the user's workflow + refresh baseline skills using the
 // templates / baseline shipped with the currently-installed clud-bug.
@@ -67,7 +68,18 @@ export async function runUpdate({
     // `clud-bug refresh`. We just emit an advisory.
   }
 
-  // 5. Stamp the manifest with the version that ran the update.
+  // 5. Refresh the AGENTS.md / CLAUDE.md clud-bug block. The block embeds
+  //    the version + strict-mode state, so an update with a new version
+  //    rewrites it. Files that don't already exist (other than AGENTS.md)
+  //    are left alone, so this never silently creates instruction stubs.
+  const agentDocs = await applyAgentDocs(cwd, {
+    version: ourVersion,
+    strictMode: manifest.strictMode !== false,
+  });
+  for (const p of agentDocs.created) changed.push({ path: join(cwd, p), label: `agent docs: created ${p}` });
+  for (const p of agentDocs.touched) changed.push({ path: join(cwd, p), label: `agent docs: ${p}` });
+
+  // 6. Stamp the manifest with the version that ran the update.
   manifest.lastUpdate = new Date().toISOString();
   manifest.lastUpdateVersion = ourVersion;
   await writeManifest(skillsDir, manifest);

--- a/lib/update.js
+++ b/lib/update.js
@@ -72,9 +72,13 @@ export async function runUpdate({
   //    the version + strict-mode state, so an update with a new version
   //    rewrites it. Files that don't already exist (other than AGENTS.md)
   //    are left alone, so this never silently creates instruction stubs.
+  // `=== true` mirrors the workflow's gate predicate at
+  // templates/workflow*.yml.tmpl. A v0.3 advisory manifest (strictMode
+  // undefined, lastUpdate set) renders "off" — matching the gate, not the
+  // default-on behavior of fresh v0.4+ installs.
   const agentDocs = await applyAgentDocs(cwd, {
     version: ourVersion,
-    strictMode: manifest.strictMode !== false,
+    strictMode: manifest.strictMode === true,
   });
   for (const p of agentDocs.created) changed.push({ path: join(cwd, p), label: `agent docs: created ${p}` });
   for (const p of agentDocs.touched) changed.push({ path: join(cwd, p), label: `agent docs: ${p}` });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/templates/skills/baseline/clud-bug-collaboration.md
+++ b/templates/skills/baseline/clud-bug-collaboration.md
@@ -1,0 +1,124 @@
+---
+name: clud-bug-collaboration
+description: How Claude Code agents working in a clud-bug-installed repo should interact with the bot's review threads, strict-mode gate, and skill set. Use this skill whenever you're about to push a commit, address a clud-bug PR review comment, edit anything under .claude/skills/, modify .github/workflows/clud-bug-*.yml, or wonder why a PR check is red. Also use when planning work in a repo that has a `clud-bug-review` workflow installed — even if the user didn't mention clud-bug by name.
+---
+
+# Working in a clud-bug-installed repo
+
+Clud Bug reviews every PR via `anthropics/claude-code-action`. As another
+Claude Code agent working alongside it, here's what to know — these aren't
+arbitrary rules, they're the consequences of how the gate is wired.
+
+## When you push fixes to a clud-bug-reviewed PR
+
+The bot reviews on `pull_request: synchronize` (every push). When you push
+a commit that addresses an issue Clud Bug flagged in a prior review, the bot
+will re-review the PR within ~2 minutes and **resolve its own prior
+unresolved inline review threads** where the flagged issue is verifiably
+fixed in the current diff. You don't have to resolve threads manually.
+
+If a thread it left isn't auto-resolved after your fix:
+- The bot judged the issue still open (read its latest comment for why).
+- Or the resolution call hit a transient API issue (re-push to retry).
+
+Don't manually resolve clud-bug threads on its behalf. The check
+(`required_conversation_resolution` branch protection) will block merge if
+unresolved threads remain — and the right fix is usually "fix the actual
+issue and re-push," not "mark the conversation resolved."
+
+## When you read the PR's `clud-bug-review` check status
+
+- **Green** = Clud Bug ran and either found no critical issues OR strict
+  mode is off (advisory).
+- **Red** = either the action errored OR strict mode is on AND Clud Bug
+  flagged a critical issue. Read the latest `## 🐛 Clud Bug review` comment
+  on the PR — the body indicates "critical findings" or "clean."
+- **Skipped/green-with-comment** = bot- or fork-authored PR (Dependabot,
+  Renovate, fork contributor). GitHub deliberately doesn't pass repo
+  secrets to those workflows. The bot posts a one-line "Clud Bug skipped"
+  comment and exits 0. Review the diff manually.
+
+## Strict mode
+
+Read `.claude/skills/.clud-bug.json` to check this repo's setting.
+`strictMode: true` means the workflow check fails on critical findings.
+The setting is read from the **base ref**, so a PR cannot disable strict
+mode on itself by editing the manifest. Changes take effect for PRs opened
+after the change merges to the base branch.
+
+To disable strict mode for a repo, edit the manifest on the base branch:
+
+```json
+{ "strictMode": false, ... }
+```
+
+## When you modify a clud-bug skill
+
+Skills live in `.claude/skills/<slug>/SKILL.md`. Three groups:
+
+- **Baseline** (`critical-issues-only`, `evidence-based-review`,
+  `respect-existing-conventions`) — managed by clud-bug; if you edit them
+  in-place they'll be overwritten on the next `clud-bug update`. To
+  customize behavior for this repo, write a NEW skill rather than mutating
+  a baseline.
+- **From skills.sh** — installed via `clud-bug add <source/name>`. Tracked
+  in `.claude/skills/.clud-bug.json`. Use `clud-bug refresh` to sync.
+- **Custom** (anything not in the manifest) — yours, never touched by any
+  clud-bug command. Drop a new `.md` here and it auto-loads on the next PR.
+
+When you write a custom skill, follow the SKILL.md frontmatter format
+(`name`, `description`) and write specific, evidence-anchored guidance.
+Generic advice gets ignored; rules with examples and quoted-line evidence
+move the bot's behavior.
+
+## When you edit `.github/workflows/clud-bug-*.yml`
+
+`anthropics/claude-code-action` **refuses to run on PRs that modify its
+own workflow file** (App token exchange fails with 401, "Workflow
+validation failed"). This is a security guard against PRs that try to
+neuter the reviewer or exfiltrate secrets.
+
+Consequence: if you bundle a workflow tweak with other work, the
+`clud-bug-review` check on that PR will fail and not actually review your
+other changes either.
+
+The fix: split workflow edits into their own PR. The CLI helps:
+
+```bash
+# After editing .github/workflows/clud-bug-*.yml locally:
+clud-bug edit-workflow
+```
+
+It refuses to run if your working tree has non-workflow changes, so the
+isolation guarantee is enforced. Branches from `origin/main`, not HEAD —
+unrelated commits on a feature branch can't leak in.
+
+## When the secret is missing
+
+`ANTHROPIC_API_KEY` must be set in the repo's Actions secrets. Without it,
+the workflow's guard step fails loudly with an `::error::` annotation
+explaining how to set it. (For bot/fork PRs where the secret legitimately
+isn't passed, the guard posts a one-line advisory comment and exits 0
+instead of failing red.)
+
+## Updating clud-bug itself
+
+`clud-bug-self-update.yml` runs weekly (Mondays 12:00 UTC) and opens a PR
+when a newer clud-bug version is published to npm. Pin to a specific
+version by adding `pinVersion: "x.y.z"` to `.claude/skills/.clud-bug.json`.
+
+To trigger an update on demand:
+
+```bash
+clud-bug update
+```
+
+Re-renders workflow templates and refreshes baseline skills from the
+currently-installed clud-bug version. Custom and skills.sh-installed
+skills are left untouched.
+
+## Where to find more
+
+- Site: https://cludbug.dev
+- Repo: https://github.com/thrillmot/clud-bug
+- Skill catalog: https://github.com/thrillmot/agent-skills

--- a/test/agents-md.test.js
+++ b/test/agents-md.test.js
@@ -1,0 +1,167 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtemp, writeFile, mkdir, readFile, rm, stat } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { applyToRepo, renderBlock, upsertBlock } from '../lib/agents-md.js';
+
+async function makeRepo(files = {}) {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-agents-md-'));
+  for (const [path, content] of Object.entries(files)) {
+    const full = join(dir, path);
+    await mkdir(dirname(full), { recursive: true });
+    await writeFile(full, content);
+  }
+  return dir;
+}
+
+async function exists(p) { try { await stat(p); return true; } catch { return false; } }
+
+test('renderBlock: includes start/end markers and strict-mode line', () => {
+  const block = renderBlock({ version: '0.5.1', strictMode: true });
+  assert.match(block, /<!-- clud-bug-start -->/);
+  assert.match(block, /<!-- clud-bug-end -->/);
+  assert.match(block, /Strict mode is \*\*on\*\*/);
+  assert.match(block, /clud-bug v0\.5\.1/);
+});
+
+test('renderBlock: strictMode false renders advisory text', () => {
+  const block = renderBlock({ version: '0.5.1', strictMode: false });
+  assert.match(block, /Strict mode is \*\*off\*\*/);
+});
+
+test('upsertBlock: appends when no prior block', () => {
+  const before = '# AGENTS.md\n\nSome content.\n';
+  const block = renderBlock({ strictMode: true });
+  const after = upsertBlock(before, block);
+  assert.match(after, /Some content\./);
+  assert.match(after, /<!-- clud-bug-start -->/);
+  // Single occurrence.
+  assert.equal(after.match(/<!-- clud-bug-start -->/g).length, 1);
+});
+
+test('upsertBlock: replaces existing block in place (idempotent)', () => {
+  const before = '# AGENTS.md\n\nIntro.\n\n<!-- clud-bug-start -->\nold body\n<!-- clud-bug-end -->\n\nFooter.\n';
+  const block = renderBlock({ version: '0.5.1', strictMode: true });
+  const after = upsertBlock(before, block);
+  assert.doesNotMatch(after, /old body/);
+  assert.match(after, /clud-bug v0\.5\.1/);
+  assert.match(after, /Intro\./);
+  assert.match(after, /Footer\./);
+  // Still single occurrence.
+  assert.equal(after.match(/<!-- clud-bug-start -->/g).length, 1);
+});
+
+test('upsertBlock: running twice in a row produces identical output', () => {
+  const block = renderBlock({ version: '0.5.1', strictMode: true });
+  const once = upsertBlock('# AGENTS.md\n', block);
+  const twice = upsertBlock(once, block);
+  assert.equal(once, twice);
+});
+
+test('applyToRepo: creates AGENTS.md when missing, no other files', async () => {
+  const dir = await makeRepo({});
+  try {
+    const r = await applyToRepo(dir, { version: '0.5.1', strictMode: true });
+    assert.deepEqual(r.created, ['AGENTS.md']);
+    assert.deepEqual(r.touched, []);
+    const agents = await readFile(join(dir, 'AGENTS.md'), 'utf8');
+    assert.match(agents, /<!-- clud-bug-start -->/);
+    assert.match(agents, /clud-bug v0\.5\.1/);
+    // Did not create CLAUDE.md or anything else.
+    assert.equal(await exists(join(dir, 'CLAUDE.md')), false);
+    assert.equal(await exists(join(dir, '.cursorrules')), false);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('applyToRepo: appends to existing AGENTS.md without touching prior content', async () => {
+  const dir = await makeRepo({
+    'AGENTS.md': '# AGENTS.md\n\nLogmind block here.\n\n<!-- logmind-start -->\nlogmind stuff\n<!-- logmind-end -->\n',
+  });
+  try {
+    const r = await applyToRepo(dir, { version: '0.5.1', strictMode: true });
+    assert.deepEqual(r.created, []);
+    assert.deepEqual(r.touched, ['AGENTS.md']);
+    const agents = await readFile(join(dir, 'AGENTS.md'), 'utf8');
+    // Logmind block preserved.
+    assert.match(agents, /<!-- logmind-start -->/);
+    assert.match(agents, /logmind stuff/);
+    // Clud-bug block added.
+    assert.match(agents, /<!-- clud-bug-start -->/);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('applyToRepo: updates existing CLAUDE.md, .cursorrules, copilot-instructions.md', async () => {
+  const dir = await makeRepo({
+    'AGENTS.md': '# AGENTS.md\n',
+    'CLAUDE.md': '# CLAUDE\n\nstuff\n',
+    '.cursorrules': 'cursor rules\n',
+    '.github/copilot-instructions.md': '# Copilot\n',
+  });
+  try {
+    const r = await applyToRepo(dir, { version: '0.5.1', strictMode: false });
+    assert.deepEqual(r.created.sort(), []);
+    assert.deepEqual(
+      r.touched.sort(),
+      ['.cursorrules', '.github/copilot-instructions.md', 'AGENTS.md', 'CLAUDE.md'],
+    );
+    const claude = await readFile(join(dir, 'CLAUDE.md'), 'utf8');
+    assert.match(claude, /<!-- clud-bug-start -->/);
+    assert.match(claude, /Strict mode is \*\*off\*\*/);
+    assert.match(claude, /^# CLAUDE/);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('applyToRepo: idempotent — second run is a no-op', async () => {
+  const dir = await makeRepo({
+    'CLAUDE.md': '# CLAUDE\n',
+  });
+  try {
+    await applyToRepo(dir, { version: '0.5.1', strictMode: true });
+    const after1 = await readFile(join(dir, 'CLAUDE.md'), 'utf8');
+    const r2 = await applyToRepo(dir, { version: '0.5.1', strictMode: true });
+    const after2 = await readFile(join(dir, 'CLAUDE.md'), 'utf8');
+    assert.equal(after1, after2, 'second run should produce identical content');
+    assert.deepEqual(r2.created, []);
+    // The second run still reports CLAUDE.md and AGENTS.md as touched targets,
+    // but content is unchanged on disk — what matters here is byte-equality.
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('applyToRepo: re-running with new version replaces the prior block', async () => {
+  const dir = await makeRepo({});
+  try {
+    await applyToRepo(dir, { version: '0.5.0', strictMode: true });
+    await applyToRepo(dir, { version: '0.5.1', strictMode: true });
+    const agents = await readFile(join(dir, 'AGENTS.md'), 'utf8');
+    assert.equal(agents.match(/<!-- clud-bug-start -->/g).length, 1, 'one block, not two');
+    assert.match(agents, /clud-bug v0\.5\.1/);
+    assert.doesNotMatch(agents, /clud-bug v0\.5\.0/);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('applyToRepo: walks .cursor/rules/*.md', async () => {
+  const dir = await makeRepo({
+    '.cursor/rules/general.md': '# general\n',
+    '.cursor/rules/typescript.md': '# ts\n',
+    '.cursor/rules/skip.txt': 'not markdown',
+  });
+  try {
+    const r = await applyToRepo(dir, { strictMode: true });
+    assert.ok(r.touched.includes('.cursor/rules/general.md'));
+    assert.ok(r.touched.includes('.cursor/rules/typescript.md'));
+    assert.ok(!r.touched.some((p) => p.endsWith('skip.txt')));
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('applyToRepo: does not create CLAUDE.md or other tool files when absent', async () => {
+  const dir = await makeRepo({});
+  try {
+    await applyToRepo(dir, { strictMode: true });
+    assert.equal(await exists(join(dir, 'AGENTS.md')), true, 'AGENTS.md is the canonical home — created');
+    assert.equal(await exists(join(dir, 'CLAUDE.md')), false);
+    assert.equal(await exists(join(dir, 'GEMINI.md')), false);
+    assert.equal(await exists(join(dir, '.cursorrules')), false);
+    assert.equal(await exists(join(dir, '.windsurfrules')), false);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});

--- a/test/agents-md.test.js
+++ b/test/agents-md.test.js
@@ -154,6 +154,35 @@ test('applyToRepo: walks .cursor/rules/*.md', async () => {
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 
+test('renderBlock: strictMode undefined renders advisory (matches workflow gate predicate)', () => {
+  // The workflow at templates/workflow*.yml.tmpl reads `JSON.parse(s).strictMode === true`.
+  // Anything other than explicit `true` (undefined, null, false) is advisory.
+  // The block must report the same.
+  const block = renderBlock({ version: '0.5.1' });   // strictMode left undefined
+  assert.match(block, /Strict mode is \*\*off\*\*/);
+  assert.doesNotMatch(block, /Strict mode is \*\*on\*\*/);
+});
+
+test('renderBlock: strictMode null renders advisory', () => {
+  const block = renderBlock({ version: '0.5.1', strictMode: null });
+  assert.match(block, /Strict mode is \*\*off\*\*/);
+});
+
+test('regression: v0.3-shaped manifest (lastUpdate set, strictMode undefined) renders "off"', async () => {
+  // This pins the v0.3 advisory upgrade path. bin/clud-bug.js#runInit
+  // deliberately keeps strictMode undefined when lastUpdate already exists
+  // (test/cli.test.js: "existing v0.3 advisory install ... is NOT auto-flipped").
+  // The brief must match the actual gate state, not the v0.4 default.
+  const dir = await makeRepo({});
+  try {
+    // Simulate what bin/clud-bug.js passes for a v0.3 manifest: strictMode === true is false.
+    await applyToRepo(dir, { version: '0.5.1', strictMode: false /* === (undefined === true) */ });
+    const agents = await readFile(join(dir, 'AGENTS.md'), 'utf8');
+    assert.match(agents, /Strict mode is \*\*off\*\*/);
+    assert.doesNotMatch(agents, /Strict mode is \*\*on\*\*/);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
 test('applyToRepo: does not create CLAUDE.md or other tool files when absent', async () => {
   const dir = await makeRepo({});
   try {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -57,8 +57,10 @@ test('init --offline --accept-all in a fresh repo writes workflow + manifest', a
     const wf = await readFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'utf8');
     assert.match(wf, /allowedTools/);
     const manifest = JSON.parse(await readFile(join(dir, '.claude/skills/.clud-bug.json'), 'utf8'));
-    assert.equal(manifest.installed.length, 3, 'should install 3 baseline skills');
+    assert.equal(manifest.installed.length, 4, 'should install 4 baseline skills');
     assert.ok(manifest.installed.every(e => e.kind === 'baseline'));
+    // The new collaboration skill ships in the baseline kit.
+    assert.ok(manifest.installed.some(e => e.slug === 'clud-bug-collaboration'));
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
## Summary

The last queued v0.5 PR. `clud-bug init` now briefs other agents working in the repo about its presence — same well-established pattern logmind uses, idempotently maintained.

- **`lib/agents-md.js`** wraps a `<!-- clud-bug-start -->` block into a self-contained module. Creates `AGENTS.md` if missing (it's the canonical cross-tool home — same call logmind made), and idempotently appends to `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules`, `.windsurfrules`, `.clinerules`, `.continuerules`, and `.cursor/rules/*.md` *where they already exist*. No proliferating stubs the user didn't ask for. Re-runs replace the prior block in place — running with a new clud-bug version updates it.
- **New baseline skill `clud-bug-collaboration`** ships in the baseline kit. Higher-fidelity guidance for Claude Code agents working in a clud-bug-installed repo: when to defer to bot thread auto-resolution (don't manually resolve threads — push the fix, the bot handles it on the next pass); how to read the `clud-bug-review` check status (red vs skipped vs green); why `claude-code-action` rejects PRs that modify its own workflow (use `clud-bug edit-workflow` to isolate); how to disable strict mode safely (it's read from base ref so a PR can't disable on itself).
- `clud-bug update` also refreshes the AGENTS.md block so the embedded version + strict-mode line stays current.
- New `test/agents-md.test.js`: 12 tests covering create/append/replace/idempotency/.cursor-walking. Existing `cli.test.js` updated for the new baseline count (3 → 4).

The new collaboration skill ships bundled in clud-bug for now; once uploaded to `thrillmot/agent-skills/skills/clud-bug-collaboration/SKILL.md` and the SHA bumped in `lib/skills.js`, it'll source from there with bundled fallback like the other baselines.

## Test plan

- [x] `npm test` — 91/91 pass (12 new in `test/agents-md.test.js`; existing cli test updated for new baseline count)
- [x] End-to-end smoke: `node bin/clud-bug.js init --offline --accept-all` in a fresh tempdir creates `AGENTS.md` with the correct block and 4 baseline skills
- [ ] Dogfood on this PR: parallel reviewers (clud-bug + baseline `claude-code-review`) post their reviews; address any critical findings
- [ ] After merge: `clud-bug-self-update.yml` will pick up v0.5.1 on its next Monday cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)