### PR TITLE
Docs polish: 401 framing, fork-PR YAML example, custom-skill example (P2 + P5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,20 +164,64 @@ If you want clud-bug to review fork PRs too, you have two options:
 1. **Maintainer re-pushes the branch** to your repo as a non-fork branch, and the review runs.
 2. **Switch the trigger to `pull_request_target`** (advanced) — this gives the workflow access to secrets but runs against the *base* ref, not the PR's code. To safely review the PR's actual code, follow [`anthropics/claude-code-action` security.md](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md): check out the PR head into a **subdirectory** (not the workspace root) and pass it via `--add-dir`. Skipping this is a code-execution risk.
 
-clud-bug's generated workflow uses `pull_request` by default. If you understand the trade-offs, edit the trigger yourself.
+Concretely, the safe shape:
+
+```yaml
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  clud-bug-review:
+    steps:
+      - uses: actions/checkout@v6  # base ref — trusted
+      - uses: actions/checkout@v6  # PR head — UNTRUSTED, into a subdir
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-head
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_args: --add-dir pr-head
+          # ... rest of args
+```
+
+The key invariant: the base checkout (with secrets in scope) lives at the workspace root; the PR head (untrusted user code) only ever lives in a subdirectory the action explicitly opts into via `--add-dir`. Any deviation — checking out the PR head at the root, running `npm install` from the subdir, etc. — re-opens the code-execution risk.
+
+clud-bug's generated workflow uses `pull_request` (not `pull_request_target`) by default. If you understand the trade-offs and want to handle fork PRs, edit the trigger yourself using the shape above.
 
 ## When you edit the workflow
 
-clud-bug uses [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action), which **refuses to run when the PR being reviewed modifies the action's own workflow file**. That's a security guard against PRs that try to neuter the reviewer or exfiltrate secrets via prompt injection. If you edit `.github/workflows/clud-bug-review.yml` (or any clud-bug workflow), expect this check to fail with a 401 — `App token exchange failed: Workflow validation failed`. That's the documented behavior, not a bug. Merge the workflow change in isolation, and subsequent PRs work normally.
+> **TL;DR:** if you see `App token exchange failed: Workflow validation failed (401)` on a PR that edits a clud-bug workflow file, that's **expected and protective** — not a bug in your PR. Read on.
 
-To make this easier, `clud-bug edit-workflow` packages the workflow change into a clean PR for you:
+clud-bug uses [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action), which **refuses to run when the PR being reviewed modifies the action's own workflow file**. That's a security guard: without it, a PR could neuter the reviewer or exfiltrate secrets via prompt injection in the workflow file itself.
+
+### What you'll see
+
+When you push a PR that touches `.github/workflows/clud-bug-review.yml` (or any other clud-bug workflow):
+
+- The `clud-bug-review` check fails with `App token exchange failed: 401 Unauthorized — Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.`
+- You'll get a GitHub email titled something like **"[thrillmot/your-repo] Run failed: Clud Bug 🐛 Crawls Your Code — `<branch-name>`"** — same wording for every workflow failure, so it doesn't visually distinguish "this is the expected self-mod guard" from "real failure."
+
+### How to merge
+
+If the PR contains **only** workflow edits, this is the expected path:
+
+1. A maintainer reviews the diff directly (the bot can't).
+2. Merge via admin override (`gh pr merge --admin` or the "Merge without waiting for requirements" button) — the failing `clud-bug-review` check is the bot refusing to review *itself*, not a real defect.
+3. Subsequent PRs on the new workflow work normally — the validation gate compares against `main`, so once your edit is on `main`, the gate passes.
+
+If the PR contains workflow edits **mixed with other code changes**, split them. The bot can't review either half while the workflow edit is in the diff, so any real findings get masked.
+
+### The helper command
+
+`clud-bug edit-workflow` packages the workflow change into a clean PR for you, refusing to run if your working tree has any non-workflow changes:
 
 ```bash
 # Edit .github/workflows/clud-bug-*.yml as you like, then:
 clud-bug edit-workflow
 ```
 
-The command refuses to run if your working tree has any non-workflow changes — keeping the PR scoped to just the workflow edit.
+This keeps the merge ceremony scoped to just the workflow edit.
 
 ## Verifying it works
 

--- a/docs/decisions-branches/site__docs-polish-p2-p5.md
+++ b/docs/decisions-branches/site__docs-polish-p2-p5.md
@@ -1,0 +1,11 @@
+## 2026-05-18 12:56 - Docs polish per audit P2 + P5: 401 framing, fork-PR YAML, custom-skill example
+
+**Reasoning:** Three concrete improvements caught in the audit prompt that close real understandability gaps: (1) the 401 self-mod-protection error is reframed from 'workflow validation failed' generic-doom to a TL;DR 'expected and protective' explanation that names the exact email subject users will see, so they don't panic when the workflow-failure email lands. (2) The fork-PR pull_request_target workaround was previously named in 1 line — now has the concrete YAML shape with the load-bearing invariant called out (base ref at root, PR head only in subdir). (3) The clud-bug-collaboration skill's 'write evidence-anchored guidance' instruction was abstract — now ships with a concrete db-query-review example showing the bad/good code pair format.
+
+**Alternatives considered:** Verbose section-rewrites rather than scoped edits — rejected, the existing sections are mostly fine; only the framing and one missing example were the actual gaps. Targeted edits leave the existing scannable structure intact.
+
+**Implications:**
+- Custom-skill example will likely become the canonical 'how to write a custom skill' reference. If we add more guidance later it should mirror the same evidence-anchored shape (specific paths, bad/good code pairs, instructions on what to quote).
+- Fork-PR YAML example uses actions/checkout@v6 (Stream S α.1 is bumping to v6 in the next PR). README will be consistent with templates after both PRs merge.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-18** — Docs polish per audit P2 + P5: 401 framing, fork-PR YAML, custom-skill example *(site/docs-polish-p2-p5)* — [decisions-branches/site__docs-polish-p2-p5.md](decisions-branches/site__docs-polish-p2-p5.md)
 - **2026-05-18** — clud-bug init offers required_conversation_resolution setup (issue #43 item 2) *(feat/init-branch-protection)* — [decisions-branches/feat__init-branch-protection.md](decisions-branches/feat__init-branch-protection.md)
 - **2026-05-18** — Status block at the top of every clud-bug review (issue #43 item 1) *(feat/review-status-block)* — [decisions-branches/feat__review-status-block.md](decisions-branches/feat__review-status-block.md)
 - **2026-05-15** — Adopt logmind v0.2 derived-file architecture (drop aggregator workflow) *(feat/logmind-0.2.0)* — [decisions-branches/feat__logmind-0.2.0.md](decisions-branches/feat__logmind-0.2.0.md)

--- a/templates/skills/baseline/clud-bug-collaboration.md
+++ b/templates/skills/baseline/clud-bug-collaboration.md
@@ -76,7 +76,7 @@ move the bot's behavior.
 Don't write generic prose like "be careful with database code." That's
 not actionable. Instead, anchor to specific files + behaviors:
 
-```markdown
+````markdown
 ---
 name: db-query-review
 description: How to review changes under lib/db/. Always flag missing parameterization, N+1 query patterns, and missing transaction boundaries on multi-statement writes.
@@ -113,7 +113,7 @@ apply these rules:
 Cite the specific line. "This is a SQL injection risk" alone isn't
 enough — quote the unsafe interpolation directly and propose the
 parameterized alternative.
-```
+````
 
 That's what "evidence-anchored" looks like: specific file paths, runnable
 code examples for both bad and good, and explicit instructions on what

--- a/templates/skills/baseline/clud-bug-collaboration.md
+++ b/templates/skills/baseline/clud-bug-collaboration.md
@@ -71,6 +71,55 @@ When you write a custom skill, follow the SKILL.md frontmatter format
 Generic advice gets ignored; rules with examples and quoted-line evidence
 move the bot's behavior.
 
+### Example: a good custom skill
+
+Don't write generic prose like "be careful with database code." That's
+not actionable. Instead, anchor to specific files + behaviors:
+
+```markdown
+---
+name: db-query-review
+description: How to review changes under lib/db/. Always flag missing parameterization, N+1 query patterns, and missing transaction boundaries on multi-statement writes.
+---
+
+# Reviewing lib/db/ changes
+
+When the diff touches `lib/db/queries.ts` or any file under `lib/db/`,
+apply these rules:
+
+## Always flag
+
+1. **SQL string interpolation** — anything that builds a query via `+`,
+   template literals, or `string.format` rather than parameterized
+   queries. Example to flag:
+
+   ```ts
+   // BAD — flag this
+   db.query(`SELECT * FROM users WHERE id = ${userId}`)
+   // GOOD — uses parameterization
+   db.query('SELECT * FROM users WHERE id = ?', [userId])
+   ```
+
+2. **N+1 patterns** — flag any `await` inside a `for`/`map` loop that
+   calls `db.query` or `db.queryOne`. The fix is usually a single
+   `WHERE id IN (...)` query or a join.
+
+3. **Multi-statement writes without `db.transaction`** — if a diff
+   adds two or more `db.query` calls that all write, demand a
+   transaction wrapper. Quote the lines.
+
+## Style of finding
+
+Cite the specific line. "This is a SQL injection risk" alone isn't
+enough — quote the unsafe interpolation directly and propose the
+parameterized alternative.
+```
+
+That's what "evidence-anchored" looks like: specific file paths, runnable
+code examples for both bad and good, and explicit instructions on what
+to quote in the finding. The bot loads this and uses it as concrete
+review criteria, not vague guidance.
+
 ## When you edit `.github/workflows/clud-bug-*.yml`
 
 `anthropics/claude-code-action` **refuses to run on PRs that modify its


### PR DESCRIPTION
Closes audit items P2 and P5.

**README:**
- 'When you edit the workflow' section: TL;DR-first ('this is expected and protective'), names the exact error message + GitHub email subject so first-time hitters recognize it, splits merge ceremony into a numbered list
- 'Fork PR caveat' section: adds a 3-line YAML example of the safe `pull_request_target` + subdirectory-checkout pattern, with the load-bearing invariant called out (base ref at root, PR head only in subdir)

**templates/skills/baseline/clud-bug-collaboration.md:**
- New 'Example: a good custom skill' subsection mirroring evidence-based-review's bad/good code-pair format. Concrete `db-query-review` example with specific file paths, runnable code, and instructions on what to quote. Demonstrates 'evidence-anchored guidance' rather than just naming the concept.

No code touched. No version bump — templates change ships via npm when next user runs `clud-bug update`, no version pin needed.

(Audit P4 + P6 were already-shipped — coverage exists in test/skills.test.js and test/update.test.js. P3 deferred — real but nuanced. P0/P1 ship next in Stream S.)