### PR TITLE
Site: lead §II with skills-as-the-moat; tighter install + scroll-fade

### DIFF
--- a/docs/decisions-branches/site__skills-as-the-moat.md
+++ b/docs/decisions-branches/site__skills-as-the-moat.md
@@ -1,0 +1,12 @@
+## 2026-05-15 14:46 - Lead site §II with skills-as-the-moat instead of baseline cards
+
+**Reasoning:** Each custom-skill card shows a quoted rule the team would write — concrete enough that a reader can imagine writing similar for their own codebase. Baselines move to a small italic footer ('always pinned floor') so they don't compete with the above-the-fold story.
+
+**Alternatives considered:** Show real team logos / case studies — rejected because we don't have any yet, and fake badges read as marketing-trick. Concrete example rules have higher trust., Add a 'configure your skill' interactive walkthrough — rejected as scope creep. Static examples + the existing install terminal cover the discoverability.
+
+**Implications:**
+- If we add more skill examples later (compliance for HIPAA, accessibility for WCAG, etc.), they slot into the same .specimens grid — keep the 2x2 visual cap, paginate or scroll if more added.
+- Install terminal also tightened (3-line first paragraph fits 375px without scroll) + new .terminal::after fade gradient signals horizontal scrollability without adding visible scrollbars.
+- Future skill names should follow the YOU-XXX cataloging hint that frames them as 'your team writes these' rather than 'we ship these'.
+
+---

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -390,7 +390,44 @@ main { position: relative; z-index: 1; }
   gap: 2.5rem;
 }
 
