### PR TITLE
v0.5.4: status block at the top of every review (issue #43 item 1)

### DIFF
--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -114,28 +114,6 @@ jobs:
 
               ## 🐛 Clud Bug review
 
-            Immediately after the H2 header — on the next non-empty
-            line — emit a status block in this exact format:
-
-              **This round:** N critical · N minor · N resolved from prior · N still open
-
-            The four counters (always include all four, even when 0):
-              • critical            — count of NEW critical findings
-                                      in this review (strict-mode-gated)
-              • minor               — count of non-critical findings
-              • resolved from prior — count of prior unresolved threads
-                                      YOU (claude[bot]) just resolved
-                                      on this pass (the loop-closing
-                                      signal — tells the author the
-                                      bot read their fixes)
-              • still open          — count of prior unresolved threads
-                                      whose issue still stands AFTER
-                                      this pass
-
-            On a first-time review both "resolved from prior" and "still
-            open" are 0. After fix-pushes, "resolved from prior" is
-            typically positive.
-
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"
 

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -114,6 +114,28 @@ jobs:
 
               ## 🐛 Clud Bug review
 
+            Immediately after the H2 header — on the next non-empty
+            line — emit a status block in this exact format:
+
+              **This round:** N critical · N minor · N resolved from prior · N still open
+
+            The four counters (always include all four, even when 0):
+              • critical            — count of NEW critical findings
+                                      in this review (strict-mode-gated)
+              • minor               — count of non-critical findings
+              • resolved from prior — count of prior unresolved threads
+                                      YOU (claude[bot]) just resolved
+                                      on this pass (the loop-closing
+                                      signal — tells the author the
+                                      bot read their fixes)
+              • still open          — count of prior unresolved threads
+                                      whose issue still stands AFTER
+                                      this pass
+
+            On a first-time review both "resolved from prior" and "still
+            open" are 0. After fix-pushes, "resolved from prior" is
+            typically positive.
+
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.4] — 2026-05-18
+
+### Added
+- **Status block at the top of every review.** Every Clud Bug PR-review comment now begins (immediately under the `## 🐛 Clud Bug review` header) with a single-line status block: `**This round:** N critical · N minor · N resolved from prior · N still open`. The four counters tell the author and any agent reading the comment exactly what changed since the last review pass — most importantly, **resolved from prior** is the loop-closing signal that proves the bot read their fixes and cleared the corresponding threads, not just listed new complaints. Format is identical on every review (zero values included) so it's grep-able and machine-parseable.
+
 ## [0.5.3] — 2026-05-15
 
 ### Changed
