### PR TITLE
v0.5.2: bump baseline-skills SHA pin to a4455977

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] — 2026-05-15
+
+### Changed
+- **Bumped baseline-skills SHA pin to [`a4455977`](https://github.com/thrillmot/agent-skills/commit/a44559770686e6c51d08ba5bb842d78f85876fb2)** so all four baseline skills (`critical-issues-only`, `evidence-based-review`, `respect-existing-conventions`, `clud-bug-collaboration`) now resolve from `thrillmot/agent-skills` instead of silently falling back to bundled copies. Prior pin pointed at a tree where only `skills/logmind/SKILL.md` existed; every install was fallback-only. Fresh installs will now log `baseline kit: 4 specimens (from thrillmot/agent-skills)` instead of `(bundled fallback)`. Bundled copies still ship as the offline fallback.
+
 ## [0.5.1] — 2026-05-15
 
 ### Added
@@ -34,6 +39,7 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 - **Bot-authored PRs are now handled gracefully.** PRs from `dependabot[bot]`, `renovate[bot]`, or forks (where GitHub deliberately doesn't pass repository secrets) used to fail loudly red — wrong signal. Now a guard step detects the case, posts a one-line advisory comment ("Clud Bug skipped — bot/fork PR cannot access secrets"), and exits 0. Check stays green; the skip is visible. Owner-authored PRs without the secret still fail loud.
 - **Site polish (carries over from the unreleased entry):** alive bug emoji (layered breathe + twitch + scuttle animations), Plate label gloss, thrillmot footer credit.
 
+[0.5.2]: https://github.com/thrillmot/clud-bug/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/thrillmot/clud-bug/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/thrillmot/clud-bug/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/thrillmot/clud-bug/compare/v0.4.0...v0.4.1

--- a/docs/decisions-branches/feat__agent-skills-sha-bump.md
+++ b/docs/decisions-branches/feat__agent-skills-sha-bump.md
@@ -1,0 +1,11 @@
+## 2026-05-15 13:09 - Bump BASELINE_SKILLS_REF to a4455977 — agent-skills now hosts all four baselines
+
+**Reasoning:** Verified locally: CLUD_BUG_AGENT_SKILLS_BASE override pointing at the new SHA produces _source: 'agent-skills' for all four entries on loadBaseline().
+
+**Alternatives considered:** Roll baselines into agent-skills' main without bumping clud-bug's SHA — rejected because the explicit SHA pin is the trust boundary; until clud-bug ships a release that names the new SHA, no install picks it up., Drop the bundled fallback now that the remote is real — rejected because the offline use case (CI without network, fork installs from cache) is still legitimate. Bundled stays as the fallback.
+
+**Implications:**
+- Future skill edits happen in agent-skills first, then a clud-bug release bumps the SHA pin. CHANGELOG entry records the SHA so users can audit what version of each skill they got.
+- Cache key includes AGENT_SKILLS_BASE so this SHA bump cleanly invalidates cached entries — users running clud-bug locally will re-fetch on next call.
+
+---

--- a/lib/skills.js
+++ b/lib/skills.js
@@ -15,7 +15,7 @@ const MANIFEST_VERSION = 1;
 // skill content, bump BASELINE_SKILLS_REF below in the same clud-bug PR
 // that ships the corresponding bundled fallback update.
 // See thrillmot/agent-skills — skills.sh `skills/<name>/SKILL.md` layout.
-const BASELINE_SKILLS_REF = '977e439ec861860351239ed89dd56edcd48cbf6b';
+const BASELINE_SKILLS_REF = 'a44559770686e6c51d08ba5bb842d78f85876fb2';
 const AGENT_SKILLS_BASE = process.env.CLUD_BUG_AGENT_SKILLS_BASE
   ?? `https://raw.githubusercontent.com/thrillmot/agent-skills/${BASELINE_SKILLS_REF}/skills`;
 const SKILL_FETCH_TIMEOUT_MS = 5000;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",


### PR DESCRIPTION
## Summary

Closes the loop on v0.5.0's canonical-home design. Until now, \`lib/skills.js\` was pinned to a SHA where only \`skills/logmind/SKILL.md\` existed in agent-skills, so every install since v0.5.0 silently used the bundled fallback. Today's [thrillmot/agent-skills#4](https://github.com/thrillmot/agent-skills/pull/4) uploaded all four baselines; this PR bumps the pin to that merge SHA.

| | Before | After |
|---|---|---|
| BASELINE_SKILLS_REF | \`977e439\` | \`a4455977\` |
| Skills available at remote | logmind only | logmind + 4 clud-bug baselines |
| Fresh-install log | \`baseline kit: 4 specimens (bundled fallback)\` | \`baseline kit: 4 specimens (from thrillmot/agent-skills)\` |
| Bundled fallback | still ships | still ships (offline / network-failure path) |

## Verification

- [x] \`npm test\` — 91/91 pass (no logic changes; SHA constant only)
- [x] Live smoke test with \`CLUD_BUG_AGENT_SKILLS_BASE\` override pointed at the new SHA: all four \`loadBaseline()\` entries return \`_source: 'agent-skills'\`
- [ ] After merge + tag v0.5.2 + npm publish: \`npx clud-bug@0.5.2 init\` in a fresh tempdir shows \`(from thrillmot/agent-skills)\`

## Scope

| File | Change |
|---|---|
| \`lib/skills.js\` | bump \`BASELINE_SKILLS_REF\` |
| \`package.json\` | 0.5.1 → 0.5.2 |
| \`CHANGELOG.md\` | new \`[0.5.2]\` entry |
| \`docs/decisions-branches/feat__agent-skills-sha-bump.md\` | logmind decision log |

🤖 Generated with [Claude Code](https://claude.com/claude-code)