### PR TITLE
logmind: refresh logmind-aggregate.yml from v0.1.4 template (LOGMIND_BOT_PAT)

### DIFF
--- a/.github/workflows/logmind-aggregate.yml
+++ b/.github/workflows/logmind-aggregate.yml
@@ -39,7 +39,20 @@ jobs:
 
       - name: Commit and push (with PR fallback under branch protection)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # If LOGMIND_BOT_PAT is set, the aggregator PR opens under that
+          # identity and downstream workflows (required checks, etc.) fire
+          # normally. Without it, the PR opens via GITHUB_TOKEN, which
+          # GitHub deliberately blocks from triggering other workflows
+          # (anti-recursion safety).
+          #
+          # If your base ref has required status checks (clud-bug, etc.),
+          # set LOGMIND_BOT_PAT to a fine-grained PAT scoped to this repo
+          # with Contents:write + Pull-requests:write. The aggregator PR
+          # will then be mergeable. Without it, the PR opens but its
+          # required checks will never run, and the PR will sit
+          # unmergeable. The workflow emits a ::warning:: in that case.
+          GH_TOKEN: ${{ secrets.LOGMIND_BOT_PAT || secrets.GITHUB_TOKEN }}
+          HAS_BOT_PAT: ${{ secrets.LOGMIND_BOT_PAT != '' }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
@@ -71,6 +84,9 @@ jobs:
                   --body "Automated decision aggregation. Direct push to \`${BASE_REF}\` was blocked by branch protection."; then
               echo "::warning::Aggregation PR could not be created. Check 'Settings → Actions → General → Allow GitHub Actions to create and approve pull requests'."
               exit 0
+            fi
+            if [ "${HAS_BOT_PAT}" != "true" ]; then
+              echo "::warning::Aggregator PR opened via GITHUB_TOKEN. Required status checks on '${BASE_REF}' will NOT trigger on this PR (GitHub anti-recursion safety). Set the LOGMIND_BOT_PAT repo secret to a fine-grained PAT (Contents:write + Pull-requests:write on this repo) so the PR can satisfy required checks. See the workflow file's env comment for details."
             fi
             echo "Opened aggregation PR for #${PR_NUMBER}."
             exit 0

--- a/docs/decisions-branches/feat__logmind-0.1.4.md
+++ b/docs/decisions-branches/feat__logmind-0.1.4.md
@@ -1,0 +1,11 @@
+## 2026-05-15 13:05 - Adopt LOGMIND_BOT_PAT in logmind-aggregate workflow (v0.1.4 template)
+
+**Reasoning:** On this repo, main is not yet protected with required status checks, so the warning will fire harmlessly. Adopting now means we're ready when we do enable required checks.
+
+**Alternatives considered:** Skip the upgrade — rejected because the aggregator becomes load-bearing as soon as we enable branch protection on main, which is on the v0.6 horizon., Mint and configure LOGMIND_BOT_PAT now — deferred because it requires a fine-grained PAT (browser flow) and would be wasted setup until branch protection actually requires it.
+
+**Implications:**
+- When/if main gets required status checks (clud-bug-review, etc.), the aggregator PR will start emitting a ::warning:: until LOGMIND_BOT_PAT is set: gh secret set LOGMIND_BOT_PAT --body '<pat-with-Contents-write-and-Pull-requests-write>'.
+- check-decisions.yml and check-doc-links.yml templates were verified byte-identical to v0.1.4 — no churn, restored from .bak.
+
+---


### PR DESCRIPTION
## Summary

Picking up logmind v0.1.4. Per the upstream upgrade procedure, this is a tiny PR — most of the v0.1.4 changes are already in effect on this repo.

**Recon found:**
- `logmind --version` already reports 0.1.4 (homebrew upgrade landed before this run)
- `logmind agents update` says "All agent files are current" — AGENTS.md is on `v2-slim`, CLAUDE.md and `.cursorrules` already in shape
- `check-decisions.yml` and `check-doc-links.yml`: byte-identical to v0.1.4 templates (verified with diff)
- `.logmind/config.yml` `ignore_patterns` already includes the v0.1.4 Node/Vercel/Turbo defaults

**Only meaningful diff:** `logmind-aggregate.yml` adds opt-in `LOGMIND_BOT_PAT` support so that when `main` gets required status checks (clud-bug-review, etc.), aggregator PRs can satisfy those checks. Without `LOGMIND_BOT_PAT`, GitHub's anti-recursion safety blocks downstream workflows from running on `GITHUB_TOKEN`-opened PRs and aggregator PRs sit unmergeable. The new template also emits a `::warning::` when the PAT is missing, so the failure mode is loud.

**Action item for you (not in this PR):** if/when `main` gets branch protection with required status checks, mint a fine-grained PAT scoped to this repo (Contents:write + Pull-requests:write) and run:
\`\`\`bash
gh secret set LOGMIND_BOT_PAT --body '<pat>'
\`\`\`
Today main is unprotected so the warning is harmless.

## Test plan

- [x] \`npm test\` — 91/91 pass (no clud-bug code touched)
- [ ] After merge: next PR's check-decisions / check-doc-links / logmind-aggregate workflows run normally
- [ ] When branch protection lands: aggregator emits the documented \`::warning::\` until \`LOGMIND_BOT_PAT\` is set

## Scope

| File | Change |
|---|---|
| \`.github/workflows/logmind-aggregate.yml\` | Replace with v0.1.4 template (adds \`LOGMIND_BOT_PAT\` env wiring + warning) |
| \`docs/decisions-branches/feat__logmind-0_1_4.md\` | Decision log entry (logmind-managed) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)