### PR TITLE
feat(templates): add clud-bug-template-version markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`# clud-bug-template-version: v1` markers** in every shipped workflow template (`workflow.yml.tmpl`, `workflow-ts`, `workflow-py`, `audit.yml.tmpl`, `self-update.yml.tmpl`). Inert today — purely informational. Enables future idempotent-refresh logic in `runUpdate`: a v0.5.8+ release can detect "this workflow is from clud-bug v1 templates" vs "user has customized this workflow" and refresh only the former without clobbering customizations. Same pattern logmind shipped in v0.2.1.
+
+### Pending (separate PR)
+- Pinning `anthropics/claude-code-action@v1` via `{{CCA_VERSION}}` placeholder substitution. Requires routing `audit.yml.tmpl` + `self-update.yml.tmpl` through `renderFile` (currently raw `readFile`).
+
 ## [0.5.6] — 2026-05-18
 
 ### Changed

--- a/templates/audit.yml.tmpl
+++ b/templates/audit.yml.tmpl
@@ -1,3 +1,4 @@
+# clud-bug-template-version: v1
 name: Clud Bug 🐛 Audit
 
 # A scheduled / on-demand walk through the whole habitat (or a recent slice).

--- a/templates/self-update.yml.tmpl
+++ b/templates/self-update.yml.tmpl
@@ -1,3 +1,4 @@
+# clud-bug-template-version: v1
 name: Clud Bug 🐛 Self-Update
 
 # Weekly check for a newer published clud-bug. If one exists, runs

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -1,3 +1,4 @@
+# clud-bug-template-version: v1
 name: Clud Bug 🐛 Crawls Your Code
 
 on:

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -1,3 +1,4 @@
+# clud-bug-template-version: v1
 name: Clud Bug 🐛 Crawls Your Code
 
 on:

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -1,3 +1,4 @@
+# clud-bug-template-version: v1
 name: Clud Bug 🐛 Crawls Your Code
 
 on:


### PR DESCRIPTION
## Summary
Adds \`# clud-bug-template-version: v1\` header to each of the 5 shipped workflow templates. Markers are inert today — purely informational.

## Why
Enables future idempotent-refresh in \`runUpdate\`: a follow-up release can detect "this workflow is from clud-bug v1 templates" vs "user has customized this workflow" and refresh only the former without clobbering customizations.

Same pattern logmind shipped in v0.2.1 (\`# logmind-template-version: vN\` headers + idempotent refresh mode).

## What's NOT in this PR
- \`anthropics/claude-code-action\` version pinning via \`{{CCA_VERSION}}\` placeholder substitution. Requires routing \`audit.yml.tmpl\` + \`self-update.yml.tmpl\` through \`renderFile\` (currently raw \`readFile\`). Separate PR.
- Behavior change in \`runUpdate\` — it still rewrites on diff (existing behavior preserved). The marker just gives future updates a hook.

## Test plan
- [x] All 107 existing tests pass
- [x] Markers visible in \`templates/*.yml.tmpl\` head -3 output

## Closes
Architectural gap C (structural prerequisite) from the 5-repo seamless-updates plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)