-@media (min-width: 900px) { .specimens { grid-template-columns: repeat(3, 1fr); gap: 2rem; } }
+@media (min-width: 900px) {
+  /* 2x2 at desktop. Four cards in a single row crushes specimen-desc to
+     unreadable widths; two columns gives each example room to breathe. */
+  .specimens { grid-template-columns: repeat(2, 1fr); gap: 2rem; }
+}
+
+/* Lead paragraph that frames the specimens grid (skills as the moat). */
+.section-prose-lead {
+  font-family: var(--body);
+  font-size: 1.05rem;
+  color: var(--ink-soft);
+  margin-bottom: 2rem;
+  max-width: var(--col);
+  line-height: 1.55;
+}
+.section-prose-lead em {
+  font-style: italic;
+  color: var(--leaf);
+}
+
+/* Footer line under the specimens grid mentioning the always-pinned
+   baselines + skills.sh. Smaller and faded so it doesn't compete with
+   the above-the-fold custom-skills story. */
+.specimens-footer {
+  margin-top: 2rem;
+  font-family: var(--body);
+  font-size: 0.92rem;
+  color: var(--ink-soft);
+  font-style: italic;
+  line-height: 1.55;
+  max-width: var(--col);
+}
+.specimens-footer a {
+  color: inherit;
+  border-bottom: 1px dotted var(--ink-faint);
+  text-decoration: none;
+}
+.specimens-footer a:hover { color: var(--citrus); border-bottom-color: var(--citrus); }
 
 .specimen {
   background: var(--paper-warm);
@@ -500,6 +537,22 @@ main { position: relative; z-index: 1; }
      gated behind ≤600px, so widths in the 600–900px tablet range had
      visible right-edge overflow. */
   overflow-x: auto;
+}
+
+/* Right-edge scroll affordance: fade the last ~2.5rem of the box to the
+   terminal's dark background. Signals "more content this way" when the
+   user can scroll, and is harmlessly invisible when content already fits
+   (the fade target IS the bg). Sits inside the border (top/right/bottom
+   inset by 1px) and ignores clicks/scroll-touch. */
+.terminal::after {
+  content: '';
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  bottom: 1px;
+  width: 2.5rem;
+  pointer-events: none;
+  background: linear-gradient(to right, transparent, var(--ink) 75%);
 }
 
 .terminal::before {

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -373,7 +373,7 @@ main { position: relative; z-index: 1; }
    Mono fonts ship visually larger than serif body text; without this the
    inline tokens overpower their surroundings. Applies to every `code` that
    isn't inside a `pre` (terminal blocks have their own scaling). */
-:where(.section-prose, .marginalia, .observation, .actions) code {
+:where(.section-prose, .marginalia, .observation, .actions, .specimen-desc, .specimens-footer) code {
   font-family: var(--mono);
   font-size: 0.86em;
   background: var(--paper-warm);

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -115,7 +115,7 @@ export default async function Home() {
                 <span className="specimen-tag">Spec. compliance</span>
                 <h3 className="specimen-name">Compliance &amp; PII</h3>
                 <p className="specimen-desc">
-                  &ldquo;No PII (email, phone, name) in logs, ever. No
+                  &ldquo;No PII (email, phone, name) in logs, ever. No{' '}
                   <code>console.log</code> in <code>app/api/*</code>. Every
                   secret read needs an audit log entry.&rdquo;
                 </p>

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -71,46 +71,75 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* ─────────── §II — SPECIMENS ─────────── */}
+      {/* ─────────── §II — SKILLS ─────────── */}
       <section className="section">
         <header className="section-head">
-          <span className="section-num">§ II — Type Specimens</span>
-          <h2 className="section-title">Three skills, always pinned.</h2>
+          <span className="section-num">§ II — Specimens for your habitat</span>
+          <h2 className="section-title">Skills are how Clud Bug knows your codebase.</h2>
         </header>
         <div className="section-body">
           <aside className="marginalia">
-            Bundled with every install. Combine with skills curated from{' '}
-            <a href="https://skills.sh" style={{ color: 'inherit' }}>skills.sh</a>{' '}
-            and your own <code>.claude/skills/</code>.
+            Drop a Markdown file into <code>.claude/skills/</code> and Clud Bug
+            cites it by name on every review. Your team&rsquo;s standards
+            become the reviewer.
           </aside>
-          <div className="specimens">
-            <article className="specimen">
-              <span className="specimen-tag">Specimen 01</span>
-              <h3 className="specimen-name">Critical issues only</h3>
-              <p className="specimen-desc">
-                Flags only correctness, security, and performance defects. Suppresses
-                style nits and naming preferences that don&rsquo;t change behavior.
-              </p>
-              <span className="specimen-pin">cat. № CB-001</span>
-            </article>
-            <article className="specimen">
-              <span className="specimen-tag">Specimen 02</span>
-              <h3 className="specimen-name">Evidence-based review</h3>
-              <p className="specimen-desc">
-                Every claim must quote the line under criticism. No hand-waving, no
-                vague &ldquo;might cause issues.&rdquo; Cite or delete.
-              </p>
-              <span className="specimen-pin">cat. № CB-002</span>
-            </article>
-            <article className="specimen">
-              <span className="specimen-tag">Specimen 03</span>
-              <h3 className="specimen-name">Respect existing conventions</h3>
-              <p className="specimen-desc">
-                A code review is not a redesign. Don&rsquo;t suggest patterns that fight
-                the surrounding codebase&rsquo;s established style.
-              </p>
-              <span className="specimen-pin">cat. № CB-003</span>
-            </article>
+          <div>
+            <p className="section-prose-lead">
+              Generic PR review tools evaluate your code against generic best
+              practices. Clud Bug evaluates it against <em>your</em> standards
+              &mdash; encoded as plain Markdown the bot loads on every PR. A
+              few of the high-value patterns teams write:
+            </p>
+            <div className="specimens">
+              <article className="specimen">
+                <span className="specimen-tag">Spec. brand-voice</span>
+                <h3 className="specimen-name">Brand voice review</h3>
+                <p className="specimen-desc">
+                  &ldquo;Microcopy reviewed against the brand guide. Button
+                  labels follow verb-noun. Toasts ≤ 80 chars. No exclamation
+                  marks outside the success state.&rdquo;
+                </p>
+                <span className="specimen-pin">cat. № YOU-001</span>
+              </article>
+              <article className="specimen">
+                <span className="specimen-tag">Spec. api-contract</span>
+                <h3 className="specimen-name">API contract enforcement</h3>
+                <p className="specimen-desc">
+                  &ldquo;Anything under <code>/v1/*</code> is frozen. Schema
+                  changes need a <code>/v2</code> alongside. Flag breaking
+                  changes; require deprecation headers on removals.&rdquo;
+                </p>
+                <span className="specimen-pin">cat. № YOU-002</span>
+              </article>
+              <article className="specimen">
+                <span className="specimen-tag">Spec. compliance</span>
+                <h3 className="specimen-name">Compliance &amp; PII</h3>
+                <p className="specimen-desc">
+                  &ldquo;No PII (email, phone, name) in logs, ever. No
+                  <code>console.log</code> in <code>app/api/*</code>. Every
+                  secret read needs an audit log entry.&rdquo;
+                </p>
+                <span className="specimen-pin">cat. № YOU-003</span>
+              </article>
+              <article className="specimen">
+                <span className="specimen-tag">Spec. test-discipline</span>
+                <h3 className="specimen-name">Test discipline</h3>
+                <p className="specimen-desc">
+                  &ldquo;Every new endpoint ships a happy-path and a 4xx test
+                  in the same PR. Refactors can&rsquo;t reduce test count
+                  without an explicit note.&rdquo;
+                </p>
+                <span className="specimen-pin">cat. № YOU-004</span>
+              </article>
+            </div>
+            <p className="specimens-footer">
+              Plus four baseline skills always pinned&nbsp;—{' '}
+              <code>critical-issues-only</code>,{' '}
+              <code>evidence-based-review</code>,{' '}
+              <code>respect-existing-conventions</code>,{' '}
+              <code>clud-bug-collaboration</code>. Browse community-contributed
+              skills at <a href="https://skills.sh">skills.sh</a>.
+            </p>
           </div>
         </div>
       </section>
@@ -161,15 +190,12 @@ export default async function Home() {
           </aside>
           <div>
             <pre className="terminal">
-              <span className="comment"># 1. Survey the habitat, pin specimens, draft the field kit.</span>{'\n'}
               <span className="cmd">npx clud-bug init</span>{'\n'}
-              <span className="out">  🐛 Field season opens in <span className="path">~/your-repo</span>.</span>{'\n'}
-              <span className="out">    baseline kit:     <span className="num">3</span> specimens</span>{'\n'}
-              <span className="out">  pinning specimens to <span className="path">.claude/skills/</span>...</span>{'\n'}
-              <span className="out">    pinned <span className="num">3</span> specimens</span>{'\n'}
+              <span className="out">  🐛 Field season opens here.</span>{'\n'}
+              <span className="out">    baseline kit: <span className="num">4</span> specimens</span>{'\n'}
+              <span className="out">  pinned <span className="num">4</span> to <span className="path">.claude/skills/</span></span>{'\n'}
               <span className="out">  wrote <span className="path">.github/workflows/clud-bug-review.yml</span></span>{'\n\n'}
-              <span className="comment"># 2. Commit the field kit and push.</span>{'\n'}
-              <span className="cmd">git add <span className="path">.claude .github/workflows/clud-bug-review.yml</span></span>{'\n'}
+              <span className="cmd">git add <span className="path">.claude .github/workflows/</span></span>{'\n'}
               <span className="cmd">git commit -m &quot;Add clud-bug&quot; && git push</span>{'\n'}
             </pre>
           </div>


### PR DESCRIPTION
## Summary

Per user feedback: the site treats skills as a feature when they're actually the moat. **Generic PR review tools all evaluate code against generic best practices — the differentiator is that Clud Bug evaluates against YOUR team's standards**, encoded as Markdown skills.

Restructured §II to lead with that value prop and show four concrete custom-skill examples teams would write (instead of three baseline cards):

| Old §II | New §II |
|---|---|
| Title: "Three skills, always pinned." | "Skills are how Clud Bug knows your codebase." |
| 3 cards: critical-issues-only / evidence-based-review / respect-existing-conventions | 4 cards: brand-voice / api-contract / compliance / test-discipline |
| Baselines as the headline | Baselines as a small italic footer ("always pinned floor") |
| No lead paragraph | Lead paragraph framing skills as the differentiator |

**Each new card quotes a concrete rule** so readers can imagine writing similar for their own codebase ("Microcopy reviewed against the brand guide. Button labels follow verb-noun. Toasts ≤ 80 chars.").

## Install terminal — also tightened

Per user feedback ("you need to actually look at the code section"):

- Trimmed verbose section comments and merged "pinning + pinned" into one line so the **first 3 lines fit at 375px without horizontal scroll**.
- New \`.terminal::after\` right-edge fade gradient as a **scroll affordance** — signals "more content this way" when long lines (workflow path, commit command) need horizontal scroll. Harmlessly invisible when content fits.
- (Best practice for mobile code blocks: internal \`overflow-x: auto\` + visual fade affordance + tight examples that fit common widths. All three together.)

## CSS structural changes

- \`.specimens\` grid: \`repeat(3, 1fr)\` → \`repeat(2, 1fr)\` at ≥900px so the four cards have room to breathe (4-in-a-row crushes \`.specimen-desc\` to unreadable widths).
- New \`.section-prose-lead\` framing the grid.
- New \`.specimens-footer\` for the demoted baselines mention.
- New \`.terminal::after\` for the right-edge fade.

## Test plan

Verified at 375px in Playwright:
- [x] 4 specimens render
- [x] doc doesn't overflow (no horizontal page scroll)
- [x] terminal scrolls internally (337/484); \`::after\` fade present
- [x] new section title + lead + footer all present
- [x] \`npm run build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)