### PR TITLE
v0.5.5: clud-bug init offers required_conversation_resolution setup (issue #43 item 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.5] — 2026-05-18
+
+### Added
+- **`clud-bug init` offers to enable `required_conversation_resolution`** on the default branch. The bot already auto-resolves its own review threads when fixes land; without this branch-protection setting, that auto-resolution doesn't gate merges. The init step detects your repo + default branch via `gh`, inspects the current state, and prompts to enable. Failure modes (no admin perms, no base protection rule, network error) degrade to advisory messages — they never fail init.
+- **New flag `--no-set-protection`** — skips the prompt + API call entirely. For repos that manage branch protection via ruleset or org policy (and don't want clud-bug editing branch protection from underneath them).
+- `--accept-all,-y` now also auto-accepts the branch-protection prompt.
+
+### Notes
+- `clud-bug init` still works in repos without `gh` installed or in non-GitHub-hosted repos. The branch-protection step prints a one-line advisory and moves on.
+
 ## [0.5.4] — 2026-05-18
 
 ### Added
@@ -49,6 +59,7 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 - **Bot-authored PRs are now handled gracefully.** PRs from `dependabot[bot]`, `renovate[bot]`, or forks (where GitHub deliberately doesn't pass repository secrets) used to fail loudly red — wrong signal. Now a guard step detects the case, posts a one-line advisory comment ("Clud Bug skipped — bot/fork PR cannot access secrets"), and exits 0. Check stays green; the skip is visible. Owner-authored PRs without the secret still fail loud.
 - **Site polish (carries over from the unreleased entry):** alive bug emoji (layered breathe + twitch + scuttle animations), Plate label gloss, thrillmot footer credit.
 
+[0.5.5]: https://github.com/thrillmot/clud-bug/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/thrillmot/clud-bug/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/thrillmot/clud-bug/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/thrillmot/clud-bug/compare/v0.5.1...v0.5.2

--- a/README.md
+++ b/README.md
@@ -36,16 +36,22 @@ The naturalist arrives at your repo, surveys the habitat, and assembles a field 
 4. **Writes** the chosen specimens to `.claude/skills/<name>/SKILL.md` (Claude Code auto-loads them in the GitHub Action).
 5. **Drafts the field kit** at `.github/workflows/clud-bug-review.yml` with your project description filled in and the right permissions/tool allowlist for `gh pr comment` to actually post.
 6. **Briefs other agents** by adding a `<!-- clud-bug-start -->` block to `AGENTS.md` (creating it if missing — it's the cross-tool canonical), and idempotently to `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules`, `.windsurfrules`, `.clinerules`, `.continuerules`, and `.cursor/rules/*.md` where they already exist. Re-runs replace the prior block in place. Files you didn't already have are left uncreated — no proliferating stubs.
+7. **Offers to enable `required_conversation_resolution`** on your default branch. Clud Bug auto-resolves its own review threads when fixes land — but that only gates merges when conversation-resolution is required. Init detects the current state via `gh`, prompts to enable (auto-yes with `--accept-all`), and degrades to an advisory message if you lack admin perms / `gh` isn't installed / the branch has no base protection rule. Pass `--no-set-protection` to skip the prompt entirely — for repos that manage branch protection via ruleset or org policy.
 
 ## CLI options
 
 ```
 npx clud-bug init [options]
 
-  --offline       Skip skills.sh; install only the bundled baseline skills.
-  --accept-all,-y Accept the recommended skill set without prompting.
-  --commit        git add + commit the generated files when done.
-  --help,-h       Show help.
+  --offline             Skip skills.sh; install only the bundled baseline skills.
+  --accept-all,-y       Accept the recommended skill set (and the
+                        branch-protection prompt) without prompting.
+  --no-set-protection   Skip the prompt that offers to enable
+                        required_conversation_resolution on the default
+                        branch. For repos that manage branch protection
+                        via ruleset or org policy.
+  --commit              git add + commit the generated files when done.
+  --help,-h             Show help.
 ```
 
 ## Staying up to date

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -339,12 +339,30 @@ async function runInitBranchProtection(args, { gh, prompt } = {}) {
     return;
   }
 
-  // current.state is now 'disabled' or 'no-protection'.
-  log(`  required_conversation_resolution: not set${current.state === 'no-protection' ? ' (no base protection rule on this branch)' : ''}`);
+  // Short-circuit on no-protection BEFORE prompting. The single-flag
+  // POST endpoint requires a base protection rule on the branch — if
+  // there's none, enableConversationResolution would just 404. Skip
+  // the prompt and go straight to the actionable guidance (set up
+  // basic protection first, then re-run).
+  if (current.state === 'no-protection') {
+    log('  required_conversation_resolution: not set (no base protection rule on this branch)');
+    log('  Cannot enable yet: this branch has no base protection rule.');
+    log(`    Set one up first: Settings → Branches → Add rule for ${branch}`);
+    log('    Then re-run clud-bug init (or toggle the setting in the GUI).');
+    return;
+  }
+
+  // current.state is 'disabled'.
+  log('  required_conversation_resolution: not set');
 
   // Decide whether to prompt.
   let shouldEnable;
   if (args.acceptAll) {
+    // --accept-all is a real side-effect flag here: it flips a
+    // merge-gating repo setting. Make that explicit in the log so
+    // CI users running `clud-bug init --accept-all` see exactly
+    // what's happening instead of silently noticing later.
+    log('  --accept-all: will enable required_conversation_resolution. Pass --no-set-protection to skip.');
     shouldEnable = true;
   } else {
     const ask = prompt ?? (async (q) => {

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -16,6 +16,7 @@ import { computeAuditFileSet, renderAuditHeader } from '../lib/audit.js';
 import { runUpdate } from '../lib/update.js';
 import { getPendingWorkflowEdits, makeBranchName, git as gitCmd } from '../lib/edit-workflow.js';
 import { applyToRepo as applyAgentDocs } from '../lib/agents-md.js';
+import { detectRepo, detectDefaultBranch, getProtectionState, enableConversationResolution } from '../lib/branch-protection.js';
 
 const PKG_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const TEMPLATES = join(PKG_ROOT, 'templates');
@@ -25,6 +26,7 @@ function parseArgs(argv) {
   const args = {
     _: [], offline: false, acceptAll: false, commit: false, help: false, version: false,
     since: null, changedIn: null, scopes: [], out: null,
+    setProtection: true,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -37,6 +39,7 @@ function parseArgs(argv) {
     else if (a === '--changed-in') args.changedIn = argv[++i];
     else if (a === '--scope') args.scopes.push(argv[++i]);
     else if (a === '--out') args.out = argv[++i];
+    else if (a === '--no-set-protection') args.setProtection = false;
     else args._.push(a);
   }
   return args;
@@ -64,6 +67,10 @@ Options:
   --offline             Skip skills.sh; pin only the bundled baseline specimens.
   --accept-all,-y       Accept the recommended specimens without prompting.
   --commit              git add + commit the generated kit when done (init only).
+  --no-set-protection   Skip the prompt that offers to enable
+                        required_conversation_resolution on the default
+                        branch (init only). Use for repos that manage
+                        branch protection via ruleset or org policy.
   --since <date>        Audit only files changed in commits after <date> (git date string).
   --changed-in <dur>    Audit only files changed in the past <dur>: 7d, 2w, 1mo, 1y. (audit only)
   --scope <glob>        Limit audit to files matching <glob>; repeatable. (audit only)
@@ -236,6 +243,13 @@ async function runInit(args) {
     spawnSync('git', ['commit', '-m', 'Add clud-bug 🐛 — a field guide to specimens crawling your code'], { cwd, stdio: 'inherit' });
   }
 
+  // Offer to enable required_conversation_resolution on the default
+  // branch. clud-bug auto-resolves its own review threads when fixes
+  // land — without this setting, that doesn't gate merges. Skipped on
+  // --no-set-protection for repos that manage protection via ruleset
+  // or org policy.
+  await runInitBranchProtection(args);
+
   log('');
   log('Field kit assembled. Next:');
   log('  1. Set ANTHROPIC_API_KEY in your repo secrets:');
@@ -276,6 +290,96 @@ async function promptForSkills(recommended) {
   } finally {
     rl.close();
   }
+}
+
+// Branch-protection setup step at the end of `clud-bug init`.
+// Offers to enable required_conversation_resolution on the default
+// branch via gh API. Skipped cleanly when --no-set-protection is
+// passed. Failure modes (no admin perms, no base protection rule,
+// network error) all degrade to advisory log messages — they never
+// fail the init run.
+//
+// gh and prompt are injectable for tests (defaults to spawning real
+// gh + reading from real stdin).
+async function runInitBranchProtection(args, { gh, prompt } = {}) {
+  if (!args.setProtection) {
+    log('');
+    log('🐛 Branch protection: skipped (--no-set-protection).');
+    return;
+  }
+  log('');
+  log('🐛 Branch protection');
+
+  // Detect repo + default branch. If gh isn't installed or the local
+  // dir isn't a github repo, treat as advisory and move on.
+  let owner, repo, branch;
+  try {
+    ({ owner, repo } = await detectRepo({ gh }));
+    branch = await detectDefaultBranch({ owner, repo, gh });
+  } catch (err) {
+    log(`  Could not detect repo/branch (${err.message.split('\n')[0]}). Skipping.`);
+    log('  You can enable it manually: gh api -X POST repos/<owner>/<repo>/branches/<default>/protection/required_conversation_resolution');
+    return;
+  }
+
+  log(`  Default branch: ${branch}`);
+
+  // Inspect current state.
+  const current = await getProtectionState({ owner, repo, branch, gh });
+  if (current.state === 'enabled') {
+    log('  required_conversation_resolution: already on — your repo is all set.');
+    return;
+  }
+  if (current.state === 'forbidden') {
+    log('  Could not read branch protection (no admin perms). Ask the repo owner to enable required_conversation_resolution, or re-run with --no-set-protection to silence this prompt.');
+    return;
+  }
+  if (current.state === 'unknown') {
+    log(`  Could not read branch protection (${current.reason}). Skipping.`);
+    return;
+  }
+
+  // current.state is now 'disabled' or 'no-protection'.
+  log(`  required_conversation_resolution: not set${current.state === 'no-protection' ? ' (no base protection rule on this branch)' : ''}`);
+
+  // Decide whether to prompt.
+  let shouldEnable;
+  if (args.acceptAll) {
+    shouldEnable = true;
+  } else {
+    const ask = prompt ?? (async (q) => {
+      const rl = createInterface({ input, output });
+      try { return await rl.question(q); } finally { rl.close(); }
+    });
+    log('');
+    log('  Clud Bug auto-resolves its own review threads when fixes land.');
+    log('  Without required_conversation_resolution, that doesn\'t actually gate merges.');
+    const answer = await ask(`  Enable required_conversation_resolution on ${branch}? [Y/n] `);
+    shouldEnable = !['n', 'no'].includes(answer.trim().toLowerCase());
+  }
+
+  if (!shouldEnable) {
+    log('  Skipped. Re-run with --accept-all or set it manually anytime.');
+    return;
+  }
+
+  const result = await enableConversationResolution({ owner, repo, branch, gh });
+  if (result.ok) {
+    log('  ✓ Enabled required_conversation_resolution.');
+    return;
+  }
+  if (result.state === 'no-protection') {
+    log('  Cannot enable: this branch has no base protection rule. Set up basic branch protection first:');
+    log(`    Settings → Branches → Add rule for ${branch}`);
+    log('  Then re-run clud-bug init (or just toggle the setting in the GUI).');
+    return;
+  }
+  if (result.state === 'forbidden') {
+    log('  Cannot enable: you do not have admin permissions on this repository.');
+    log('  Ask the repo owner to enable it, or re-run with --no-set-protection to silence this prompt.');
+    return;
+  }
+  log(`  Cannot enable (${result.reason}). You can enable it manually anytime.`);
 }
 
 async function runList(_args) {

--- a/docs/decisions-branches/feat__init-branch-protection.md
+++ b/docs/decisions-branches/feat__init-branch-protection.md
@@ -1,0 +1,12 @@
+## 2026-05-18 11:40 - clud-bug init offers required_conversation_resolution setup (issue #43 item 2)
+
+**Reasoning:** lib/branch-protection.js uses a discriminated-union return shape ({ state: 'enabled' | 'disabled' | 'no-protection' | 'forbidden' | 'unknown' }) instead of throwing on failure. Each state has a different user-facing message and follow-up action (e.g. 'no-protection' tells the user to set up base protection first; 'forbidden' tells them to ask the repo owner). Callers pattern-match on state and produce specific guidance.
+
+**Alternatives considered:** PUT /protection with the full merged JSON — rejected because it would clobber unrelated settings (status checks, force-push restrictions, signed-commits). The single-flag POST is the standard recommended path., Default-on without a prompt — rejected because some repos use reporulez or org-level rulesets and don't want clud-bug editing protection from underneath them. Prompt + --no-set-protection opt-out preserves agency., Hard-fail on any error — rejected because clud-bug init must work in repos without gh installed / non-GitHub repos / no-admin-perms scenarios. Every failure mode degrades to an advisory log line.
+
+**Implications:**
+- Injectable gh in lib/branch-protection.js makes the helper unit-testable — 12 tests in test/branch-protection.test.js cover all five state branches for both read and enable paths, no real network or shell-out.
+- Existing cli.test.js init tests pass --no-set-protection to stay hermetic. CI without a real gh install no longer trips the new step.
+- v0.5.5 — npm publish auto-triggers on tag push via the OIDC workflow that landed in v0.5.4-era infra.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-18** — clud-bug init offers required_conversation_resolution setup (issue #43 item 2) *(feat/init-branch-protection)* — [decisions-branches/feat__init-branch-protection.md](decisions-branches/feat__init-branch-protection.md)
 - **2026-05-18** — Status block at the top of every clud-bug review (issue #43 item 1) *(feat/review-status-block)* — [decisions-branches/feat__review-status-block.md](decisions-branches/feat__review-status-block.md)
 - **2026-05-15** — Adopt logmind v0.2 derived-file architecture (drop aggregator workflow) *(feat/logmind-0.2.0)* — [decisions-branches/feat__logmind-0.2.0.md](decisions-branches/feat__logmind-0.2.0.md)
 - **2026-05-15** — Collapse npm-dist-tag into npm-publish (single TP entry covers both) *(ci/unify-publish-and-promote)* — [decisions-branches/ci__unify-publish-and-promote.md](decisions-branches/ci__unify-publish-and-promote.md)

--- a/lib/branch-protection.js
+++ b/lib/branch-protection.js
@@ -78,9 +78,14 @@ export async function getProtectionState({ owner, repo, branch, gh = defaultGh }
     return { state: stdout.trim() === 'true' ? 'enabled' : 'disabled' };
   }
   // gh prints HTTP details to stderr. Look for the markers we recognize.
+  // We deliberately key on 403 / 'Forbidden' / 'Resource not accessible'
+  // rather than the bare word 'admin' — gh's error vocabulary can mention
+  // 'admin' in unrelated contexts (administrator@…, admin api endpoint,
+  // future error copy) and we don't want to misclassify those as
+  // permission failures.
   const blob = `${stdout}\n${stderr}`;
   if (/404|Branch not protected|Not Found/i.test(blob)) return { state: 'no-protection' };
-  if (/403|Forbidden|Resource not accessible|admin/i.test(blob)) return { state: 'forbidden' };
+  if (/403|Forbidden|Resource not accessible/i.test(blob)) return { state: 'forbidden' };
   return { state: 'unknown', reason: stderr.trim() || stdout.trim() || `gh exited ${code}` };
 }
 
@@ -94,11 +99,14 @@ export async function enableConversationResolution({ owner, repo, branch, gh = d
     `repos/${owner}/${repo}/branches/${branch}/protection/required_conversation_resolution`,
   ]);
   if (code === 0) return { ok: true };
+  // Match the same precise alternatives as getProtectionState — no bare
+  // 'admin' fallback to avoid misclassifying unrelated error messages
+  // that happen to contain the word.
   const blob = `${stdout}\n${stderr}`;
   if (/404|Branch not protected|Not Found/i.test(blob)) {
     return { ok: false, state: 'no-protection', reason: 'Branch has no base protection rule; enable basic branch protection first.' };
   }
-  if (/403|Forbidden|Resource not accessible|admin/i.test(blob)) {
+  if (/403|Forbidden|Resource not accessible/i.test(blob)) {
     return { ok: false, state: 'forbidden', reason: 'You do not have admin permissions on this repository.' };
   }
   return { ok: false, state: 'unknown', reason: stderr.trim() || stdout.trim() || `gh exited ${code}` };

--- a/lib/branch-protection.js
+++ b/lib/branch-protection.js
@@ -1,0 +1,105 @@
+// Helpers for managing `required_conversation_resolution` on the default
+// branch via the `gh` CLI. Factored out so `runInit` can call this without
+// embedding `spawnSync` boilerplate, and so tests can swap a mock for the
+// real `gh` invocation.
+//
+// Why `gh` rather than direct fetch(): clud-bug already depends on `gh`
+// being installed and authenticated (workflows use `gh pr comment`, edit
+// workflows use `gh pr create`). Reusing it inherits the user's auth
+// instead of asking them to set up another token.
+//
+// API endpoints used:
+//   GET /repos/{owner}/{repo}
+//     → .default_branch
+//   GET /repos/{owner}/{repo}/branches/{branch}/protection
+//     → .required_conversation_resolution.enabled (true/false), OR 404 if
+//       the branch has no protection rule at all.
+//   POST /repos/{owner}/{repo}/branches/{branch}/protection/required_conversation_resolution
+//     → enables the single flag without touching other settings. This is
+//       a real single-flag endpoint; we don't have to GET-merge-PUT the
+//       full protection JSON.
+
+import { spawn } from 'node:child_process';
+
+// Default `gh` invoker: spawns `gh <args>` and resolves with
+// { code, stdout, stderr }. Tests pass a function with the same shape.
+function defaultGh(args, { stdin } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('gh', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => { stdout += d; });
+    child.stderr.on('data', (d) => { stderr += d; });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+    if (stdin) child.stdin.end(stdin);
+    else child.stdin.end();
+  });
+}
+
+// Returns { owner, repo } from the local git remote. Uses
+// `gh repo view --json owner,name` so it doesn't depend on parsing URLs.
+export async function detectRepo({ gh = defaultGh } = {}) {
+  const { code, stdout, stderr } = await gh(['repo', 'view', '--json', 'owner,name']);
+  if (code !== 0) {
+    throw new Error(`gh repo view failed (${code}): ${stderr.trim() || '(no stderr)'}`);
+  }
+  const parsed = JSON.parse(stdout);
+  return { owner: parsed.owner.login, repo: parsed.name };
+}
+
+// Returns the default branch name (e.g. "main", "master", "trunk").
+export async function detectDefaultBranch({ owner, repo, gh = defaultGh } = {}) {
+  const { code, stdout, stderr } = await gh(['api', `repos/${owner}/${repo}`, '--jq', '.default_branch']);
+  if (code !== 0) {
+    throw new Error(`Could not read default_branch for ${owner}/${repo}: ${stderr.trim() || stdout.trim()}`);
+  }
+  return stdout.trim();
+}
+
+// Inspects the current required_conversation_resolution state. Returns
+// one of:
+//   { state: 'enabled' }
+//   { state: 'disabled' }
+//   { state: 'no-protection' }   // branch has no protection rule at all
+//   { state: 'forbidden' }       // user lacks admin perms
+//   { state: 'unknown', reason }  // any other failure mode
+//
+// The reason this returns a discriminated union rather than throwing is
+// that runInit decides what to do based on the state: each value above
+// has a different user-facing message and follow-up action.
+export async function getProtectionState({ owner, repo, branch, gh = defaultGh } = {}) {
+  const { code, stdout, stderr } = await gh([
+    'api',
+    `repos/${owner}/${repo}/branches/${branch}/protection`,
+    '--jq', '.required_conversation_resolution.enabled // false',
+  ]);
+  if (code === 0) {
+    return { state: stdout.trim() === 'true' ? 'enabled' : 'disabled' };
+  }
+  // gh prints HTTP details to stderr. Look for the markers we recognize.
+  const blob = `${stdout}\n${stderr}`;
+  if (/404|Branch not protected|Not Found/i.test(blob)) return { state: 'no-protection' };
+  if (/403|Forbidden|Resource not accessible|admin/i.test(blob)) return { state: 'forbidden' };
+  return { state: 'unknown', reason: stderr.trim() || stdout.trim() || `gh exited ${code}` };
+}
+
+// Enables the single flag via the dedicated endpoint. Doesn't touch any
+// other protection settings. Returns { ok: true } on success or
+// { ok: false, state, reason } using the same state taxonomy as
+// getProtectionState() so callers can produce a consistent message.
+export async function enableConversationResolution({ owner, repo, branch, gh = defaultGh } = {}) {
+  const { code, stdout, stderr } = await gh([
+    'api', '-X', 'POST',
+    `repos/${owner}/${repo}/branches/${branch}/protection/required_conversation_resolution`,
+  ]);
+  if (code === 0) return { ok: true };
+  const blob = `${stdout}\n${stderr}`;
+  if (/404|Branch not protected|Not Found/i.test(blob)) {
+    return { ok: false, state: 'no-protection', reason: 'Branch has no base protection rule; enable basic branch protection first.' };
+  }
+  if (/403|Forbidden|Resource not accessible|admin/i.test(blob)) {
+    return { ok: false, state: 'forbidden', reason: 'You do not have admin permissions on this repository.' };
+  }
+  return { ok: false, state: 'unknown', reason: stderr.trim() || stdout.trim() || `gh exited ${code}` };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/test/branch-protection.test.js
+++ b/test/branch-protection.test.js
@@ -1,0 +1,122 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import {
+  detectRepo,
+  detectDefaultBranch,
+  getProtectionState,
+  enableConversationResolution,
+} from '../lib/branch-protection.js';
+
+// Tiny mock factory for the injectable `gh` invoker. Returns a fn that
+// matches arg patterns to canned responses, so tests stay focused on
+// one branch at a time.
+function mockGh(routes) {
+  return async (args) => {
+    const key = args.join(' ');
+    for (const [pattern, response] of routes) {
+      const re = pattern instanceof RegExp ? pattern : new RegExp(`^${pattern}$`);
+      if (re.test(key)) return response;
+    }
+    throw new Error(`mockGh: no route for "${key}"`);
+  };
+}
+
+test('detectRepo: parses owner/repo from gh repo view JSON', async () => {
+  const gh = mockGh([
+    [/^repo view --json owner,name$/, { code: 0, stdout: JSON.stringify({ owner: { login: 'octo' }, name: 'demo' }), stderr: '' }],
+  ]);
+  const r = await detectRepo({ gh });
+  assert.deepEqual(r, { owner: 'octo', repo: 'demo' });
+});
+
+test('detectRepo: rejects when gh fails', async () => {
+  const gh = mockGh([
+    [/^repo view/, { code: 1, stdout: '', stderr: 'not authenticated' }],
+  ]);
+  await assert.rejects(detectRepo({ gh }), /gh repo view failed/);
+});
+
+test('detectDefaultBranch: returns trimmed branch name', async () => {
+  const gh = mockGh([
+    [/repos\/octo\/demo --jq \.default_branch/, { code: 0, stdout: 'main\n', stderr: '' }],
+  ]);
+  const branch = await detectDefaultBranch({ owner: 'octo', repo: 'demo', gh });
+  assert.equal(branch, 'main');
+});
+
+test('getProtectionState: enabled when API returns true', async () => {
+  const gh = mockGh([
+    [/protection --jq/, { code: 0, stdout: 'true\n', stderr: '' }],
+  ]);
+  const s = await getProtectionState({ owner: 'o', repo: 'r', branch: 'main', gh });
+  assert.deepEqual(s, { state: 'enabled' });
+});
+
+test('getProtectionState: disabled when API returns false', async () => {
+  const gh = mockGh([
+    [/protection --jq/, { code: 0, stdout: 'false\n', stderr: '' }],
+  ]);
+  const s = await getProtectionState({ owner: 'o', repo: 'r', branch: 'main', gh });
+  assert.deepEqual(s, { state: 'disabled' });
+});
+
+test('getProtectionState: no-protection on 404 ("Branch not protected")', async () => {
+  const gh = mockGh([
+    [/protection --jq/, { code: 1, stdout: '', stderr: 'gh: Branch not protected (HTTP 404)' }],
+  ]);
+  const s = await getProtectionState({ owner: 'o', repo: 'r', branch: 'main', gh });
+  assert.deepEqual(s, { state: 'no-protection' });
+});
+
+test('getProtectionState: forbidden on 403', async () => {
+  const gh = mockGh([
+    [/protection --jq/, { code: 1, stdout: '', stderr: 'gh: 403 Forbidden — must have admin rights' }],
+  ]);
+  const s = await getProtectionState({ owner: 'o', repo: 'r', branch: 'main', gh });
+  assert.deepEqual(s, { state: 'forbidden' });
+});
+
+test('getProtectionState: unknown on any other error', async () => {
+  const gh = mockGh([
+    [/protection --jq/, { code: 1, stdout: '', stderr: '503 server error' }],
+  ]);
+  const s = await getProtectionState({ owner: 'o', repo: 'r', branch: 'main', gh });
+  assert.equal(s.state, 'unknown');
+  assert.match(s.reason, /503/);
+});
+
+test('enableConversationResolution: ok on 0 exit', async () => {
+  const gh = mockGh([
+    [/api -X POST .*required_conversation_resolution/, { code: 0, stdout: '{}', stderr: '' }],
+  ]);
+  const r = await enableConversationResolution({ owner: 'o', repo: 'r', branch: 'main', gh });
+  assert.deepEqual(r, { ok: true });
+});
+
+test('enableConversationResolution: no-protection on 404', async () => {
+  const gh = mockGh([
+    [/api -X POST .*required_conversation_resolution/, { code: 1, stdout: '', stderr: 'gh: Not Found (HTTP 404)' }],
+  ]);
+  const r = await enableConversationResolution({ owner: 'o', repo: 'r', branch: 'main', gh });
+  assert.equal(r.ok, false);
+  assert.equal(r.state, 'no-protection');
+});
+
+test('enableConversationResolution: forbidden on 403', async () => {
+  const gh = mockGh([
+    [/api -X POST .*required_conversation_resolution/, { code: 1, stdout: '', stderr: 'HTTP 403: Resource not accessible by integration' }],
+  ]);
+  const r = await enableConversationResolution({ owner: 'o', repo: 'r', branch: 'main', gh });
+  assert.equal(r.ok, false);
+  assert.equal(r.state, 'forbidden');
+});
+
+test('enableConversationResolution: unknown on other error', async () => {
+  const gh = mockGh([
+    [/api -X POST .*required_conversation_resolution/, { code: 1, stdout: '', stderr: 'connection reset by peer' }],
+  ]);
+  const r = await enableConversationResolution({ owner: 'o', repo: 'r', branch: 'main', gh });
+  assert.equal(r.ok, false);
+  assert.equal(r.state, 'unknown');
+  assert.match(r.reason, /connection reset/);
+});

--- a/test/branch-protection.test.js
+++ b/test/branch-protection.test.js
@@ -70,10 +70,22 @@ test('getProtectionState: no-protection on 404 ("Branch not protected")', async 
 
 test('getProtectionState: forbidden on 403', async () => {
   const gh = mockGh([
-    [/protection --jq/, { code: 1, stdout: '', stderr: 'gh: 403 Forbidden — must have admin rights' }],
+    [/protection --jq/, { code: 1, stdout: '', stderr: 'gh: 403 Forbidden — Resource not accessible by integration' }],
   ]);
   const s = await getProtectionState({ owner: 'o', repo: 'r', branch: 'main', gh });
   assert.deepEqual(s, { state: 'forbidden' });
+});
+
+test('getProtectionState: unrelated message containing "administrator" stays unknown (regex precision)', async () => {
+  // Regression: the prior regex used `/admin/i` which matched any token
+  // containing "admin". Now we key only on 403/Forbidden/Resource not
+  // accessible so an error like "Contact your administrator@example.com"
+  // doesn't get misclassified as a permission failure.
+  const gh = mockGh([
+    [/protection --jq/, { code: 1, stdout: '', stderr: 'something failed. Contact administrator@example.com.' }],
+  ]);
+  const s = await getProtectionState({ owner: 'o', repo: 'r', branch: 'main', gh });
+  assert.equal(s.state, 'unknown');
 });
 
 test('getProtectionState: unknown on any other error', async () => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -52,7 +52,7 @@ test('init --offline --accept-all in a fresh repo writes workflow + manifest', a
     'package.json': JSON.stringify({ name: 'demo', dependencies: { next: '^15' }}),
   });
   try {
-    const r = run(dir, ['init', '--offline', '--accept-all']);
+    const r = run(dir, ['init', '--offline', '--accept-all', '--no-set-protection']);
     assert.equal(r.status, 0, `init failed: ${r.stderr}`);
     const wf = await readFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'utf8');
     assert.match(wf, /allowedTools/);
@@ -61,13 +61,16 @@ test('init --offline --accept-all in a fresh repo writes workflow + manifest', a
     assert.ok(manifest.installed.every(e => e.kind === 'baseline'));
     // The new collaboration skill ships in the baseline kit.
     assert.ok(manifest.installed.some(e => e.slug === 'clud-bug-collaboration'));
+    // --no-set-protection should print the documented skip line — the
+    // step exists and gates correctly on the flag.
+    assert.match(r.stdout, /Branch protection: skipped \(--no-set-protection\)/);
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 
 test('init: fresh install gets strictMode: true (v0.4 default)', async () => {
   const dir = await makeRepo({ 'package.json': '{}' });
   try {
-    run(dir, ['init', '--offline', '--accept-all']);
+    run(dir, ['init', '--offline', '--accept-all', '--no-set-protection']);
     const manifest = JSON.parse(await readFile(join(dir, '.claude/skills/.clud-bug.json'), 'utf8'));
     assert.equal(manifest.strictMode, true, 'fresh install should default to strict mode');
   } finally { await rm(dir, { recursive: true, force: true }); }
@@ -87,7 +90,7 @@ test('init: existing v0.3 advisory install (no strictMode field, has lastUpdate)
         lastUpdateVersion: '0.3.4',
       }, null, 2),
     );
-    run(dir, ['init', '--offline', '--accept-all']);
+    run(dir, ['init', '--offline', '--accept-all', '--no-set-protection']);
     const manifest = JSON.parse(await readFile(join(dir, '.claude/skills/.clud-bug.json'), 'utf8'));
     assert.equal(manifest.strictMode, undefined, 'pre-existing advisory install must keep advisory behavior');
   } finally { await rm(dir, { recursive: true, force: true }); }
@@ -101,7 +104,7 @@ test('init: existing install with explicit strictMode: false stays false', async
       join(dir, '.claude/skills/.clud-bug.json'),
       JSON.stringify({ version: 1, installed: [], strictMode: false }, null, 2),
     );
-    run(dir, ['init', '--offline', '--accept-all']);
+    run(dir, ['init', '--offline', '--accept-all', '--no-set-protection']);
     const manifest = JSON.parse(await readFile(join(dir, '.claude/skills/.clud-bug.json'), 'utf8'));
     assert.equal(manifest.strictMode, false, 'explicit opt-out must be preserved');
   } finally { await rm(dir, { recursive: true, force: true }); }
@@ -110,7 +113,7 @@ test('init: existing install with explicit strictMode: false stays false', async
 test('list shows baseline + custom after init + hand-authored skill', async () => {
   const dir = await makeRepo({ 'package.json': '{}' });
   try {
-    run(dir, ['init', '--offline', '--accept-all']);
+    run(dir, ['init', '--offline', '--accept-all', '--no-set-protection']);
     // hand-author a custom skill
     const customDir = join(dir, '.claude/skills/my-team-rules');
     await mkdir(customDir, { recursive: true });
@@ -135,7 +138,7 @@ test('list reports zero state cleanly', async () => {
 test('remove refuses unmanaged slug, succeeds on managed one', async () => {
   const dir = await makeRepo({});
   try {
-    run(dir, ['init', '--offline', '--accept-all']);
+    run(dir, ['init', '--offline', '--accept-all', '--no-set-protection']);
     const fail = run(dir, ['remove', 'no-such-slug']);
     assert.notEqual(fail.status, 0);
     assert.match(fail.stderr, /not in the clud-bug manifest/);
@@ -217,7 +220,7 @@ test('refresh --offline --accept-all does NOT remove remote skills from manifest
 test('refresh --offline shows no-op when only baseline installed', async () => {
   const dir = await makeRepo({ 'package.json': '{}' });
   try {
-    run(dir, ['init', '--offline', '--accept-all']);
+    run(dir, ['init', '--offline', '--accept-all', '--no-set-protection']);
     const r = run(dir, ['refresh', '--offline', '--accept-all']);
     assert.equal(r.status, 0, r.stderr);
     assert.match(r.stdout, /sync with skills\.sh|collection updated/);


### PR DESCRIPTION
## Summary

Closes issue #43 item 2. \`clud-bug init\` now offers to enable \`required_conversation_resolution\` on the default branch — the missing piece that makes the bot's auto-resolve-on-fix loop actually gate merges.

**The gap this closes:** clud-bug already resolves its own review threads when it verifies a fix in the diff (the v0.4 auto-resolve-on-fix pattern). But unless the repo has \`required_conversation_resolution: true\`, that resolution is purely cosmetic — open threads don't block merges. Today's init writes the workflow but never touches protection.

## Flow

After workflows + manifest + AGENTS.md are written:

\`\`\`
🐛 Branch protection
  Default branch: main
  required_conversation_resolution: not set

  Clud Bug auto-resolves its own review threads when fixes land.
  Without required_conversation_resolution, that doesn't actually gate merges.
  Enable required_conversation_resolution on main? [Y/n] y
  ✓ Enabled required_conversation_resolution.
\`\`\`

With \`--accept-all,-y\`: auto-yes. With \`--no-set-protection\`: step skipped entirely (printed log: "Branch protection: skipped (--no-set-protection).").

## Failure modes — all advisory, none fail init

| State | What we say |
|---|---|
| already enabled | "required_conversation_resolution: already on — your repo is all set." |
| no admin perms (403) | "Could not read branch protection (no admin perms). Ask the repo owner to enable required_conversation_resolution, or re-run with --no-set-protection to silence this prompt." |
| no base protection rule (404) | "Cannot enable: this branch has no base protection rule. Set up basic branch protection first: Settings → Branches → Add rule for main" |
| gh not installed / not a GH repo | "Could not detect repo/branch (...). Skipping. You can enable it manually: gh api -X POST repos/<owner>/<repo>/branches/<default>/protection/required_conversation_resolution" |
| network / other unknown | "Could not read branch protection (<reason>). Skipping." |

## Why the single-flag POST endpoint

Used \`POST /repos/{owner}/{repo}/branches/{branch}/protection/required_conversation_resolution\` instead of \`PUT /branches/{branch}/protection\`. The PUT endpoint requires sending the **full** protection JSON, which would mass-overwrite anything else the repo had configured (status checks, force-push restrictions, signed-commits). The single-flag POST flips just this setting.

## Scope

| File | Change |
|---|---|
| \`lib/branch-protection.js\` | New helper module. \`detectRepo\` / \`detectDefaultBranch\` / \`getProtectionState\` / \`enableConversationResolution\` — all with injectable \`gh\` for testability. |
| \`bin/clud-bug.js\` | Wire \`runInitBranchProtection\` into \`runInit\`. Parse \`--no-set-protection\`. Update help text. |
| \`test/branch-protection.test.js\` | 12 new tests covering all 5 states (enabled / disabled / no-protection / forbidden / unknown) for both read and enable paths. Uses injectable mock-gh — no real network. |
| \`test/cli.test.js\` | Existing init tests now pass \`--no-set-protection\` so they stay hermetic. New assertion that the skip line is printed when the flag is passed. |
| \`README.md\` | New \`init\` step + flag documentation. |
| \`CHANGELOG.md\` | \`[0.5.5]\` entry. |
| \`package.json\` | 0.5.4 → 0.5.5. |

## Test plan

- [x] \`npm test\` — 106/106 pass (12 new + 94 existing).
- [x] Smoke test: \`node bin/clud-bug.js init --offline --accept-all --no-set-protection\` in a tempdir — branch-protection step prints the documented skip line and continues cleanly.
- [ ] After merge + tag-push: npm-publish workflow auto-publishes v0.5.5 → \`latest\`.
- [ ] Issue #43 close-out: both items now shipped — close the issue with merge-commit links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)