### PR TITLE
feat: per-skill check-runs via GitHub Checks API (v0.5.10)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -142,48 +142,58 @@ runs:
           exit 0
         fi
 
-        # Emit one check-run per configured strictSkill. Status comes from
-        # the skill's line in the "### Per-skill scan" block of the review:
-        #   - line contains " 0 findings" OR " n/a " → success
-        #   - any other content (typically "N findings"/"N finding")    → failure
-        # If the skill isn't mentioned in the review at all (because the
-        # bot didn't emit a Per-skill scan block — e.g. an older v2-template
-        # comment), the check-run is emitted with conclusion=neutral and a
-        # text body explaining the absence, so the gate is loud rather than
-        # silently green.
-        EXIT_CODE=0
-        while IFS= read -r SKILL_NAME; do
+        # Emit one check-run per configured strictSkill. Classification
+        # (success / failure / neutral) is delegated to Node so the rule
+        # has unit-test coverage in test/skills.test.js — bash regex was
+        # the source of a "0 findings substring matches 10 findings" bug
+        # caught on PR #57. See classifyPerSkillOutcome in lib/skills.js
+        # for the contract.
+        #
+        # The classifier is sourced from this repo at the same ref the
+        # composite is pinned at (thrillmot/clud-bug@<ref>/lib/skills.js
+        # is the action's own checkout when consumed remotely via
+        # `uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@vX`).
+        SKILLS_LIB="${{ github.action_path }}/../../../lib/skills.js"
+        if [ ! -f "$SKILLS_LIB" ]; then
+          echo "::warning::Per-skill check-runs disabled — classifier at $SKILLS_LIB not found. (Composite action may be running outside its expected layout.)"
+          exit 0
+        fi
+
+        # Pre-export the constants Node needs.
+        export LATEST STRICT_SKILLS SKILLS_LIB
+
+        # Pipe strictSkills (one per line) into a Node script that
+        # classifies each skill via classifyPerSkillOutcome + emits the
+        # gh-api invocation params on stdout. We then loop in bash over
+        # the result and call `gh api` per skill. (Doing the gh api call
+        # from Node would be cleaner but requires GH_TOKEN env propagation
+        # + adds a dependency on @octokit/* — bash + gh is the minimal path.)
+        CLASSIFIED=$(echo "$STRICT_SKILLS" | node -e "
+          import('file://' + process.env.SKILLS_LIB).then(({ extractPerSkillLine, classifyPerSkillOutcome }) => {
+            const latest = process.env.LATEST || '';
+            let buf = '';
+            process.stdin.on('data', c => buf += c);
+            process.stdin.on('end', () => {
+              for (const name of buf.split(/\n/).map(s => s.trim()).filter(Boolean)) {
+                const line = extractPerSkillLine(latest, name);
+                const conclusion = classifyPerSkillOutcome(line);
+                const summary = line ?? 'No outcome reported for [' + name + '] in the latest clud-bug review.';
+                // Tab-separated record: name<TAB>conclusion<TAB>summary
+                // Summary is single-lined by the bot's prompt; replace any
+                // embedded newlines defensively.
+                process.stdout.write(name + '\t' + conclusion + '\t' + summary.replace(/[\r\n]+/g, ' ') + '\n');
+              }
+            });
+          }).catch(e => { console.error('classifier failed:', e.message); process.exit(2); });
+        ") || {
+          echo "::error::Per-skill check-runs classifier failed — see preceding error."
+          exit 1
+        }
+
+        # Loop in bash; emit one check-run per classified skill.
+        while IFS=$'\t' read -r SKILL_NAME CONCLUSION SUMMARY; do
           [ -z "$SKILL_NAME" ] && continue
-          # Match the skill's line in the Per-skill scan block. Format:
-          #   - [<skill-name>]: <one-sentence outcome>
-          # The bracket-anchored prefix prevents partial-name collisions
-          # (e.g. "brand-voice-review" not matching "brand-voice").
-          SKILL_LINE=$(echo "$LATEST" | grep -E "^[[:space:]]*-[[:space:]]*\[${SKILL_NAME}\]:" || true)
-
-          CONCLUSION="neutral"
-          SUMMARY="No outcome reported for [${SKILL_NAME}] in the latest clud-bug review."
-          if [ -n "$SKILL_LINE" ]; then
-            # Strip the "  - [name]: " prefix to get the outcome sentence
-            # for the check-run summary.
-            OUTCOME=$(echo "$SKILL_LINE" | sed -E "s/^[[:space:]]*-[[:space:]]*\[${SKILL_NAME}\]:[[:space:]]*//")
-            SUMMARY="$OUTCOME"
-            # Conservative match: "0 findings" or " n/a " (case-insensitive)
-            # → success. Anything else → failure. This treats "1 finding",
-            # "2 critical findings below", etc. all as failure, which is
-            # the intended strict-mode semantics for a per-skill gate.
-            if echo "$SKILL_LINE" | grep -qiE "0 findings|[[:space:]]n/a[[:space:]\.,]"; then
-              CONCLUSION="success"
-            else
-              CONCLUSION="failure"
-              EXIT_CODE=0   # check-run failure surfaces in branch protection, not via exit code here
-            fi
-          fi
-
           echo "::notice title=clud-bug[skill: ${SKILL_NAME}]::${CONCLUSION} — ${SUMMARY}"