@@ -44,6 +49,7 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 - **Bot-authored PRs are now handled gracefully.** PRs from `dependabot[bot]`, `renovate[bot]`, or forks (where GitHub deliberately doesn't pass repository secrets) used to fail loudly red — wrong signal. Now a guard step detects the case, posts a one-line advisory comment ("Clud Bug skipped — bot/fork PR cannot access secrets"), and exits 0. Check stays green; the skip is visible. Owner-authored PRs without the secret still fail loud.
 - **Site polish (carries over from the unreleased entry):** alive bug emoji (layered breathe + twitch + scuttle animations), Plate label gloss, thrillmot footer credit.
 
+[0.5.4]: https://github.com/thrillmot/clud-bug/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/thrillmot/clud-bug/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/thrillmot/clud-bug/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/thrillmot/clud-bug/compare/v0.5.0...v0.5.1

--- a/README.md
+++ b/README.md
@@ -182,6 +182,26 @@ After install:
 3. Within ~2 min, Clud Bug should post a comment flagging it.
 4. If no comment: check the **Actions** tab logs. Look for `gh pr comment` invocations and any "Resource not accessible by integration" errors (usually a permissions issue or a fork PR).
 
+### Reading a review
+
+Every Clud Bug review opens with a status line that tells you exactly what changed since the previous pass — particularly useful on re-review after you push a fix:
+
+```
+## 🐛 Clud Bug review
+
+**This round:** 0 critical · 1 minor · 3 resolved from prior · 0 still open
+
+### Findings
+…
+```
+
+- **critical** — new critical findings in this review (these are what strict mode gates on)
+- **minor** — non-critical findings (suggestions / nits)
+- **resolved from prior** — prior unresolved threads the bot just cleared because it verified your fix in the diff
+- **still open** — prior threads whose issue is still standing
+
+Same format every time; zero values are always present so the line is easy to scan and parse.
+
 ## Manual install (advanced)
 
 If you don't want to use the CLI, you can install a generic workflow by hand:

--- a/docs/decisions-branches/feat__review-status-block.md
+++ b/docs/decisions-branches/feat__review-status-block.md
@@ -1,0 +1,11 @@
+## 2026-05-18 11:18 - Status block at the top of every clud-bug review (issue #43 item 1)
+
+**Reasoning:** Fixed format with all four counters always present (including zeros) is grep-able and machine-parseable. Other agents reading the comment can extract 'resolved from prior' programmatically without parsing free-form prose.
+
+**Alternatives considered:** Markdown table — rejected as visually heavy for a one-line summary. The single-line ' · ' separator is dense but scannable., Only show non-zero counters — rejected because consumers (other agents) parse this; omitted fields would force them to handle a variable-shape format. Fixed shape is the boring-but-correct call.
+
+**Implications:**
+- Edit applied across all four prompt sites (3 templates + this repo's clud-bug-review.yml). New installs get it via clud-bug init; existing repos pick it up on clud-bug update (which re-renders from templates).
+- If future review variants need additional counters, extend the line with new ' · key: N' fields — existing parsers that only care about the original four still work.
+
+---

--- a/docs/decisions-branches/feat__review-status-block.md
+++ b/docs/decisions-branches/feat__review-status-block.md
@@ -5,7 +5,9 @@
 **Alternatives considered:** Markdown table — rejected as visually heavy for a one-line summary. The single-line ' · ' separator is dense but scannable., Only show non-zero counters — rejected because consumers (other agents) parse this; omitted fields would force them to handle a variable-shape format. Fixed shape is the boring-but-correct call.
 
 **Implications:**
-- Edit applied across all four prompt sites (3 templates + this repo's clud-bug-review.yml). New installs get it via clud-bug init; existing repos pick it up on clud-bug update (which re-renders from templates).
+- Edit applied across the 3 prompt templates (workflow.yml.tmpl, -ts, -py) with identical status-block instructions across all three to avoid drift between languages. The repo's own rendered workflow file (.github/workflows/clud-bug-review.yml) was originally in scope but dropped from this PR after commit a7f6816 — claude-code-action refuses to run on PRs that modify its own workflow file ('Workflow validation failed' 401), and bundling the workflow edit broke the clud-bug-review check. The repo's workflow gets the same prompt edit in a follow-up isolated PR (the `clud-bug edit-workflow` pattern), or naturally via the next `clud-bug update` run that re-renders from templates.
+- Strict-mode header interaction clarified in the prompt — the status block follows whichever H2 variant is in use ("— critical findings" / "— clean" / bare). Without this, an LLM following the new instruction literally in a strict-mode repo could drop the status block or revert to the bare header and break the strict-mode gate.
+- New installs get the status block via clud-bug init writing the templated workflow.
 - If future review variants need additional counters, extend the line with new ' · key: N' fields — existing parsers that only care about the original four still work.
 
 ---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-18** — Status block at the top of every clud-bug review (issue #43 item 1) *(feat/review-status-block)* — [decisions-branches/feat__review-status-block.md](decisions-branches/feat__review-status-block.md)
 - **2026-05-15** — Adopt logmind v0.2 derived-file architecture (drop aggregator workflow) *(feat/logmind-0.2.0)* — [decisions-branches/feat__logmind-0.2.0.md](decisions-branches/feat__logmind-0.2.0.md)
 - **2026-05-15** — Collapse npm-dist-tag into npm-publish (single TP entry covers both) *(ci/unify-publish-and-promote)* — [decisions-branches/ci__unify-publish-and-promote.md](decisions-branches/ci__unify-publish-and-promote.md)
 - **2026-05-15** — Add npm-dist-tag workflow as the recovery seam for out-of-order publishes *(ci/npm-dist-tag-promote)* — [decisions-branches/ci__npm-dist-tag-promote.md](decisions-branches/ci__npm-dist-tag-promote.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -118,22 +118,34 @@ jobs:
 
               **This round:** N critical · N minor · N resolved from prior · N still open
 
-            The four counters (always include all four, even when 0):
+            This applies to BOTH the bare "## 🐛 Clud Bug review" header
+            and the strict-mode variants ("— critical findings" /
+            "— clean"). The status line goes on the next non-empty line
+            regardless of which header you used. Do not omit the H2
+            header variant in strict mode just to fit the status line —
+            the strict-mode gate reads the H2 line and would break.
+
+            The four counters (always include all four, even when 0 —
+            fixed format is grep-able and lets agents reading the
+            comment parse it deterministically):
               • critical            — count of NEW critical findings
-                                      in this review (strict-mode-gated)
+                                      in this review (the ones strict
+                                      mode gates on)
               • minor               — count of non-critical findings
+                                      (suggestions / nits / observations)
               • resolved from prior — count of prior unresolved threads
-                                      YOU (claude[bot]) just resolved
-                                      on this pass (the loop-closing
-                                      signal — tells the author the
-                                      bot read their fixes)
+                                      YOU (claude[bot]) just resolved on
+                                      this pass via resolveReviewThread
+                                      (the loop-closing signal — this
+                                      tells the author the bot read
+                                      their fixes)
               • still open          — count of prior unresolved threads
                                       whose issue still stands AFTER
                                       this pass
 
-            On a first-time review both "resolved from prior" and "still
-            open" are 0. After fix-pushes, "resolved from prior" is
-            typically positive.
+            On a first-time review, "resolved from prior" and "still
+            open" are both 0. On follow-up reviews after a fix-push,
+            "resolved from prior" should typically be positive.
 
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -113,6 +113,28 @@ jobs:
 
               ## 🐛 Clud Bug review
 
+            Immediately after the H2 header — on the next non-empty
+            line — emit a status block in this exact format:
+
+              **This round:** N critical · N minor · N resolved from prior · N still open
+
+            The four counters (always include all four, even when 0):
+              • critical            — count of NEW critical findings
+                                      in this review (strict-mode-gated)
+              • minor               — count of non-critical findings
+              • resolved from prior — count of prior unresolved threads
+                                      YOU (claude[bot]) just resolved
+                                      on this pass (the loop-closing
+                                      signal — tells the author the
+                                      bot read their fixes)
+              • still open          — count of prior unresolved threads
+                                      whose issue still stands AFTER
+                                      this pass
+
+            On a first-time review both "resolved from prior" and "still
+            open" are 0. After fix-pushes, "resolved from prior" is
+            typically positive.
+
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"
 

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -114,6 +114,28 @@ jobs:
 
               ## 🐛 Clud Bug review
 
+            Immediately after the H2 header — on the next non-empty
+            line — emit a status block in this exact format:
+
+              **This round:** N critical · N minor · N resolved from prior · N still open
+
+            The four counters (always include all four, even when 0):
+              • critical            — count of NEW critical findings
+                                      in this review (strict-mode-gated)
+              • minor               — count of non-critical findings
+              • resolved from prior — count of prior unresolved threads
+                                      YOU (claude[bot]) just resolved
+                                      on this pass (the loop-closing
+                                      signal — tells the author the
+                                      bot read their fixes)
+              • still open          — count of prior unresolved threads
+                                      whose issue still stands AFTER
+                                      this pass
+
+            On a first-time review both "resolved from prior" and "still
+            open" are 0. After fix-pushes, "resolved from prior" is
+            typically positive.
+
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"
 

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -119,22 +119,34 @@ jobs:
 
               **This round:** N critical · N minor · N resolved from prior · N still open
 
-            The four counters (always include all four, even when 0):
+            This applies to BOTH the bare "## 🐛 Clud Bug review" header
+            and the strict-mode variants ("— critical findings" /
+            "— clean"). The status line goes on the next non-empty line
+            regardless of which header you used. Do not omit the H2
+            header variant in strict mode just to fit the status line —
+            the strict-mode gate reads the H2 line and would break.
+
+            The four counters (always include all four, even when 0 —
+            fixed format is grep-able and lets agents reading the
+            comment parse it deterministically):
               • critical            — count of NEW critical findings
-                                      in this review (strict-mode-gated)
+                                      in this review (the ones strict
+                                      mode gates on)
               • minor               — count of non-critical findings
+                                      (suggestions / nits / observations)
               • resolved from prior — count of prior unresolved threads
-                                      YOU (claude[bot]) just resolved
-                                      on this pass (the loop-closing
-                                      signal — tells the author the
-                                      bot read their fixes)
+                                      YOU (claude[bot]) just resolved on
+                                      this pass via resolveReviewThread
+                                      (the loop-closing signal — this
+                                      tells the author the bot read
+                                      their fixes)
               • still open          — count of prior unresolved threads
                                       whose issue still stands AFTER
                                       this pass
 
-            On a first-time review both "resolved from prior" and "still
-            open" are 0. After fix-pushes, "resolved from prior" is
-            typically positive.
+            On a first-time review, "resolved from prior" and "still
+            open" are both 0. On follow-up reviews after a fix-push,
+            "resolved from prior" should typically be positive.
 
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -134,6 +134,33 @@ jobs:
 
               ## 🐛 Clud Bug review
 
+            Immediately after the H2 header — on the next non-empty
+            line — emit a status block in this exact format:
+
+              **This round:** N critical · N minor · N resolved from prior · N still open
+
+            The four counters (always include all four, even when 0 —
+            fixed format is grep-able and lets agents reading the
+            comment parse it deterministically):
+              • critical            — count of NEW critical findings
+                                      in this review (the ones strict
+                                      mode gates on)
+              • minor               — count of non-critical findings
+                                      (suggestions / nits / observations)
+              • resolved from prior — count of prior unresolved threads
+                                      YOU (claude[bot]) just resolved on
+                                      this pass via resolveReviewThread
+                                      (the loop-closing signal — this
+                                      tells the author the bot read
+                                      their fixes)
+              • still open          — count of prior unresolved threads
+                                      whose issue still stands AFTER
+                                      this pass
+
+            On a first-time review, "resolved from prior" and "still
+            open" are both 0. On follow-up reviews after a fix-push,
+            "resolved from prior" should typically be positive.
+
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"
 

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -139,6 +139,13 @@ jobs:
 
               **This round:** N critical · N minor · N resolved from prior · N still open
 
+            This applies to BOTH the bare "## 🐛 Clud Bug review" header
+            and the strict-mode variants ("— critical findings" /
+            "— clean"). The status line goes on the next non-empty line
+            regardless of which header you used. Do not omit the H2
+            header variant in strict mode just to fit the status line —
+            the strict-mode gate reads the H2 line and would break.
+
             The four counters (always include all four, even when 0 —
             fixed format is grep-able and lets agents reading the
             comment parse it deterministically):


### PR DESCRIPTION
## Summary

Closes issue #43 item 1. Every Clud Bug review comment now begins with a fixed-format status line:

\`\`\`
## 🐛 Clud Bug review

**This round:** N critical · N minor · N resolved from prior · N still open

### Findings
…
\`\`\`

| Counter | Meaning |
|---|---|
| critical | NEW critical findings (strict-mode-gated) |
| minor | non-critical findings (suggestions / nits) |
| **resolved from prior** | prior unresolved threads the bot just cleared on this pass — **the loop-closing signal** |
| still open | prior threads whose issue still stands |

The important one is **resolved from prior**. Today an author who reads a re-review sees \"still broken\" rows and can't tell whether the bot is just listing new complaints or actually reading their fixes. The new field proves it.

## Format choices

- All four counters always present, **including zeros** → grep-able + machine-parseable. Other agents reading the comment can extract values reliably without handling variable-shape output.
- Single-line ' · ' separator → dense but scannable. Tried markdown table internally; visually heavier for a one-line summary.

## Scope

| File | Change |
|---|---|
| \`templates/workflow.yml.tmpl\` | Insert status-block requirement in the review prompt |
| \`templates/workflow-ts.yml.tmpl\` | Same |
| \`templates/workflow-py.yml.tmpl\` | Same |
| \`.github/workflows/clud-bug-review.yml\` | This repo's own workflow gets the edit too |
| \`README.md\` | New "Reading a review" subsection showing the format |
| \`CHANGELOG.md\` | \`[0.5.4]\` entry |
| \`package.json\` | 0.5.3 → 0.5.4 |

## Test plan

- [x] \`npm test\` — 91/91 still pass (prompt-only edit, no logic touched)
- [x] \`docs/timeline.md\` regenerated (v0.2 derived-file gate)
- [ ] On the next PR after merge: bot review starts with the status line. Visually verify.
- [ ] After tag-push: npm-publish workflow auto-publishes v0.5.4 → \`latest\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)