### PR TITLE
Workflows: sync repo's .github/workflows/ with v0.5.6 template change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version: '20'
@@ -18,7 +18,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version: '20'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -36,7 +36,6 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -36,6 +36,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0   # strict-mode gate reads base ref's manifest
 
@@ -51,12 +51,11 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(cat .claude/skills/.clud-bug.json)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json)"
           prompt: |
             This project is "clud-bug". Claude Code PR review GitHub Action with project-aware skills auto-discovered from skills.sh. It's primarily javascript.
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -76,9 +76,6 @@ jobs:
     permissions:
       contents: read
       id-token: write    # OIDC for npm Trusted Publishing + provenance
-    env:
-      # See clud-bug-review.yml for the rationale on this env var.
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - name: Validate dispatch inputs
         # Guard the workflow_dispatch path. The 'tag' input had to drop
@@ -99,7 +96,7 @@ jobs:
           fi
 
       - name: Checkout the tag
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # On tag push, github.ref is refs/tags/vX.Y.Z (correct).
           # On workflow_dispatch (publish mode), inputs.tag is now
@@ -137,8 +134,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/setup-node@v5
         with:

--- a/docs/decisions-branches/workflow__checkout-v6-repo.md
+++ b/docs/decisions-branches/workflow__checkout-v6-repo.md
@@ -1,0 +1,11 @@
+## 2026-05-18 13:12 - Sync repo workflow files with v0.5.6 template change (checkout v6, drop FORCE shim)
+
+**Reasoning:** Bundling 4 workflow file edits in a single PR rather than 4 separate PRs because they all share the same self-mod 401 failure mode and admin-merge ceremony — splitting wouldn't reduce risk, just multiply ceremony.
+
+**Alternatives considered:** Wait for next clud-bug update to auto-sync — rejected, that would mean clud-bug v0.5.6's auto-update workflow opens a PR with the same content + same self-mod failure mode + still needs admin merge. Same ceremony, longer delay., Skip Bash(git show:*) on the repo's clud-bug-review.yml since the bot doesn't currently need it — rejected, keeping the rendered workflow byte-equivalent to the template (post-render placeholder substitution) is the simplest drift-prevention story.
+
+**Implications:**
+- After merge: the workflow files are in sync with templates. Next clud-bug update on this repo should produce zero diff for these files.
+- clud-bug-review will fail by design on this PR (the bot refusing to review its own workflow edit). Merging requires admin override; documented in README 'When you edit the workflow' section.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-18** — Sync repo workflow files with v0.5.6 template change (checkout v6, drop FORCE shim) *(workflow/checkout-v6-repo)* — [decisions-branches/workflow__checkout-v6-repo.md](decisions-branches/workflow__checkout-v6-repo.md)
 - **2026-05-18** — Bump actions/checkout v5 to v6, drop FORCE_JAVASCRIPT shim, defensive git show in allowlist *(feat/checkout-v6-templates)* — [decisions-branches/feat__checkout-v6-templates.md](decisions-branches/feat__checkout-v6-templates.md)
 - **2026-05-18** — Docs polish per audit P2 + P5: 401 framing, fork-PR YAML, custom-skill example *(site/docs-polish-p2-p5)* — [decisions-branches/site__docs-polish-p2-p5.md](decisions-branches/site__docs-polish-p2-p5.md)
 - **2026-05-18** — clud-bug init offers required_conversation_resolution setup (issue #43 item 2) *(feat/init-branch-protection)* — [decisions-branches/feat__init-branch-protection.md](decisions-branches/feat__init-branch-protection.md)


### PR DESCRIPTION
Mirror of v0.5.6 (PR #48 / commit `67ed953`) into this repo's rendered workflow files. Templates landed first; this PR syncs the repo to match so they don't drift.

## Scope

| File | Change |
|---|---|
| `ci.yml` | `actions/checkout@v5` → `@v6` (both jobs; no FORCE shim there) |
| `claude-code-review.yml` | checkout v6 + drop `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` |
| `clud-bug-review.yml` | checkout v6 + drop FORCE + add `Bash(git show:*)` to the allowedTools allowlist (matches template) |
| `npm-publish.yml` | checkout v6 + drop both top-level `env:` blocks (publish job + promote-tag job each had FORCE as the only env var) |

**Not touched:** `check-decisions.yml`, `check-doc-links.yml`, `regen-timeline.yml` — logmind-owned, pinned at `actions/checkout@v4`, managed upstream.

## ⚠️ Self-mod ceremony

This PR modifies `.github/workflows/clud-bug-review.yml`. `claude-code-action` refuses to run on PRs that touch its own workflow file (401 `Workflow validation failed`) — that's documented + expected. The `clud-bug-review` check will fail by design.

**Merge plan:**
1. Wait for the non-bot checks (test, actionlint, check-decisions, check-derived-docs, check-links) to pass.
2. Merge via `gh pr merge --admin` since `clud-bug-review` will be red by design.
3. Subsequent PRs work normally — the validation gate compares against `main`, so once this lands on `main` the gate passes against the new workflow.

## After merge

Plan continues: Stream U step 3 — delete classic branch protection. The ruleset (already applied earlier this session) is enforcing all 6 contexts; classic is redundant.