### PR TITLE
ci: upgrade npm to 11.5+ before publish (fixes 404 on Trusted Publishing)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -63,6 +63,15 @@ jobs:
           # the OIDC exchange automatically.
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm to a Trusted-Publishing-capable version
+        # Node 20 ships npm 10.x. npm 10 signs provenance attestations
+        # but does NOT exchange the OIDC token for a publish token —
+        # it falls back to looking for NPM_TOKEN, finds none, and the
+        # publish PUT gets rejected with a misleading 404. Trusted
+        # Publishing's full flow (sign + auth via OIDC end-to-end)
+        # requires npm 11.5.1+.
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm install --no-audit --no-fund
 


### PR DESCRIPTION
## Summary

The four publish runs from PR #32 (manually triggered for v0.4.1, v0.5.0, v0.5.1, v0.5.2) all failed identically:

\`\`\`
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=1549666962
npm error 404 Not Found - PUT https://registry.npmjs.org/clud-bug - Not found
npm error 404 'clud-bug@0.4.1' is not in this registry.
\`\`\`

That exact failure mode (provenance signs successfully, then PUT 404s) is what **npm 10.x** produces under Trusted Publishing: it signs the attestation via OIDC fine, then falls back to looking for \`NPM_TOKEN\` for the actual registry PUT. No token, 404 from npm.

End-to-end OIDC publishing (sign + authenticate against the registry) landed in **npm 11.5.1** in July 2025. Node 20's bundled npm is still 10.x. Trusted publisher config + OIDC permissions on the workflow are correct (verified with @thrillmot's screenshot of the npm settings page) — only the npm CLI version was wrong.

## Fix

One-line addition: \`npm install -g npm@latest\` before the publish step. Stays on Node 20 (no Node-version churn) but uses an OIDC-capable npm.

## Plan after merge

Re-trigger \`workflow_dispatch\` four times for v0.4.1, v0.5.0, v0.5.1, v0.5.2. Same as before, just with the upgraded npm in the runner.

## Scope

| File | Change |
|---|---|
| \`.github/workflows/npm-publish.yml\` | Add npm-upgrade step + comment explaining the npm 10 vs 11.5+ trap |

🤖 Generated with [Claude Code](https://claude.com/claude-code)