### PR TITLE
claude-code-review.yml: checkout v6 + drop FORCE shim (2/2)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -36,7 +36,6 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true

--- a/docs/decisions-branches/workflow__checkout-v6-claude-baseline.md
+++ b/docs/decisions-branches/workflow__checkout-v6-claude-baseline.md
@@ -1,0 +1,10 @@
+## 2026-05-18 13:23 - Part 2 of v0.5.6 workflow sync: claude-code-review.yml (separate PR for per-bot review coverage)
+
+**Reasoning:** This PR is the second half. clud-bug-review will fully review since clud-bug-review.yml is untouched here. claude-review fails self-mod by design (it's reviewing its own workflow edit) — admin-bypassed via temporary ruleset disable, same pattern as PR #49.
+
+**Alternatives considered:** Add a bypass_actor to the ruleset permanently (RepositoryAdmin) — rejected because it would let admin force-merge ANY ruleset violation, not just self-mod. Self-mod is a known/expected failure mode; broader admin bypass increases the failure surface.
+
+**Implications:**
+- After this merges, this repo's .github/workflows/ files are fully synced with v0.5.6 templates. Next clud-bug update should produce zero diff for any of those files.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-18** — Part 2 of v0.5.6 workflow sync: claude-code-review.yml (separate PR for per-bot review coverage) *(workflow/checkout-v6-claude-baseline)* — [decisions-branches/workflow__checkout-v6-claude-baseline.md](decisions-branches/workflow__checkout-v6-claude-baseline.md)
 - **2026-05-18** — Sync repo workflow files with v0.5.6 template change (checkout v6, drop FORCE shim) *(workflow/checkout-v6-repo)* — [decisions-branches/workflow__checkout-v6-repo.md](decisions-branches/workflow__checkout-v6-repo.md)
 - **2026-05-18** — Bump actions/checkout v5 to v6, drop FORCE_JAVASCRIPT shim, defensive git show in allowlist *(feat/checkout-v6-templates)* — [decisions-branches/feat__checkout-v6-templates.md](decisions-branches/feat__checkout-v6-templates.md)
 - **2026-05-18** — Docs polish per audit P2 + P5: 401 framing, fork-PR YAML, custom-skill example *(site/docs-polish-p2-p5)* — [decisions-branches/site__docs-polish-p2-p5.md](decisions-branches/site__docs-polish-p2-p5.md)


### PR DESCRIPTION
Part 2 of the v0.5.6 template sync that PR #49 split out. This PR touches **only** `claude-code-review.yml`.

| Bot | Outcome |
|---|---|
| `clud-bug-review` (runs in `clud-bug-review.yml`) | **Should fully review** — its own workflow file isn't touched here |
| `claude-review` (runs in `claude-code-review.yml`) | **Fails by design** — it's reviewing the very file this PR edits (self-mod 401) |

Same admin-bypass ceremony as PR #49 — temporarily disable the ruleset, admin-merge, re-enable.

After this lands: workflow files are fully in sync with v0.5.6 templates. Next `clud-bug update` on this repo should produce zero diff for any of those files.