### PR TITLE
v0.5.6: actions/checkout@v5 → @v6, drop FORCE_JAVASCRIPT shim, add Bash(git show:*) (P0 + P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.6] — 2026-05-18
+
+### Changed
+- **Bumped `actions/checkout@v5` → `@v6`** in all 5 workflow templates (`workflow.yml.tmpl`, `workflow-ts`, `workflow-py`, `audit.yml.tmpl`, `self-update.yml.tmpl`). v6 ships with Node 24 natively, so the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` shim that v5 needed (a workaround for Node 20 deprecation) is gone. Net -10 lines across the templates; one less workaround future maintainers won't understand.
+
+### Added
+- **`Bash(git show:*)`** added to the `--allowedTools` list in `workflow.yml.tmpl` + `workflow-ts.yml.tmpl` + `workflow-py.yml.tmpl`. Defensive — the bot doesn't currently need `git show` (the strict-mode gate uses it from a separate shell step, not inside `claude-code-action`), but future prompt enhancements that read base-ref state from inside the action would silently fail without it.
+
 ## [0.5.5] — 2026-05-18
 
 ### Added
@@ -59,6 +67,7 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 - **Bot-authored PRs are now handled gracefully.** PRs from `dependabot[bot]`, `renovate[bot]`, or forks (where GitHub deliberately doesn't pass repository secrets) used to fail loudly red — wrong signal. Now a guard step detects the case, posts a one-line advisory comment ("Clud Bug skipped — bot/fork PR cannot access secrets"), and exits 0. Check stays green; the skip is visible. Owner-authored PRs without the secret still fail loud.
 - **Site polish (carries over from the unreleased entry):** alive bug emoji (layered breathe + twitch + scuttle animations), Plate label gloss, thrillmot footer credit.
 
+[0.5.6]: https://github.com/thrillmot/clud-bug/compare/v0.5.5...v0.5.6
 [0.5.5]: https://github.com/thrillmot/clud-bug/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/thrillmot/clud-bug/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/thrillmot/clud-bug/compare/v0.5.2...v0.5.3

--- a/docs/decisions-branches/feat__checkout-v6-templates.md
+++ b/docs/decisions-branches/feat__checkout-v6-templates.md
@@ -1,0 +1,11 @@
+## 2026-05-18 12:59 - Bump actions/checkout v5 to v6, drop FORCE_JAVASCRIPT shim, defensive git show in allowlist
+
+**Reasoning:** Bash(git show:*) added defensively. The bot doesn't currently need it — the strict-mode gate runs git show from a separate shell step at workflow level (where shell access is unrestricted), not from inside claude-code-action. Audit P1 noted this as 'future-proofing only.' Cheap to bundle since we're already editing the allowlist.
+
+**Alternatives considered:** Keep v5 + the env shim — rejected because v6 has been GA for weeks, the shim was always a transitional measure, and shipping templates with dead workarounds confuses future maintainers., Drop git show entirely from the audit since the bot doesn't need it today — rejected because it's a single tiny addition that's defensive against a plausible future need. Asymmetric: cheap now, expensive to debug 'why does the bot fail silently when I add git show to the prompt?' later.
+
+**Implications:**
+- This repo's own workflow files (clud-bug-review.yml, claude-code-review.yml, npm-publish.yml) still pin v5 + FORCE shim. They get the same treatment in a separate isolated PR (Stream S α.2) using clud-bug edit-workflow to dodge the self-mod gate.
+- Existing user repos pick up the template change on their next clud-bug update run (or when self-update workflow opens an automated PR).
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-18** — Bump actions/checkout v5 to v6, drop FORCE_JAVASCRIPT shim, defensive git show in allowlist *(feat/checkout-v6-templates)* — [decisions-branches/feat__checkout-v6-templates.md](decisions-branches/feat__checkout-v6-templates.md)
 - **2026-05-18** — clud-bug init offers required_conversation_resolution setup (issue #43 item 2) *(feat/init-branch-protection)* — [decisions-branches/feat__init-branch-protection.md](decisions-branches/feat__init-branch-protection.md)
 - **2026-05-18** — Status block at the top of every clud-bug review (issue #43 item 1) *(feat/review-status-block)* — [decisions-branches/feat__review-status-block.md](decisions-branches/feat__review-status-block.md)
 - **2026-05-15** — Adopt logmind v0.2 derived-file architecture (drop aggregator workflow) *(feat/logmind-0.2.0)* — [decisions-branches/feat__logmind-0.2.0.md](decisions-branches/feat__logmind-0.2.0.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/templates/audit.yml.tmpl
+++ b/templates/audit.yml.tmpl
@@ -28,14 +28,11 @@ permissions:
   pull-requests: write
   id-token: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0   # full history needed for git --since
 
@@ -96,7 +93,6 @@ jobs:
         env:
           AUDIT_DATE: ${{ steps.prep.outputs.date }}
           AUDIT_BRANCH: ${{ steps.prep.outputs.branch }}
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true

--- a/templates/self-update.yml.tmpl
+++ b/templates/self-update.yml.tmpl
@@ -19,14 +19,11 @@ permissions:
   contents: write
   pull-requests: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v5
         with:

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -13,7 +13,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0   # strict-mode gate reads base ref's manifest
 
@@ -51,12 +51,11 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -13,7 +13,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0   # strict-mode gate reads base ref's manifest
 
@@ -51,12 +51,11 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -13,7 +13,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # fetch-depth: 0 so the strict-mode gate can `git show
           # origin/<base_ref>:.claude/skills/.clud-bug.json` to read the base
