### PR TITLE
v0.5.3: metadata-only bump (fix npm latest dist-tag)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] — 2026-05-15
+
+### Changed
+- **No functional changes.** Metadata-only release. The Stream A2 backfill of v0.4.1, v0.5.0, v0.5.1, v0.5.2 via parallel `workflow_dispatch` finished out of order, leaving npm's `latest` dist-tag pinned to v0.5.1 instead of v0.5.2. npm Trusted Publishing currently authenticates `publish` only — `dist-tag` operations need a long-lived token, which we deliberately don't store. Republishing as v0.5.3 lets the standard tag-push → OIDC-publish flow naturally promote the new version to `latest`. The on-disk code is byte-identical to v0.5.2.
+
 ## [0.5.2] — 2026-05-15
 
 ### Changed
@@ -39,6 +44,7 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 - **Bot-authored PRs are now handled gracefully.** PRs from `dependabot[bot]`, `renovate[bot]`, or forks (where GitHub deliberately doesn't pass repository secrets) used to fail loudly red — wrong signal. Now a guard step detects the case, posts a one-line advisory comment ("Clud Bug skipped — bot/fork PR cannot access secrets"), and exits 0. Check stays green; the skip is visible. Owner-authored PRs without the secret still fail loud.
 - **Site polish (carries over from the unreleased entry):** alive bug emoji (layered breathe + twitch + scuttle animations), Plate label gloss, thrillmot footer credit.
 
+[0.5.3]: https://github.com/thrillmot/clud-bug/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/thrillmot/clud-bug/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/thrillmot/clud-bug/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/thrillmot/clud-bug/compare/v0.4.1...v0.5.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",


### PR DESCRIPTION
Stream A2 backfilled v0.4.1, v0.5.0, v0.5.1, v0.5.2 via parallel workflow_dispatch. They finished out of order so npm 'latest' is pinned to v0.5.1 instead of v0.5.2.

npm Trusted Publishing currently authenticates 'publish' only — 'dist-tag' commands require a long-lived NPM_TOKEN, which we deliberately don't store. So instead of fighting it: republish as v0.5.3 (no functional diff). The standard tag-push → OIDC-publish flow naturally promotes the new latest. On-disk code is byte-identical to v0.5.2.

After merge: tag v0.5.3 at the merge commit, push the tag, npm-publish workflow auto-runs, latest → v0.5.3.