### PR TITLE
feat: skill routing via review_mode + per-skill review output (v0.5.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 ### Pending (separate PR)
 - Pinning `anthropics/claude-code-action@v1` via `{{CCA_VERSION}}` placeholder substitution. Requires routing `audit.yml.tmpl` + `self-update.yml.tmpl` through `renderFile` (currently raw `readFile`).
 
+## [0.5.9] — 2026-05-18
+
+### Added — Stream BB.1 + BB.2 (skill routing + per-skill review output)
+
+- **`review_mode` frontmatter field on skills.** Every SKILL.md can declare `review_mode: shared` or `review_mode: dedicated` (default: `shared` when omitted). The four shipped baselines (`critical-issues-only`, `evidence-based-review`, `respect-existing-conventions`, `clud-bug-collaboration`) now declare `review_mode: shared`. Domain skills published in [thrillmot/agent-skills](https://github.com/thrillmot/agent-skills) (`brand-voice-review`, `api-contract-enforcement`, `pii-and-compliance`, `test-discipline`) declare `review_mode: dedicated`.
+- **`readReviewMode(content)` + `partitionByReviewMode(skills)` in `lib/skills.js`** — parsing + bucketing helpers. Single source of truth that the upcoming v0.6 GitHub App will reuse to route literal parallel Claude calls.
+- **Per-skill review output structure.** The workflow prompt now requires:
+  - A `### Per-skill scan` block under the status line — one line per loaded skill, even silent ones. Forces the bot to acknowledge each skill explicitly (anti-dilution for shared skills, visibility for dedicated ones).
+  - Dedicated H3 sections (`### Brand voice [brand-voice-review]`) for each dedicated-mode skill that produced findings.
+  - Shared-mode skill findings stay in the existing combined Critical/Minor buckets (preserves cross-correlation).
+
+### Changed
+
+- **Template marker bumped `v2` → `v3`** in `workflow.yml.tmpl`, `workflow-ts.yml.tmpl`, `workflow-py.yml.tmpl`. Existing v2 installs auto-upgrade via v0.5.7's refresh-mode on the next `clud-bug update`.
+
+### Architecture note
+
+v0.5.9 ships the user-visible BB.1+BB.2 behavior via prompt restructuring inside the existing single `claude-code-action` call — same one-Claude-call cost model. The v0.6 GitHub App will use the same `review_mode` metadata to route to literal parallel API calls (one shared + N dedicated, per the locked architecture decision). The frontmatter contract is identical across both runtimes.
+
 ## [0.5.8] — 2026-05-18
 
 ### Added
@@ -91,6 +110,7 @@ Installs predating PR #52 have markerless workflows. The first `clud-bug update`
 - **Bot-authored PRs are now handled gracefully.** PRs from `dependabot[bot]`, `renovate[bot]`, or forks (where GitHub deliberately doesn't pass repository secrets) used to fail loudly red — wrong signal. Now a guard step detects the case, posts a one-line advisory comment ("Clud Bug skipped — bot/fork PR cannot access secrets"), and exits 0. Check stays green; the skip is visible. Owner-authored PRs without the secret still fail loud.
 - **Site polish (carries over from the unreleased entry):** alive bug emoji (layered breathe + twitch + scuttle animations), Plate label gloss, thrillmot footer credit.
 
+[0.5.9]: https://github.com/thrillmot/clud-bug/compare/v0.5.8...v0.5.9
 [0.5.8]: https://github.com/thrillmot/clud-bug/compare/v0.5.7...v0.5.8
 [0.5.7]: https://github.com/thrillmot/clud-bug/compare/v0.5.6...v0.5.7
 [0.5.6]: https://github.com/thrillmot/clud-bug/compare/v0.5.5...v0.5.6

--- a/docs/decisions-branches/feat__skill-routing-v0.5.9.md
+++ b/docs/decisions-branches/feat__skill-routing-v0.5.9.md
@@ -1,0 +1,11 @@
+## 2026-05-18 17:49 - Stream BB.1+BB.2: skill routing via review_mode + per-skill review output (v0.5.9)
+
+**Reasoning:** Locked option-D-unified architecture from the v0.6 plan: skills declare review_mode in frontmatter (shared = bundled, dedicated = focused section). v0.5.9 ships the user-visible behavior via prompt restructuring inside the existing single claude-code-action call - same one-Claude-call cost model. v0.6 App will use same metadata for literal parallel API calls. Single source of truth across both runtimes.
+
+**Alternatives considered:** Implement literal parallel Claude calls in v0.5.9 workflow (matrix-style job per dedicated skill) - rejected: massive workflow-template restructuring for a prompt-level concern. v0.6 App is the right place since it controls API calls directly., Skip review_mode entirely until v0.6 - rejected: the metadata IS the contract. Authors can start declaring review_mode now; runtime semantics arrive in v0.6 transparently. Defers no work, blocks nothing.
+
+**Implications:**
+- Bumps template marker v2 -> v3. Existing v2 installs (post-v0.5.8) auto-upgrade via refresh-mode on next clud-bug update. This repo own clud-bug-review.yml is v2 - the post-merge self-update workflow OR a follow-up clud-bug update PR will refresh it to v3 (no self-mod ceremony needed since refresh-mode now handles versioned files).
+- The 4 baseline skills in templates/skills/baseline/ now declare review_mode: shared. agent-skills repo already has the 4 dedicated-mode skills (brand-voice-review, api-contract-enforcement, pii-and-compliance, test-discipline) from PR #9. The skill-routing contract is now end-to-end across both repos.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-18** — Stream BB.1+BB.2: skill routing via review_mode + per-skill review output (v0.5.9) *(feat/skill-routing-v0.5.9)* — [decisions-branches/feat__skill-routing-v0.5.9.md](decisions-branches/feat__skill-routing-v0.5.9.md)
 - **2026-05-18** — Self-mod ceremony: render v2 templates into this repo own clud-bug-review.yml *(feat/render-v2-templates-self-mod)* — [decisions-branches/feat__render-v2-templates-self-mod.md](decisions-branches/feat__render-v2-templates-self-mod.md)
 - **2026-05-18** — Stream Y: extract strict-mode gate into a composite GitHub Action (v0.5.8) *(feat/composite-strict-mode-gate)* — [decisions-branches/feat__composite-strict-mode-gate.md](decisions-branches/feat__composite-strict-mode-gate.md)
 - **2026-05-18** — Implement clud-bug update refresh-mode using template-version markers (v0.5.7) *(feat/update-refresh-mode)* — [decisions-branches/feat__update-refresh-mode.md](decisions-branches/feat__update-refresh-mode.md)

--- a/lib/skills.js
+++ b/lib/skills.js
@@ -348,4 +348,52 @@ function sanitizeSlug(name) {
   return name.toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '');
 }
 
+// Extract the `review_mode` field from a SKILL.md's frontmatter.
+//
+// Contract (from the v0.6 plan, option D-unified):
+//   - `shared`    → the skill loads alongside other shared skills in ONE
+//                   Claude call. Bug-finding baselines + most skills.sh
+//                   contributions live here; they benefit from cross-
+//                   correlation (an evidence-based finding flagged for
+//                   critical-issues-only also gets the convention check).
+//   - `dedicated` → the skill gets its OWN focused Claude call. Reserved
+//                   for domain-specific skills (brand voice, compliance,
+//                   API-contract) where attention dilution at high skill
+//                   counts is the real failure mode.
+//   - Missing field → default to `shared`. Conservative: the skill loads,
+//                   no surprise per-skill API cost. Users opt skills INTO
+//                   `dedicated` by authoring the field.
+//
+// The CLI runtime (v0.5.9) honors this via prompt restructuring inside a
+// single claude-code-action call. The v0.6 GitHub App will use the same
+// field to route to literal parallel API calls. Single source of truth.
+export function readReviewMode(skillContent) {
+  if (typeof skillContent !== 'string') return 'shared';
+  // Scope to the YAML frontmatter block (between the first two `---` lines).
+  // A `review_mode:` line in the body is documentation, not configuration.
+  const fm = skillContent.match(/^---\n([\s\S]*?)\n---/);
+  if (!fm) return 'shared';
+  const m = fm[1].match(/^review_mode:\s*(\S+)\s*$/m);
+  if (!m) return 'shared';
+  const value = m[1].toLowerCase();
+  return value === 'dedicated' ? 'dedicated' : 'shared';
+}
+
+// Partition a set of loaded skills into {shared, dedicated} buckets per
+// each skill's review_mode frontmatter. Expects skills with a `content`
+// field (SKILL.md text). Skills without content default to `shared`.
+//
+// Shape: input is the same skill objects produced by loadBaseline /
+// writeSkills / listInstalled. Output is two arrays of the same shape;
+// caller decides what to do with each bucket.
+export function partitionByReviewMode(skills) {
+  const shared = [];
+  const dedicated = [];
+  for (const skill of skills) {
+    const mode = readReviewMode(skill?.content);
+    (mode === 'dedicated' ? dedicated : shared).push(skill);
+  }
+  return { shared, dedicated };
+}
+
 export const _internal = { normalizeList, sanitizeSlug, entryKey, MAX_SKILLS, API_BASE, MANIFEST_FILE };

--- a/lib/skills.js
+++ b/lib/skills.js
@@ -375,7 +375,11 @@ export function readReviewMode(skillContent) {
   if (!fm) return 'shared';
   const m = fm[1].match(/^review_mode:\s*(\S+)\s*$/m);
   if (!m) return 'shared';
-  const value = m[1].toLowerCase();
+  // Strip optional YAML string-quotes — `review_mode: "dedicated"` and
+  // `review_mode: 'dedicated'` are both valid YAML, but the (\S+) capture
+  // grabs the quotes too. Without this, quoted forms silently fell back
+  // to `shared` even though the author clearly meant dedicated.
+  const value = m[1].toLowerCase().replace(/^["']|["']$/g, '');
   return value === 'dedicated' ? 'dedicated' : 'shared';
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/templates/skills/baseline/clud-bug-collaboration.md
+++ b/templates/skills/baseline/clud-bug-collaboration.md
@@ -1,6 +1,7 @@
 ---
 name: clud-bug-collaboration
 description: How Claude Code agents working in a clud-bug-installed repo should interact with the bot's review threads, strict-mode gate, and skill set. Use this skill whenever you're about to push a commit, address a clud-bug PR review comment, edit anything under .claude/skills/, modify .github/workflows/clud-bug-*.yml, or wonder why a PR check is red. Also use when planning work in a repo that has a `clud-bug-review` workflow installed — even if the user didn't mention clud-bug by name.
+review_mode: shared
 ---
 
 # Working in a clud-bug-installed repo

--- a/templates/skills/baseline/critical-issues-only.md
+++ b/templates/skills/baseline/critical-issues-only.md
@@ -1,6 +1,7 @@
 ---
 name: critical-issues-only
 description: PR review discipline - flag only correctness, security, and performance issues. Skip nits.
+review_mode: shared
 ---
 
 # Critical issues only

--- a/templates/skills/baseline/evidence-based-review.md
+++ b/templates/skills/baseline/evidence-based-review.md
@@ -1,6 +1,7 @@
 ---
 name: evidence-based-review
 description: Every PR review claim must quote the specific code being criticized. No hand-waving.
+review_mode: shared
 ---
 
 # Evidence-based review

--- a/templates/skills/baseline/respect-existing-conventions.md
+++ b/templates/skills/baseline/respect-existing-conventions.md
@@ -1,6 +1,7 @@
 ---
 name: respect-existing-conventions
 description: Don't suggest changes that fight the codebase's established patterns. Match what's already there.
+review_mode: shared
 ---
 
 # Respect existing conventions

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -56,7 +56,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v2
+# clud-bug-template-version: v3
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -80,6 +80,23 @@ jobs:
             based-review]: this claim isn't anchored to a line"). Generic
             advice that contradicts a project skill is wrong by definition.
 
+            Skill routing — shared vs dedicated:
+            Each loaded skill carries a `review_mode:` field in its YAML
+            frontmatter at .claude/skills/<name>/SKILL.md. Two values:
+
+              - `review_mode: shared` — bug-finding / convention / evidence
+                skills. Their findings bundle into the standard "Critical
+                findings" / "Minor findings" sections.
+              - `review_mode: dedicated` — domain-specific skills (brand
+                voice, compliance, API-contract, test-discipline). Each
+                gets its own focused H3 section in the review.
+              - Missing field → treat as `shared`.
+
+            Before writing the review, scan each loaded skill's frontmatter
+            (the first `---`-delimited block of its SKILL.md) to identify
+            its review_mode. You can read them with:
+              cat .claude/skills/*/SKILL.md
+
             At the end of every review, append a single-line footer:
               Skills referenced: [skill-name-1, skill-name-2, ...]
             If you genuinely cited none, list "[none]" and explain why no
@@ -146,6 +163,38 @@ jobs:
             On a first-time review, "resolved from prior" and "still
             open" are both 0. On follow-up reviews after a fix-push,
             "resolved from prior" should typically be positive.
+
+            Per-skill scan block (required, immediately under the status line):
+            After the **This round:** counters, emit a "### Per-skill scan"
+            section with ONE line per loaded skill — even silent ones. This
+            is the anti-dilution layer: every loaded skill must be
+            acknowledged so authors can see their skill ran, even when it
+            produced no findings.
+
+              ### Per-skill scan
+              - [<skill-name>]: <one-sentence outcome>
+
+            Examples (mix of shared + dedicated, with and without findings):
+              - [critical-issues-only]: scanned all paths. 2 critical findings below.
+              - [evidence-based-review]: applied to all findings. ✓ all anchored.
+              - [respect-existing-conventions]: scanned for pattern fights. 0 findings.
+              - [brand-voice-review]: scanned 3 microcopy changes. 1 finding (below).
+              - [pii-and-compliance]: scanned logging + analytics. 0 findings.
+
+            Per-skill findings sections (dedicated-mode skills only):
+            For each dedicated-mode skill that produced one or more
+            findings, emit a dedicated H3 section before the standard
+            critical/minor buckets:
+
+              ### Brand voice [brand-voice-review]
+              - Finding: button label "Click here!" violates verb-noun rule
+                (lib/ui/Button.tsx:42). Suggested: "Open settings."
+
+            Shared-mode skill findings stay in the existing combined
+            "Critical findings" / "Minor findings" buckets — they
+            cross-correlate (a logging-PII issue belongs in both the
+            critical-issues-only and pii-and-compliance lens at once), so
+            bundling preserves that signal.
 
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -56,7 +56,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v2
+# clud-bug-template-version: v3
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -81,6 +81,23 @@ jobs:
             based-review]: this claim isn't anchored to a line"). Generic
             advice that contradicts a project skill is wrong by definition.
 
+            Skill routing — shared vs dedicated:
+            Each loaded skill carries a `review_mode:` field in its YAML
+            frontmatter at .claude/skills/<name>/SKILL.md. Two values:
+
+              - `review_mode: shared` — bug-finding / convention / evidence
+                skills. Their findings bundle into the standard "Critical
+                findings" / "Minor findings" sections.
+              - `review_mode: dedicated` — domain-specific skills (brand
+                voice, compliance, API-contract, test-discipline). Each
+                gets its own focused H3 section in the review.
+              - Missing field → treat as `shared`.
+
+            Before writing the review, scan each loaded skill's frontmatter
+            (the first `---`-delimited block of its SKILL.md) to identify
+            its review_mode. You can read them with:
+              cat .claude/skills/*/SKILL.md
+
             At the end of every review, append a single-line footer:
               Skills referenced: [skill-name-1, skill-name-2, ...]
             If you genuinely cited none, list "[none]" and explain why no
@@ -147,6 +164,38 @@ jobs:
             On a first-time review, "resolved from prior" and "still
             open" are both 0. On follow-up reviews after a fix-push,
             "resolved from prior" should typically be positive.
+
+            Per-skill scan block (required, immediately under the status line):
+            After the **This round:** counters, emit a "### Per-skill scan"
+            section with ONE line per loaded skill — even silent ones. This
+            is the anti-dilution layer: every loaded skill must be
+            acknowledged so authors can see their skill ran, even when it
+            produced no findings.
+
+              ### Per-skill scan
+              - [<skill-name>]: <one-sentence outcome>
+
+            Examples (mix of shared + dedicated, with and without findings):
+              - [critical-issues-only]: scanned all paths. 2 critical findings below.
+              - [evidence-based-review]: applied to all findings. ✓ all anchored.
+              - [respect-existing-conventions]: scanned for pattern fights. 0 findings.
+              - [brand-voice-review]: scanned 3 microcopy changes. 1 finding (below).
+              - [pii-and-compliance]: scanned logging + analytics. 0 findings.
+
+            Per-skill findings sections (dedicated-mode skills only):
+            For each dedicated-mode skill that produced one or more
+            findings, emit a dedicated H3 section before the standard
+            critical/minor buckets:
+
+              ### Brand voice [brand-voice-review]
+              - Finding: button label "Click here!" violates verb-noun rule
+                (lib/ui/Button.tsx:42). Suggested: "Open settings."
+
+            Shared-mode skill findings stay in the existing combined
+            "Critical findings" / "Minor findings" buckets — they
+            cross-correlate (a logging-PII issue belongs in both the
+            critical-issues-only and pii-and-compliance lens at once), so
+            bundling preserves that signal.
 
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v2
+# clud-bug-template-version: v3
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -101,6 +101,23 @@ jobs:
             based-review]: this claim isn't anchored to a line"). Generic
             advice that contradicts a project skill is wrong by definition.
 
+            Skill routing — shared vs dedicated:
+            Each loaded skill carries a `review_mode:` field in its YAML
+            frontmatter at .claude/skills/<name>/SKILL.md. Two values:
+
+              - `review_mode: shared` — bug-finding / convention / evidence
+                skills. Their findings bundle into the standard "Critical
+                findings" / "Minor findings" sections.
+              - `review_mode: dedicated` — domain-specific skills (brand
+                voice, compliance, API-contract, test-discipline). Each
+                gets its own focused H3 section in the review.
+              - Missing field → treat as `shared`.
+
+            Before writing the review, scan each loaded skill's frontmatter
+            (the first `---`-delimited block of its SKILL.md) to identify
+            its review_mode. You can read them with:
+              cat .claude/skills/*/SKILL.md
+
             At the end of every review, append a single-line footer:
               Skills referenced: [skill-name-1, skill-name-2, ...]
             If you genuinely cited none, list "[none]" and explain why no
@@ -167,6 +184,38 @@ jobs:
             On a first-time review, "resolved from prior" and "still
             open" are both 0. On follow-up reviews after a fix-push,
             "resolved from prior" should typically be positive.
+
+            Per-skill scan block (required, immediately under the status line):
+            After the **This round:** counters, emit a "### Per-skill scan"
+            section with ONE line per loaded skill — even silent ones. This
+            is the anti-dilution layer: every loaded skill must be
+            acknowledged so authors can see their skill ran, even when it
+            produced no findings.
+
+              ### Per-skill scan
+              - [<skill-name>]: <one-sentence outcome>
+
+            Examples (mix of shared + dedicated, with and without findings):
+              - [critical-issues-only]: scanned all paths. 2 critical findings below.
+              - [evidence-based-review]: applied to all findings. ✓ all anchored.
+              - [respect-existing-conventions]: scanned for pattern fights. 0 findings.
+              - [brand-voice-review]: scanned 3 microcopy changes. 1 finding (below).
+              - [pii-and-compliance]: scanned logging + analytics. 0 findings.
+
+            Per-skill findings sections (dedicated-mode skills only):
+            For each dedicated-mode skill that produced one or more
+            findings, emit a dedicated H3 section before the standard
+            critical/minor buckets:
+
+              ### Brand voice [brand-voice-review]
+              - Finding: button label "Click here!" violates verb-noun rule
+                (lib/ui/Button.tsx:42). Suggested: "Open settings."
+
+            Shared-mode skill findings stay in the existing combined
+            "Critical findings" / "Minor findings" buckets — they
+            cross-correlate (a logging-PII issue belongs in both the
+            critical-issues-only and pii-and-compliance lens at once), so
+            bundling preserves that signal.
 
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -80,7 +80,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md)"
           prompt: |
             {{PROJECT_DESCRIPTION}}
 

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -7,6 +7,7 @@ import {
   SkillsClient, rankAndCap, writeSkills, loadBaseline,
   readManifest, writeManifest, mergeManifest,
   removeSkill, listInstalled, diffManifest,
+  readReviewMode, partitionByReviewMode,
   _internal,
 } from '../lib/skills.js';
 
@@ -418,4 +419,72 @@ test('manifest extra fields (pinVersion, lastUpdate*) survive writeSkills + merg
     assert.ok(after.installed.find((e) => e.slug === 'z'));
     assert.ok(after.installed.find((e) => e.slug === 'a'));
   } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('readReviewMode: returns "shared" when frontmatter omits review_mode', () => {
+  const content = '---\nname: foo\ndescription: bar\n---\n\n# Body\n';
+  assert.equal(readReviewMode(content), 'shared');
+});
+
+test('readReviewMode: returns "dedicated" when frontmatter declares it', () => {
+  const content = '---\nname: brand\ndescription: x\nreview_mode: dedicated\n---\n\n# Body\n';
+  assert.equal(readReviewMode(content), 'dedicated');
+});
+
+test('readReviewMode: returns "shared" when review_mode appears only in body, not frontmatter', () => {
+  // Defensive: a `review_mode: dedicated` line inside the body (documentation,
+  // not configuration) must NOT be interpreted as the skill's mode. The parser
+  // scopes its match to the frontmatter block between the first two `---` lines.
+  const content = '---\nname: foo\ndescription: x\n---\n\nThe `review_mode: dedicated` field is documented here.\n';
+  assert.equal(readReviewMode(content), 'shared');
+});
+
+test('readReviewMode: returns "shared" for unknown values (forward-compat)', () => {
+  const content = '---\nname: foo\nreview_mode: experimental\n---\n';
+  assert.equal(readReviewMode(content), 'shared');
+});
+
+test('readReviewMode: returns "shared" on missing/empty/non-string input', () => {
+  assert.equal(readReviewMode(null), 'shared');
+  assert.equal(readReviewMode(undefined), 'shared');
+  assert.equal(readReviewMode(''), 'shared');
+  assert.equal(readReviewMode(42), 'shared');
+});
+
+test('partitionByReviewMode: splits skills by review_mode, defaulting to shared', () => {
+  const skills = [
+    { name: 'critical-issues-only', content: '---\nname: a\nreview_mode: shared\n---\n' },
+    { name: 'brand-voice-review',    content: '---\nname: b\nreview_mode: dedicated\n---\n' },
+    { name: 'no-mode',               content: '---\nname: c\n---\n' },
+    { name: 'pii-and-compliance',    content: '---\nname: d\nreview_mode: dedicated\n---\n' },
+  ];
+  const { shared, dedicated } = partitionByReviewMode(skills);
+  assert.deepEqual(shared.map((s) => s.name), ['critical-issues-only', 'no-mode']);
+  assert.deepEqual(dedicated.map((s) => s.name), ['brand-voice-review', 'pii-and-compliance']);
+});
+
+test('partitionByReviewMode: handles skills with no content (defaults to shared)', () => {
+  const skills = [
+    { name: 'a' },                      // no content
+    { name: 'b', content: undefined },  // explicit undefined
+    { name: 'c', content: '---\nname: c\nreview_mode: dedicated\n---\n' },
+  ];
+  const { shared, dedicated } = partitionByReviewMode(skills);
+  assert.deepEqual(shared.map((s) => s.name), ['a', 'b']);
+  assert.deepEqual(dedicated.map((s) => s.name), ['c']);
+});
+
+test('readReviewMode: all 4 bundled baseline skills declare shared mode', async () => {
+  // Pins the contract that v0.5.9 added: baselines are bug-finding /
+  // convention / evidence skills; bundling them in one Claude call preserves
+  // cross-correlation. If a future baseline drifts to dedicated, this test
+  // catches the regression at the right layer.
+  const baselineDir = join(process.cwd(), 'templates', 'skills', 'baseline');
+  const { readdir, readFile } = await import('node:fs/promises');
+  const names = (await readdir(baselineDir)).filter((n) => n.endsWith('.md'));
+  assert.ok(names.length >= 4, `expected ≥4 bundled baselines, found ${names.length}`);
+  for (const name of names) {
+    const content = await readFile(join(baselineDir, name), 'utf8');
+    assert.equal(readReviewMode(content), 'shared', `baseline ${name} should be shared-mode`);
+  }
 });

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -444,6 +444,18 @@ test('readReviewMode: returns "shared" for unknown values (forward-compat)', () 
   assert.equal(readReviewMode(content), 'shared');
 });
 
+test('readReviewMode: strips YAML string quotes around the value', () => {
+  // YAML allows `review_mode: "dedicated"` and `review_mode: 'dedicated'`.
+  // Both must resolve to dedicated; otherwise an author using either valid
+  // YAML form gets silent shared-routing.
+  for (const form of [
+    '---\nname: x\nreview_mode: "dedicated"\n---\n',
+    "---\nname: x\nreview_mode: 'dedicated'\n---\n",
+  ]) {
+    assert.equal(readReviewMode(form), 'dedicated', `quoted form: ${form.match(/review_mode:[^\n]+/)[0]}`);
+  }
+});
+
 test('readReviewMode: returns "shared" on missing/empty/non-string input', () => {
   assert.equal(readReviewMode(null), 'shared');
   assert.equal(readReviewMode(undefined), 'shared');

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -59,7 +59,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // Workflow refreshed
     const wf = await readFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'utf8');
     assert.match(wf, /allowedTools/);
-    assert.match(wf, /^# clud-bug-template-version: v2/);
+    assert.match(wf, /^# clud-bug-template-version: v3/);
     // Baseline rewritten with current shipped content
     const baseline = await readFile(join(dir, '.claude/skills/critical-issues-only/SKILL.md'), 'utf8');
     assert.match(baseline, /critical-issues-only/);
@@ -74,7 +74,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // The refreshed workflow records a from/to version note.
     const wfChange = r.changed.find((c) => c.label === 'review workflow');
     assert.equal(wfChange.from, 'v0');
-    assert.equal(wfChange.to, 'v2');
+    assert.equal(wfChange.to, 'v3');
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
## Summary

Stream BB.1 + BB.2 from the v0.6 plan — the load-bearing skill-routing change that turns the 4 dedicated-mode skills shipped in [agent-skills PR #9](https://github.com/thrillmot/agent-skills/pull/9) from inert frontmatter into real per-skill review sections in every PR comment.

## What changes

**Skills declare review_mode in frontmatter:**
- 4 baselines (`critical-issues-only`, `evidence-based-review`, `respect-existing-conventions`, `clud-bug-collaboration`) → `review_mode: shared`
- 4 dedicated examples already shipped in agent-skills → `review_mode: dedicated`
- Missing field → defaults to `shared` (conservative; user opts skills INTO `dedicated`)

**Workflow prompt restructured (templates v2 → v3):**
- Bot scans each loaded skill's frontmatter to identify its routing
- Emits a `### Per-skill scan` block under the status line — one line per loaded skill, even silent ones. Anti-dilution layer.
- Dedicated-mode skills get focused H3 sections (`### Brand voice [brand-voice-review]`)
- Shared-mode findings stay in combined Critical/Minor buckets (preserves cross-correlation across baselines)

**lib/skills.js adds:**
- `readReviewMode(content)` — parses frontmatter, scopes match to the first `---`-block (a `review_mode:` line in the body is documentation, not configuration)
- `partitionByReviewMode(skills)` → `{ shared, dedicated }` — the v0.6 GitHub App will reuse this exact helper for literal parallel API calls

## Architecture note (option D-unified)

v0.5.9 ships behavior via prompt restructuring inside the existing single `claude-code-action` call — same one-Claude-call cost model. v0.6 App will use the same `review_mode` metadata for literal parallel API calls (1 shared + N dedicated). The frontmatter contract is identical across both runtimes — single source of truth.

## Test plan
- [x] `npm test` — 117 tests pass (+8 new for `readReviewMode` / `partitionByReviewMode` / baseline-routing pin)
- [x] One test pins the contract: every shipped baseline declares `review_mode: shared` — catches future drift at the right layer
- [x] One test asserts `review_mode:` in the body (documentation) doesn't poison frontmatter parsing
- [x] actionlint — all 3 templates lint
- [ ] Bot review on this PR (uses v2-marker template; v3 takes effect on the NEXT post-update review)
- [ ] After merge: tag v0.5.9 → npm publish → `clud-bug update` in this repo refreshes v2 → v3 via refresh-mode (no self-mod ceremony needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)