@@ -75,12 +75,11 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 


### PR DESCRIPTION
Closes audit P0 + P1.

**P0: checkout@v5 → @v6 + drop FORCE_JAVASCRIPT_ACTIONS_TO_NODE24**

v6 ships with Node 24 natively. v5 required the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` env shim to force the older v5 (still on Node 20 default) onto Node 24 during the Node 20 deprecation window. v6 makes the shim dead weight.

Edited across all 5 templates:
- `templates/workflow.yml.tmpl`
- `templates/workflow-ts.yml.tmpl`
- `templates/workflow-py.yml.tmpl`
- `templates/audit.yml.tmpl`
- `templates/self-update.yml.tmpl`

Net **−10 lines** across templates; removed both the env-var line and (where it was the only env) the surrounding `env:` block.

**P1: `Bash(git show:*)` in allowedTools**

Added to `workflow.yml.tmpl` + `-ts` + `-py` variants. Defensive — the bot doesn't currently need git show (the strict-mode gate runs it from a separate shell step at workflow level), but a future prompt enhancement that reads base-ref state from inside `claude-code-action` would silently fail without this. Cheap to add now while editing the allowlist anyway.

**Not in this PR (separate, isolated, with self-mod ceremony):**

This repo's own `.github/workflows/clud-bug-review.yml`, `claude-code-review.yml`, `npm-publish.yml` still pin v5 + FORCE shim. Editing them in this PR would trigger claude-code-action's 401 self-mod protection. They get the same treatment in a follow-up isolated PR via `clud-bug edit-workflow`.

**Audit items intentionally skipped:**

| Item | Why |
|---|---|
| P3 (`gh pr comment` verification) | Real gap, defer until it bites — nuanced 'bot exited silently because nothing critical' vs 'bot legitimately failed' distinction |
| P4 (offline skills.sh test coverage) | Already shipped — `test/skills.test.js` has three offline tests (network-error throw, 404, empty body) |
| P6 (`clud-bug update` AGENTS.md churn) | Already shipped — `lib/agents-md.js:upsertBlock` is byte-equal idempotent; `test/update.test.js:runUpdate: no-ops when files already match latest` confirms |

**Test plan:**
- [x] `npm test` — 107/107 pass
- [x] `grep -rn 'actions/checkout@v5' templates/` — no matches
- [x] `grep -rn 'FORCE_JAVASCRIPT' templates/` — no matches
- [x] Rendered templates validate as YAML (manual sed-render)
- [ ] After tag-push: npm-publish workflow auto-publishes v0.5.6 → `latest`