-
-          # Emit the check-run. POST /repos/.../check-runs with head_sha=PR
-          # head. Skill name becomes the check name so it shows up in the
-          # PR's check list and is gateable via branch protection.
           gh api --method POST "repos/${{ github.repository }}/check-runs" \
             -f "name=${SKILL_NAME}" \
             -f "head_sha=${PR_HEAD_SHA}" \
@@ -192,8 +202,6 @@ runs:
             -f "output[title]=clud-bug: ${SKILL_NAME}" \
             -f "output[summary]=${SUMMARY}" \
             --silent || {
-              echo "::warning::Failed to emit check-run for ${SKILL_NAME} (this usually means the workflow lacks 'checks: write' permission)."
+              echo "::warning::Failed to emit check-run for ${SKILL_NAME} (workflow may lack 'checks: write' permission)."
             }
-        done <<< "$STRICT_SKILLS"
-
-        exit $EXIT_CODE
+        done <<< "$CLASSIFIED"

--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -1,29 +1,44 @@
-# Composite action: clud-bug strict-mode gate.
+# Composite action: clud-bug strict-mode gate + per-skill check-runs.
 #
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.8
+#   - uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.10
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}
 #
-# What it does (unchanged contract from v0.5.x):
-#   1. Reads .claude/skills/.clud-bug.json from origin/<base_ref> via
-#      `git show` — base, not head, so a PR can't opt itself out of
-#      strict mode by editing its own manifest. Requires fetch-depth: 0
-#      on the workflow's actions/checkout step.
-#   2. If base manifest's strictMode !== true, exit 0 (advisory).
-#   3. Otherwise, read the latest clud-bug[bot] review comment and look
-#      at its FIRST LINE. If it starts with "## 🐛 Clud Bug review —
-#      critical findings", fail the check.
+# Does two things, in order:
+#
+#   1. Strict-mode gate (v0.5.x contract, unchanged): read
+#      .claude/skills/.clud-bug.json from origin/<base_ref> via `git show`
+#      (base, not head, so a PR can't opt itself out of strict mode by
+#      editing its own manifest — requires fetch-depth: 0). If strictMode
+#      is true AND the latest clud-bug[bot] review comment's FIRST LINE
+#      starts with "## 🐛 Clud Bug review — critical findings", fail
+#      the check.
+#
+#   2. Per-skill check-runs (v0.5.10+, Stream BB.3): for each skill in the
+#      base manifest's `strictSkills` array, emit a separate check-run via
+#      the GitHub Checks API. Status is derived from the skill's line in
+#      the "### Per-skill scan" block of the latest review:
+#        - line contains "0 findings" or " n/a " → conclusion=success
+#        - otherwise                              → conclusion=failure
+#      Each emitted check-run shows up in the PR's check list and is
+#      individually gateable in branch protection (`brand-voice-review`,
+#      `pii-and-compliance`, etc.).
+#
+#      strictSkills is OPT-IN: users who don't configure it get the same
+#      behaviour as v0.5.x (no extra check-runs, no UI clutter). The
+#      emitted check-runs require `checks: write` permission on the
+#      workflow's permissions block; templates v4+ grant it automatically.
 #
 # Why a composite (and not a JS action): every input is already a shell
 # string or a `gh api` call — no Node deps, no compilation, no separate
 # release pipeline. The cost is one fewer abstraction; the win is that
 # changes to the gate ship in the same repo + tag as the templates.
-name: 'clud-bug strict-mode gate'
-description: 'Fail the check on critical findings if base manifest has strictMode: true.'
+name: 'clud-bug strict-mode gate + per-skill check-runs'
+description: 'Fail the check on critical findings if base manifest has strictMode: true, and emit per-skill check-runs for strictSkills.'
 
 inputs:
   github-token:
@@ -38,6 +53,7 @@ runs:
   using: 'composite'
   steps:
     - name: 'Strict mode — fail check on critical findings'
+      id: strict-mode-gate
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
@@ -74,3 +90,110 @@ runs:
           echo "::error::See the latest Clud Bug review comment for details. Push a fix and the gate will clear on the next run."
           exit 1
         fi
+
+    - name: 'Per-skill check-runs (BB.3)'
+      # Always run after the gate — even on strict-mode failure, the
+      # per-skill check-runs are still useful signal. The gate step can
+      # have failed; this step runs anyway and the workflow's overall
+      # status reflects the gate, not this step's per-skill outcomes
+      # (per-skill outcomes surface via the check-runs themselves).
+      if: always()
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        BOT_LOGIN: ${{ inputs.bot-login }}
+      run: |
+        # Re-read base manifest. (Step boundary means we can't share the
+        # variable from the gate step; one extra git-show is cheap.)
+        BASE_MANIFEST=$(git show "origin/${{ github.base_ref }}:.claude/skills/.clud-bug.json" 2>/dev/null) || {
+          echo "::warning::Per-skill check-runs disabled — base manifest not found on ${{ github.base_ref }}."
+          exit 0
+        }
+
+        # Extract the strictSkills array. Emits one line per skill on stdout.
+        # No strictSkills → empty stdout → no check-runs emitted (opt-in).
+        STRICT_SKILLS=$(echo "$BASE_MANIFEST" | node -e "
+          let s='';
+          process.stdin.on('data', c => s += c);
+          process.stdin.on('end', () => {
+            try {
+              const m = JSON.parse(s);
+              const list = Array.isArray(m.strictSkills) ? m.strictSkills : [];
+              for (const name of list) {
+                if (typeof name === 'string' && name.trim()) console.log(name.trim());
+              }
+            } catch (e) { /* malformed manifest → no check-runs, noop */ }
+          });
+        ")
+
+        if [ -z "$STRICT_SKILLS" ]; then
+          echo "No strictSkills configured in base manifest — skipping per-skill check-runs (opt-in feature)."
+          exit 0
+        fi
+
+        # Fetch the latest review comment again (different step, no shared state).
+        LATEST=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?sort=created&direction=desc&per_page=100" \
+          --jq '[.[] | select(.user.login == env.BOT_LOGIN and (.body | startswith("## 🐛 Clud Bug review")))][0].body // ""')
+
+        if [ -z "$LATEST" ]; then
+          echo "::warning::No clud-bug review comment found yet — skipping per-skill check-runs."
+          exit 0
+        fi
+
+        # Emit one check-run per configured strictSkill. Status comes from
+        # the skill's line in the "### Per-skill scan" block of the review:
+        #   - line contains " 0 findings" OR " n/a " → success
+        #   - any other content (typically "N findings"/"N finding")    → failure
+        # If the skill isn't mentioned in the review at all (because the
+        # bot didn't emit a Per-skill scan block — e.g. an older v2-template
+        # comment), the check-run is emitted with conclusion=neutral and a
+        # text body explaining the absence, so the gate is loud rather than
+        # silently green.
+        EXIT_CODE=0
+        while IFS= read -r SKILL_NAME; do
+          [ -z "$SKILL_NAME" ] && continue
+          # Match the skill's line in the Per-skill scan block. Format:
+          #   - [<skill-name>]: <one-sentence outcome>
+          # The bracket-anchored prefix prevents partial-name collisions
+          # (e.g. "brand-voice-review" not matching "brand-voice").
+          SKILL_LINE=$(echo "$LATEST" | grep -E "^[[:space:]]*-[[:space:]]*\[${SKILL_NAME}\]:" || true)
+
+          CONCLUSION="neutral"
+          SUMMARY="No outcome reported for [${SKILL_NAME}] in the latest clud-bug review."
+          if [ -n "$SKILL_LINE" ]; then
+            # Strip the "  - [name]: " prefix to get the outcome sentence
+            # for the check-run summary.
+            OUTCOME=$(echo "$SKILL_LINE" | sed -E "s/^[[:space:]]*-[[:space:]]*\[${SKILL_NAME}\]:[[:space:]]*//")
+            SUMMARY="$OUTCOME"
+            # Conservative match: "0 findings" or " n/a " (case-insensitive)
+            # → success. Anything else → failure. This treats "1 finding",
+            # "2 critical findings below", etc. all as failure, which is
+            # the intended strict-mode semantics for a per-skill gate.
+            if echo "$SKILL_LINE" | grep -qiE "0 findings|[[:space:]]n/a[[:space:]\.,]"; then
+              CONCLUSION="success"
+            else
+              CONCLUSION="failure"
+              EXIT_CODE=0   # check-run failure surfaces in branch protection, not via exit code here
+            fi
+          fi
+
+          echo "::notice title=clud-bug[skill: ${SKILL_NAME}]::${CONCLUSION} — ${SUMMARY}"
+
+          # Emit the check-run. POST /repos/.../check-runs with head_sha=PR
+          # head. Skill name becomes the check name so it shows up in the
+          # PR's check list and is gateable via branch protection.
+          gh api --method POST "repos/${{ github.repository }}/check-runs" \
+            -f "name=${SKILL_NAME}" \
+            -f "head_sha=${PR_HEAD_SHA}" \
+            -f "status=completed" \
+            -f "conclusion=${CONCLUSION}" \
+            -f "output[title]=clud-bug: ${SKILL_NAME}" \
+            -f "output[summary]=${SUMMARY}" \
+            --silent || {
+              echo "::warning::Failed to emit check-run for ${SKILL_NAME} (this usually means the workflow lacks 'checks: write' permission)."
+            }
+        done <<< "$STRICT_SKILLS"
+
+        exit $EXIT_CODE

--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -22,8 +22,16 @@
 #      base manifest's `strictSkills` array, emit a separate check-run via
 #      the GitHub Checks API. Status is derived from the skill's line in
 #      the "### Per-skill scan" block of the latest review:
-#        - line contains "0 findings" or " n/a " → conclusion=success
-#        - otherwise                              → conclusion=failure
+#        - line contains "0 findings" / "0 finding" / " n/a " → success
+#        - any other line (incl. "N findings" with N>0)       → failure
+#        - skill NOT mentioned in the scan block              → failure
+#      The "missing skill → failure" choice is deliberate: GitHub treats
+#      `conclusion: neutral` as PASSING for required checks (only failure /
+#      cancelled / timed_out / action_required block merge). A strictSkill
+#      that doesn't appear in the review (typo, prompt regression, race)
+#      must fail loud, not silently green. See classifyPerSkillOutcome in
+#      lib/skills.js for the canonical logic + tests.
+#
 #      Each emitted check-run shows up in the PR's check list and is
 #      individually gateable in branch protection (`brand-voice-review`,
 #      `pii-and-compliance`, etc.).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 ### Added — Stream BB.3 (per-skill check-runs via GitHub Checks API)
 
 - **Composite strict-mode-gate action now emits per-skill check-runs.** For each skill listed in the base manifest's new `strictSkills` array, the composite emits a separate check-run via `POST /repos/{owner}/{repo}/check-runs`. The check-run's conclusion is derived from the skill's line in the latest review comment's `### Per-skill scan` block:
-  - line contains `0 findings` or ` n/a ` → `conclusion: success`
-  - any other content (`N finding`, `N findings`) → `conclusion: failure`
-  - skill not mentioned in the review → `conclusion: neutral` (loud rather than silently green)
+  - line contains `0 findings` / `0 finding` / `n/a` → `conclusion: success`
+  - any other content (`N finding`, `N findings` with N>0) → `conclusion: failure`
+  - skill not mentioned in the review → `conclusion: failure` (GitHub treats `neutral` as passing for required checks — a missing skill must fail loud, not silently green)
 
   Each emitted check-run shows up in the PR's check list with the skill name as the check name (`brand-voice-review`, `pii-and-compliance`, etc.) and is **individually gateable in branch protection** — letting a repo require a clean `brand-voice-review` check alongside the master `clud-bug-review` check.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 ### Pending (separate PR)
 - Pinning `anthropics/claude-code-action@v1` via `{{CCA_VERSION}}` placeholder substitution. Requires routing `audit.yml.tmpl` + `self-update.yml.tmpl` through `renderFile` (currently raw `readFile`).
 
+## [0.5.10] — 2026-05-18
+
+### Added — Stream BB.3 (per-skill check-runs via GitHub Checks API)
+
+- **Composite strict-mode-gate action now emits per-skill check-runs.** For each skill listed in the base manifest's new `strictSkills` array, the composite emits a separate check-run via `POST /repos/{owner}/{repo}/check-runs`. The check-run's conclusion is derived from the skill's line in the latest review comment's `### Per-skill scan` block:
+  - line contains `0 findings` or ` n/a ` → `conclusion: success`
+  - any other content (`N finding`, `N findings`) → `conclusion: failure`
+  - skill not mentioned in the review → `conclusion: neutral` (loud rather than silently green)
+
+  Each emitted check-run shows up in the PR's check list with the skill name as the check name (`brand-voice-review`, `pii-and-compliance`, etc.) and is **individually gateable in branch protection** — letting a repo require a clean `brand-voice-review` check alongside the master `clud-bug-review` check.
+
+  **Opt-in.** Users who don't set `strictSkills` see no behavior change. The composite emits zero check-runs and exits 0.
+
+  Example `.claude/skills/.clud-bug.json`:
+  ```json
+  {
+    "strictMode": true,
+    "strictSkills": ["brand-voice-review", "pii-and-compliance"]
+  }
+  ```
+
+- **`checks: write` permission added to all 3 workflow templates** — required for the Checks API call. No-op for users who don't configure `strictSkills`.
+
+### Changed
+
+- **Template marker bumped `v3` → `v4`** in `workflow.yml.tmpl`, `workflow-ts.yml.tmpl`, `workflow-py.yml.tmpl`. Existing v3 installs auto-upgrade via v0.5.7's refresh-mode on the next `clud-bug update`.
+- **Composite action ref bumped `@v0.5.8` → `@v0.5.10`** in the same three templates. v0.5.9 installs that adopted v3 templates will need a `clud-bug update` to pick up the v4 templates referencing the new action ref.
+- **`strict-mode-gate@v0.5.8` continues to resolve unchanged** — the action's strict-mode gate logic is byte-identical at both refs. Existing v3 templates pointing at `@v0.5.8` keep working; only the per-skill check-runs behavior (BB.3) is gated behind the `@v0.5.10` ref.
+
 ## [0.5.9] — 2026-05-18
 
 ### Added — Stream BB.1 + BB.2 (skill routing + per-skill review output)
@@ -110,6 +139,7 @@ Installs predating PR #52 have markerless workflows. The first `clud-bug update`
 - **Bot-authored PRs are now handled gracefully.** PRs from `dependabot[bot]`, `renovate[bot]`, or forks (where GitHub deliberately doesn't pass repository secrets) used to fail loudly red — wrong signal. Now a guard step detects the case, posts a one-line advisory comment ("Clud Bug skipped — bot/fork PR cannot access secrets"), and exits 0. Check stays green; the skip is visible. Owner-authored PRs without the secret still fail loud.
 - **Site polish (carries over from the unreleased entry):** alive bug emoji (layered breathe + twitch + scuttle animations), Plate label gloss, thrillmot footer credit.
 
+[0.5.10]: https://github.com/thrillmot/clud-bug/compare/v0.5.9...v0.5.10
 [0.5.9]: https://github.com/thrillmot/clud-bug/compare/v0.5.8...v0.5.9
 [0.5.8]: https://github.com/thrillmot/clud-bug/compare/v0.5.7...v0.5.8
 [0.5.7]: https://github.com/thrillmot/clud-bug/compare/v0.5.6...v0.5.7

--- a/docs/decisions-branches/feat__per-skill-check-runs-v0.5.10.md
+++ b/docs/decisions-branches/feat__per-skill-check-runs-v0.5.10.md
@@ -1,0 +1,12 @@
+## 2026-05-18 18:17 - Stream BB.3: per-skill check-runs in composite action (v0.5.10)
+
+**Reasoning:** Per the v0.6 plan: each dedicated-mode skill gets its own check-run in the PR check list, gateable in branch protection. The composite action reads .clud-bug.json strictSkills array, parses the Per-skill scan block from the latest review, and emits one check-run per configured skill via Checks API. Opt-in (zero check-runs when strictSkills unset) so no UI clutter for users who do not care.
+
+**Alternatives considered:** Emit check-runs for EVERY loaded skill (rejected): bloats PR check list with 4 baselines + N dedicated checks, even when the user does not gate on most of them. Opt-in via strictSkills keeps the surface clean., Use a separate workflow job per skill (rejected): would require N parallel jobs in template + cross-job comment-aggregation. Composite-action extension is the smaller change for v0.5.10; the v0.6 App will do literal parallel API calls instead.
+
+**Implications:**
+- Adds checks: write permission to all 3 templates. No-op when strictSkills is unset. Marker bumps v3 -> v4 so refresh-mode propagates the permission change automatically.
+- Composite action remains backward-compatible: @v0.5.8 ref still resolves and behaves identically (strict-mode gate is byte-equivalent). Templates that pin @v0.5.8 keep working; only @v0.5.10 templates get the new check-runs behavior.
+- Bash comment parsing relies on the v3+ prompt emitting a stable Per-skill scan block format. v2-marker workflows that pre-date BB.2 will produce comments without that block; the composite emits conclusion=neutral check-runs in that case (loud rather than silently green).
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-18** — Stream BB.3: per-skill check-runs in composite action (v0.5.10) *(feat/per-skill-check-runs-v0.5.10)* — [decisions-branches/feat__per-skill-check-runs-v0.5.10.md](decisions-branches/feat__per-skill-check-runs-v0.5.10.md)
 - **2026-05-18** — Stream BB.1+BB.2: skill routing via review_mode + per-skill review output (v0.5.9) *(feat/skill-routing-v0.5.9)* — [decisions-branches/feat__skill-routing-v0.5.9.md](decisions-branches/feat__skill-routing-v0.5.9.md)
 - **2026-05-18** — Self-mod ceremony: render v2 templates into this repo own clud-bug-review.yml *(feat/render-v2-templates-self-mod)* — [decisions-branches/feat__render-v2-templates-self-mod.md](decisions-branches/feat__render-v2-templates-self-mod.md)
 - **2026-05-18** — Stream Y: extract strict-mode gate into a composite GitHub Action (v0.5.8) *(feat/composite-strict-mode-gate)* — [decisions-branches/feat__composite-strict-mode-gate.md](decisions-branches/feat__composite-strict-mode-gate.md)

--- a/lib/skills.js
+++ b/lib/skills.js
@@ -436,17 +436,27 @@ export function extractPerSkillLine(comment, skillName) {
 // parallel calls.
 //
 // Contract:
-//   - `null` (skill not mentioned in the review) → 'neutral'
+//   - `null` (skill not mentioned in the review) → 'failure'
 //   - line contains "0 findings" / "0 finding" as a STANDALONE TOKEN → 'success'
 //   - line contains "n/a" as a standalone token → 'success'
+//   - empty line (bot emitted "- [name]:" with no outcome) → 'failure'
 //   - otherwise (typically "N finding" / "N findings" with N>0) → 'failure'
+//
+// Why null → failure (not neutral): GitHub's branch-protection contract
+// treats `conclusion: neutral` as PASSING for required status checks —
+// only `failure`, `cancelled`, `timed_out`, `action_required` block merge.
+// A strictSkills entry that doesn't appear in the per-skill scan block
+// (typo, prompt regression, mid-review race) emitting `neutral` would
+// silently pass branch protection, defeating the gate the user opted into.
+// Failing loud is the right posture for a gate that ships with "strict" in
+// its name; the cost is a re-run if a bot mid-review somehow drops a skill.
 //
 // The "0 findings" match is anchored on a leading word boundary so "10
 // findings" / "100 findings" don't substring-match to success — the exact
 // bug that v0.5.10's first revision had, caught by clud-bug-review + claude-
 // review on PR #57.
 export function classifyPerSkillOutcome(outcomeLine) {
-  if (outcomeLine == null) return 'neutral';
+  if (outcomeLine == null) return 'failure';
   const text = String(outcomeLine);
   // 0 findings / 0 finding — anchored: NOT preceded by a digit. So "10 findings"
   // doesn't match (the `0 findings` substring has `1` before it), and "0

--- a/lib/skills.js
+++ b/lib/skills.js
@@ -400,4 +400,62 @@ export function partitionByReviewMode(skills) {
   return { shared, dedicated };
 }
 
+// Pull the line for `skillName` from a clud-bug review's `### Per-skill scan`
+// block. The block format (set by the v3+ prompt) is one line per loaded skill:
+//
+//   ### Per-skill scan
+//   - [critical-issues-only]: scanned all paths. 2 critical findings below.
+//   - [brand-voice-review]: scanned 3 microcopy changes. 1 finding (below).
+//   - [pii-and-compliance]: scanned analytics + logging. 0 findings.
+//
+// Returns the OUTCOME portion (everything after the `- [name]: ` prefix), with
+// trailing whitespace stripped. Returns null if the skill isn't mentioned, the
+// comment has no Per-skill scan block, or `comment` is empty.
+//
+// The brackets in the line prefix anchor the match so a partial-name collision
+// (e.g. `brand-voice` finding `brand-voice-review`) is impossible.
+export function extractPerSkillLine(comment, skillName) {
+  if (typeof comment !== 'string' || !comment) return null;
+  if (typeof skillName !== 'string' || !skillName) return null;
+  // Escape regex metacharacters in the skill name. A skill name with a `.` or
+  // `+` would otherwise alter the match. Skills are conventionally kebab-case,
+  // but defense in depth is cheap.
+  const escaped = skillName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // Anchor on the bracket-prefix; tolerate optional leading whitespace and
+  // dash. The OUTCOME is everything from after `]:` to end-of-line.
+  const re = new RegExp(`^\\s*-\\s*\\[${escaped}\\]:\\s*(.+?)\\s*$`, 'm');
+  const m = comment.match(re);
+  return m ? m[1] : null;
+}
+
+// Classify a Per-skill scan outcome line into the check-run conclusion the
+// composite action will emit for that skill. Source of truth for the BB.3
+// gate decision — the v0.5.10 composite shells out to node + this helper
+// rather than parsing in bash, so the gate has unit-test coverage and the
+// v0.6 App can reuse the same classification when it routes its own
+// parallel calls.
+//
+// Contract:
+//   - `null` (skill not mentioned in the review) → 'neutral'
+//   - line contains "0 findings" / "0 finding" as a STANDALONE TOKEN → 'success'
+//   - line contains "n/a" as a standalone token → 'success'
+//   - otherwise (typically "N finding" / "N findings" with N>0) → 'failure'
+//
+// The "0 findings" match is anchored on a leading word boundary so "10
+// findings" / "100 findings" don't substring-match to success — the exact
+// bug that v0.5.10's first revision had, caught by clud-bug-review + claude-
+// review on PR #57.
+export function classifyPerSkillOutcome(outcomeLine) {
+  if (outcomeLine == null) return 'neutral';
+  const text = String(outcomeLine);
+  // 0 findings / 0 finding — anchored: NOT preceded by a digit. So "10 findings"
+  // doesn't match (the `0 findings` substring has `1` before it), and "0
+  // findings" / " 0 findings." both match.
+  if (/(^|[^0-9])0\s+findings?\b/i.test(text)) return 'success';
+  // n/a — anchored on word boundaries either side (so "n/a." at sentence end
+  // matches but "diagnostics" would not contain a matching n/a).
+  if (/\bn\/a\b/i.test(text)) return 'success';
+  return 'failure';
+}
+
 export const _internal = { normalizeList, sanitizeSlug, entryKey, MAX_SKILLS, API_BASE, MANIFEST_FILE };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v3
+# clud-bug-template-version: v4
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -12,6 +12,8 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
+      # checks: write — composite emits per-skill check-runs (BB.3).
+      checks: write
 
     steps:
       - uses: actions/checkout@v6
@@ -220,6 +222,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.8
+        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.10
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v3
+# clud-bug-template-version: v4
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -12,6 +12,8 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
+      # checks: write — composite emits per-skill check-runs (BB.3).
+      checks: write
 
     steps:
       - uses: actions/checkout@v6
@@ -221,6 +223,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.8
+        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.10
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v3
+# clud-bug-template-version: v4
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -12,6 +12,10 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
+      # checks: write — composite action emits per-skill check-runs via
+      # the GitHub Checks API for any skill in .clud-bug.json's strictSkills
+      # list (BB.3, v0.5.10+). No-op when strictSkills is unset.
+      checks: write
 
     steps:
       - uses: actions/checkout@v6
@@ -253,6 +257,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.8
+        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.10
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -8,6 +8,7 @@ import {
   readManifest, writeManifest, mergeManifest,
   removeSkill, listInstalled, diffManifest,
   readReviewMode, partitionByReviewMode,
+  extractPerSkillLine, classifyPerSkillOutcome,
   _internal,
 } from '../lib/skills.js';
 
@@ -484,6 +485,114 @@ test('partitionByReviewMode: handles skills with no content (defaults to shared)
   const { shared, dedicated } = partitionByReviewMode(skills);
   assert.deepEqual(shared.map((s) => s.name), ['a', 'b']);
   assert.deepEqual(dedicated.map((s) => s.name), ['c']);
+});
+
+// --- BB.3: per-skill check-run classifier (v0.5.10) ---
+// classifyPerSkillOutcome + extractPerSkillLine are the source of truth that
+// the composite strict-mode-gate action calls into via `node -e ...` for
+// every entry in .clud-bug.json's strictSkills array. Bash regex shipped in
+// PR #57's first revision had a "0 findings" substring match that silently
+// passed "10 findings" / "100 findings" as success — caught by both bots,
+// fixed here, pinned by these tests.
+
+const SAMPLE_COMMENT = [
+  '## 🐛 Clud Bug review',
+  '',
+  '**This round:** 0 critical · 0 minor · 0 resolved from prior · 0 still open',
+  '',
+  '### Per-skill scan',
+  '- [critical-issues-only]: scanned all paths. 0 findings.',
+  '- [evidence-based-review]: applied to all findings. ✓ all anchored.',
+  '- [brand-voice-review]: scanned 3 microcopy changes. 1 finding (below).',
+  '- [pii-and-compliance]: scanned analytics + logging. 10 findings (below).',
+  '- [api-contract-enforcement]: n/a — no public API surface in this diff.',
+  '',
+].join('\n');
+
+test('extractPerSkillLine: returns the outcome portion stripped of the prefix', () => {
+  assert.equal(
+    extractPerSkillLine(SAMPLE_COMMENT, 'critical-issues-only'),
+    'scanned all paths. 0 findings.',
+  );
+  assert.equal(
+    extractPerSkillLine(SAMPLE_COMMENT, 'brand-voice-review'),
+    'scanned 3 microcopy changes. 1 finding (below).',
+  );
+});
+
+test('extractPerSkillLine: returns null when the skill is absent', () => {
+  assert.equal(extractPerSkillLine(SAMPLE_COMMENT, 'no-such-skill'), null);
+});
+
+test('extractPerSkillLine: bracket prefix prevents partial-name collisions', () => {
+  // "brand-voice" must NOT match a line for "brand-voice-review".
+  assert.equal(extractPerSkillLine(SAMPLE_COMMENT, 'brand-voice'), null);
+});
+
+test('extractPerSkillLine: handles missing/empty inputs without throwing', () => {
+  assert.equal(extractPerSkillLine(null, 'x'), null);
+  assert.equal(extractPerSkillLine('', 'x'), null);
+  assert.equal(extractPerSkillLine(SAMPLE_COMMENT, ''), null);
+  assert.equal(extractPerSkillLine(SAMPLE_COMMENT, null), null);
+});
+
+test('classifyPerSkillOutcome: "0 findings" → success', () => {
+  assert.equal(classifyPerSkillOutcome('scanned all paths. 0 findings.'), 'success');
+});
+
+test('classifyPerSkillOutcome: "0 finding" (singular) → success', () => {
+  // Singular is theoretically nonsensical ("0 finding" not "0 findings") but
+  // a lazy bot rendering of `${n} finding${plural}` could emit it.
+  assert.equal(classifyPerSkillOutcome('scanned. 0 finding.'), 'success');
+});
+
+test('classifyPerSkillOutcome: REGRESSION — "10 findings" does NOT match 0 substring (failure)', () => {
+  // The exact bug both bots caught on PR #57. "10 findings" contains the
+  // literal substring "0 findings"; an unanchored match would classify this
+  // as success. The leading-non-digit anchor (`(^|[^0-9])`) prevents it.
+  assert.equal(classifyPerSkillOutcome('scanned. 10 findings (below).'), 'failure');
+  assert.equal(classifyPerSkillOutcome('scanned. 100 findings.'), 'failure');
+  assert.equal(classifyPerSkillOutcome('scanned. 20 findings.'), 'failure');
+});
+
+test('classifyPerSkillOutcome: any other finding count → failure', () => {
+  assert.equal(classifyPerSkillOutcome('1 finding (below).'), 'failure');
+  assert.equal(classifyPerSkillOutcome('2 critical findings below.'), 'failure');
+  assert.equal(classifyPerSkillOutcome('scanned 3 microcopy changes. 1 finding (below).'), 'failure');
+});
+
+test('classifyPerSkillOutcome: "n/a" → success', () => {
+  assert.equal(classifyPerSkillOutcome('n/a — no API surface in this diff.'), 'success');
+  // Trailing punctuation handled.
+  assert.equal(classifyPerSkillOutcome('n/a.'), 'success');
+  // Bare n/a at end-of-line.
+  assert.equal(classifyPerSkillOutcome('skipped, n/a'), 'success');
+});
+
+test('classifyPerSkillOutcome: null/missing line → neutral (skill not in review)', () => {
+  assert.equal(classifyPerSkillOutcome(null), 'neutral');
+  assert.equal(classifyPerSkillOutcome(undefined), 'neutral');
+});
+
+test('classifyPerSkillOutcome: empty string → failure (line present but unparseable)', () => {
+  // Empty outcome line means the bot emitted "- [name]: " with no text —
+  // that's broken output, not "no findings." Conservative classification:
+  // failure surfaces the issue rather than greenlighting a malformed review.
+  assert.equal(classifyPerSkillOutcome(''), 'failure');
+});
+
+test('classifyPerSkillOutcome: SAMPLE_COMMENT end-to-end matches expected classifications', () => {
+  const cases = [
+    ['critical-issues-only', 'success'],   // 0 findings
+    ['brand-voice-review',   'failure'],   // 1 finding
+    ['pii-and-compliance',   'failure'],   // 10 findings (regression check)
+    ['api-contract-enforcement', 'success'], // n/a
+    ['nonexistent-skill',   'neutral'],    // not in review
+  ];
+  for (const [name, expected] of cases) {
+    const line = extractPerSkillLine(SAMPLE_COMMENT, name);
+    assert.equal(classifyPerSkillOutcome(line), expected, `${name} should be ${expected}`);
+  }
 });
 
 test('readReviewMode: all 4 bundled baseline skills declare shared mode', async () => {

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -569,9 +569,33 @@ test('classifyPerSkillOutcome: "n/a" → success', () => {
   assert.equal(classifyPerSkillOutcome('skipped, n/a'), 'success');
 });
 
-test('classifyPerSkillOutcome: null/missing line → neutral (skill not in review)', () => {
-  assert.equal(classifyPerSkillOutcome(null), 'neutral');
-  assert.equal(classifyPerSkillOutcome(undefined), 'neutral');
+test('classifyPerSkillOutcome: null/missing line → failure (skill not in review)', () => {
+  // GitHub branch protection treats `conclusion: neutral` as PASSING for
+  // required checks (only failure / cancelled / timed_out / action_required
+  // block merge). So a strictSkills entry that doesn't appear in the bot's
+  // per-skill scan block (typo, prompt regression, race) MUST classify as
+  // `failure` — otherwise the gate the user opted into is silently green.
+  // claude-review caught this on PR #57's first revision.
+  assert.equal(classifyPerSkillOutcome(null), 'failure');
+  assert.equal(classifyPerSkillOutcome(undefined), 'failure');
+});
+
+test('classifyPerSkillOutcome: missing skill in review block → failure (named)', () => {
+  // Named version of the assertion above, walking through
+  // extractPerSkillLine to exercise the full "strictSkill typo" /
+  // "skill dropped from review output" scenario as a single integrated test.
+  const commentWithoutBrandSkill = [
+    '## 🐛 Clud Bug review',
+    '',
+    '### Per-skill scan',
+    '- [critical-issues-only]: scanned all paths. 0 findings.',
+    '- [evidence-based-review]: applied. ✓ all anchored.',
+  ].join('\n');
+  // User configured strictSkills: ["brand-voice-review"] but the bot's
+  // review block doesn't mention it.
+  const line = extractPerSkillLine(commentWithoutBrandSkill, 'brand-voice-review');
+  assert.equal(line, null, 'extractPerSkillLine returns null for absent skill');
+  assert.equal(classifyPerSkillOutcome(line), 'failure', 'absent skill must fail the gate, not neutral-pass it');
 });
 
 test('classifyPerSkillOutcome: empty string → failure (line present but unparseable)', () => {
@@ -587,7 +611,7 @@ test('classifyPerSkillOutcome: SAMPLE_COMMENT end-to-end matches expected classi
     ['brand-voice-review',   'failure'],   // 1 finding
     ['pii-and-compliance',   'failure'],   // 10 findings (regression check)
     ['api-contract-enforcement', 'success'], // n/a
-    ['nonexistent-skill',   'neutral'],    // not in review
+    ['nonexistent-skill',   'failure'],    // not in review → fail loud (not neutral, which BP would pass)
   ];
   for (const [name, expected] of cases) {
     const line = extractPerSkillLine(SAMPLE_COMMENT, name);

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -59,7 +59,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // Workflow refreshed
     const wf = await readFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'utf8');
     assert.match(wf, /allowedTools/);
-    assert.match(wf, /^# clud-bug-template-version: v3/);
+    assert.match(wf, /^# clud-bug-template-version: v4/);
     // Baseline rewritten with current shipped content
     const baseline = await readFile(join(dir, '.claude/skills/critical-issues-only/SKILL.md'), 'utf8');
     assert.match(baseline, /critical-issues-only/);
@@ -74,7 +74,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // The refreshed workflow records a from/to version note.
     const wfChange = r.changed.find((c) => c.label === 'review workflow');
     assert.equal(wfChange.from, 'v0');
-    assert.equal(wfChange.to, 'v3');
+    assert.equal(wfChange.to, 'v4');
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
## Summary

Stream BB.3 from the v0.6 plan. Extends the composite `strict-mode-gate` action to emit one check-run per skill listed in the base manifest's new `strictSkills` array. Each emitted check-run shows up in the PR's check list with the skill name (`brand-voice-review`, `pii-and-compliance`, etc.) and is independently gateable in branch protection.

## How it works

The composite action runs after `claude-code-action` posts the review. The new step:

1. Reads `strictSkills` from `origin/<base_ref>:.claude/skills/.clud-bug.json` (base, not head — a PR can't opt itself out)
2. Re-fetches the latest `clud-bug[bot]` review comment
3. For each skill in `strictSkills`, parses the matching line from the `### Per-skill scan` block:
   - `0 findings` or ` n/a ` → `conclusion: success`
   - `N finding(s)` → `conclusion: failure`
   - skill not mentioned → `conclusion: neutral` (loud, not silently green)
4. `POST /repos/{owner}/{repo}/check-runs` with `name=<skill-name>` and the derived conclusion

## Opt-in by design

Users who don't configure `strictSkills` see **zero new check-runs**. The composite emits no API calls and exits 0. No UI clutter for the default install.

Configure to enable:
```json
// .claude/skills/.clud-bug.json (on the base branch)
{
  "strictMode": true,
  "strictSkills": ["brand-voice-review", "pii-and-compliance"]
}
```

After this, branch protection can require `brand-voice-review` as a status check alongside `clud-bug-review`.

## Backward compatibility

- The composite at `@v0.5.8` continues to work — strict-mode gate logic is byte-equivalent. v3 templates pinning `@v0.5.8` keep functioning.
- Only `@v0.5.10` templates pick up the per-skill check-runs behavior. Marker v3 → v4 propagates the new `checks: write` permission + new action ref via refresh-mode.

## What this PR does NOT do

- Doesn't render this repo's own `.github/workflows/clud-bug-review.yml` to v4 — refresh-mode will pick it up via `clud-bug update` post-publish, OR the weekly self-update workflow will. No self-mod ceremony bundled.
- The `Bash(cat .claude/skills/*/SKILL.md)` allowlist pattern from v0.5.9 remains untested in production (see prior PR #56's sub-critical note). If it turns out to need `Bash(cat:*)`, that's a quick follow-up.

## Test plan
- [x] `npm test` — 118 tests pass (no new tests needed; the bash parsing is too thin for unit testing in isolation, and the end-to-end exercises in PRs post-publish)
- [x] actionlint — composite action + all 3 templates lint
- [x] YAML safe-load on all changed files
- [ ] Bot review on this PR
- [ ] After merge: tag v0.5.10 → npm publish → refresh this repo → next PR's bot review exercises the composite at @v0.5.10
- [ ] Future smoke test: configure a `strictSkills` array in this repo's `.clud-bug.json`, open a PR, verify per-skill check-runs appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)