### PR TITLE
ceremony: refresh to v4 templates + composite @v0.5.10 (self-mod)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "installed": [],
+  "lastUpdate": "2026-05-26T14:59:41.127Z",
+  "lastUpdateVersion": "0.5.10"
+}

--- a/.claude/skills/clud-bug-collaboration/SKILL.md
+++ b/.claude/skills/clud-bug-collaboration/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: clud-bug-collaboration
+description: How Claude Code agents working in a clud-bug-installed repo should interact with the bot's review threads, strict-mode gate, and skill set. Use this skill whenever you're about to push a commit, address a clud-bug PR review comment, edit anything under .claude/skills/, modify .github/workflows/clud-bug-*.yml, or wonder why a PR check is red. Also use when planning work in a repo that has a `clud-bug-review` workflow installed — even if the user didn't mention clud-bug by name.
+---
+
+# Working in a clud-bug-installed repo
+
+Clud Bug reviews every PR via `anthropics/claude-code-action`. As another
+Claude Code agent working alongside it, here's what to know — these aren't
+arbitrary rules, they're the consequences of how the gate is wired.
+
+## When you push fixes to a clud-bug-reviewed PR
+
+The bot reviews on `pull_request: synchronize` (every push). When you push
+a commit that addresses an issue Clud Bug flagged in a prior review, the bot
+will re-review the PR within ~2 minutes and **resolve its own prior
+unresolved inline review threads** where the flagged issue is verifiably
+fixed in the current diff. You don't have to resolve threads manually.
+
+If a thread it left isn't auto-resolved after your fix:
+- The bot judged the issue still open (read its latest comment for why).
+- Or the resolution call hit a transient API issue (re-push to retry).
+
+Don't manually resolve clud-bug threads on its behalf. The check
+(`required_conversation_resolution` branch protection) will block merge if
+unresolved threads remain — and the right fix is usually "fix the actual
+issue and re-push," not "mark the conversation resolved."
+
+## When you read the PR's `clud-bug-review` check status
+
+- **Green** = Clud Bug ran and either found no critical issues OR strict
+  mode is off (advisory).
+- **Red** = either the action errored OR strict mode is on AND Clud Bug
+  flagged a critical issue. Read the latest `## 🐛 Clud Bug review` comment
+  on the PR — the body indicates "critical findings" or "clean."
+- **Skipped/green-with-comment** = bot- or fork-authored PR (Dependabot,
+  Renovate, fork contributor). GitHub deliberately doesn't pass repo
+  secrets to those workflows. The bot posts a one-line "Clud Bug skipped"
+  comment and exits 0. Review the diff manually.
+
+## Strict mode
+
+Read `.claude/skills/.clud-bug.json` to check this repo's setting.
+`strictMode: true` means the workflow check fails on critical findings.
+The setting is read from the **base ref**, so a PR cannot disable strict
+mode on itself by editing the manifest. Changes take effect for PRs opened
+after the change merges to the base branch.
+
+To disable strict mode for a repo, edit the manifest on the base branch:
+
+```json
+{ "strictMode": false, ... }
+```
+
+## When you modify a clud-bug skill
+
+Skills live in `.claude/skills/<slug>/SKILL.md`. Three groups:
+
+- **Baseline** (`critical-issues-only`, `evidence-based-review`,
+  `respect-existing-conventions`) — managed by clud-bug; if you edit them
+  in-place they'll be overwritten on the next `clud-bug update`. To
+  customize behavior for this repo, write a NEW skill rather than mutating
+  a baseline.
+- **From skills.sh** — installed via `clud-bug add <source/name>`. Tracked
+  in `.claude/skills/.clud-bug.json`. Use `clud-bug refresh` to sync.
+- **Custom** (anything not in the manifest) — yours, never touched by any
+  clud-bug command. Drop a new `.md` here and it auto-loads on the next PR.
+
+When you write a custom skill, follow the SKILL.md frontmatter format
+(`name`, `description`) and write specific, evidence-anchored guidance.
+Generic advice gets ignored; rules with examples and quoted-line evidence
+move the bot's behavior.
+
+## When you edit `.github/workflows/clud-bug-*.yml`
+
+`anthropics/claude-code-action` **refuses to run on PRs that modify its
+own workflow file** (App token exchange fails with 401, "Workflow
+validation failed"). This is a security guard against PRs that try to
+neuter the reviewer or exfiltrate secrets.
+
+Consequence: if you bundle a workflow tweak with other work, the
+`clud-bug-review` check on that PR will fail and not actually review your
+other changes either.
+
+The fix: split workflow edits into their own PR. The CLI helps:
+
+```bash
+# After editing .github/workflows/clud-bug-*.yml locally:
+clud-bug edit-workflow
+```
+
+It refuses to run if your working tree has non-workflow changes, so the
+isolation guarantee is enforced. Branches from `origin/main`, not HEAD —
+unrelated commits on a feature branch can't leak in.
+
+## When the secret is missing
+
+`ANTHROPIC_API_KEY` must be set in the repo's Actions secrets. Without it,
+the workflow's guard step fails loudly with an `::error::` annotation
+explaining how to set it. (For bot/fork PRs where the secret legitimately
+isn't passed, the guard posts a one-line advisory comment and exits 0
+instead of failing red.)
+
+## Updating clud-bug itself
+
+`clud-bug-self-update.yml` runs weekly (Mondays 12:00 UTC) and opens a PR
+when a newer clud-bug version is published to npm. Pin to a specific
+version by adding `pinVersion: "x.y.z"` to `.claude/skills/.clud-bug.json`.
+
+To trigger an update on demand:
+
+```bash
+clud-bug update
+```
+
+Re-renders workflow templates and refreshes baseline skills from the
+currently-installed clud-bug version. Custom and skills.sh-installed
+skills are left untouched.
+
+## Where to find more
+
+- Site: https://cludbug.dev
+- Repo: https://github.com/thrillmot/clud-bug
+- Skill catalog: https://github.com/thrillmot/agent-skills

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,3 +1,48 @@
 <!-- logmind-stub: AI agent instructions for this project live in AGENTS.md -->
 See [AGENTS.md](AGENTS.md) for project-specific AI agent instructions, including
 the decision-logging requirement (logmind) and required reading.
+
+<!-- clud-bug-start -->
+<!-- clud-bug-block-version: v1 -->
+## clud-bug — Claude PR review
+
+This repository uses [clud-bug](https://cludbug.dev) to review pull requests
+automatically. Three things matter when other agents (or future-you) work
+in this repo:
+
+### When you push fixes addressing prior Clud Bug review threads
+
+The bot resolves its own prior review threads on the next pass when it can
+verify the fix in the diff. You don't need to manually resolve threads it
+opened — push the fix, wait ~2 minutes, and check the PR. If a thread it
+left isn't auto-resolved after a fix, the bot judged the issue still open;
+read its latest review comment for what it's still flagging.
+
+### Strict mode
+
+Strict mode is **off** in this repo (advisory only). Toggle by editing `.claude/skills/.clud-bug.json`:
+
+```json
+{ "strictMode": true | false, ... }
+```
+
+The setting is read from the **base ref** of any open PR, so PRs cannot
+disable strict mode on themselves. Changes take effect on PRs opened after
+they merge to the base branch.
+
+### Where the skills live
+
+Project-aware review rules live in `.claude/skills/<name>/SKILL.md`. A
+small baseline kit ships with every install — see
+`.claude/skills/.clud-bug.json` for the current set. Add more via
+`clud-bug add <source/name>` (from skills.sh) or by dropping your own
+`.md` files there. They auto-load into the reviewer.
+
+### Editing the workflow
+
+Anthropic's `claude-code-action` refuses to run on PRs that modify its own
+workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
+their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
+
+_Installed at clud-bug v0.5.10._
+<!-- clud-bug-end -->

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v2
+# clud-bug-template-version: v4
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -12,6 +12,8 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
+      # checks: write — composite emits per-skill check-runs (BB.3).
+      checks: write
 
     steps:
       - uses: actions/checkout@v6
@@ -56,7 +58,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md)"
           prompt: |
             This project is "clud-bug". Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh. It's primarily javascript.
 
@@ -80,6 +82,23 @@ jobs:
             review MUST reference it by name in the finding (e.g. "[evidence-
             based-review]: this claim isn't anchored to a line"). Generic
             advice that contradicts a project skill is wrong by definition.
+
+            Skill routing — shared vs dedicated:
+            Each loaded skill carries a `review_mode:` field in its YAML
+            frontmatter at .claude/skills/<name>/SKILL.md. Two values:
+
+              - `review_mode: shared` — bug-finding / convention / evidence
+                skills. Their findings bundle into the standard "Critical
+                findings" / "Minor findings" sections.
+              - `review_mode: dedicated` — domain-specific skills (brand
+                voice, compliance, API-contract, test-discipline). Each
+                gets its own focused H3 section in the review.
+              - Missing field → treat as `shared`.
+
+            Before writing the review, scan each loaded skill's frontmatter
+            (the first `---`-delimited block of its SKILL.md) to identify
+            its review_mode. You can read them with:
+              cat .claude/skills/*/SKILL.md
 
             At the end of every review, append a single-line footer:
               Skills referenced: [skill-name-1, skill-name-2, ...]
@@ -148,6 +167,38 @@ jobs:
             open" are both 0. On follow-up reviews after a fix-push,
             "resolved from prior" should typically be positive.
 
+            Per-skill scan block (required, immediately under the status line):
+            After the **This round:** counters, emit a "### Per-skill scan"
+            section with ONE line per loaded skill — even silent ones. This
+            is the anti-dilution layer: every loaded skill must be
+            acknowledged so authors can see their skill ran, even when it
+            produced no findings.
+
+              ### Per-skill scan
+              - [<skill-name>]: <one-sentence outcome>
+
+            Examples (mix of shared + dedicated, with and without findings):
+              - [critical-issues-only]: scanned all paths. 2 critical findings below.
+              - [evidence-based-review]: applied to all findings. ✓ all anchored.
+              - [respect-existing-conventions]: scanned for pattern fights. 0 findings.
+              - [brand-voice-review]: scanned 3 microcopy changes. 1 finding (below).
+              - [pii-and-compliance]: scanned logging + analytics. 0 findings.
+
+            Per-skill findings sections (dedicated-mode skills only):
+            For each dedicated-mode skill that produced one or more
+            findings, emit a dedicated H3 section before the standard
+            critical/minor buckets:
+
+              ### Brand voice [brand-voice-review]
+              - Finding: button label "Click here!" violates verb-noun rule
+                (lib/ui/Button.tsx:42). Suggested: "Open settings."
+
+            Shared-mode skill findings stay in the existing combined
+            "Critical findings" / "Minor findings" buckets — they
+            cross-correlate (a logging-PII issue belongs in both the
+            critical-issues-only and pii-and-compliance lens at once), so
+            bundling preserves that signal.
+
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"
 
@@ -172,6 +223,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.8
+        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.10
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,48 @@ companion files, and creates the commit in one step. Use
 ## Development Commands
 
 <!-- Common commands a contributor needs (build, test, lint, run). -->
+
+<!-- clud-bug-start -->
+<!-- clud-bug-block-version: v1 -->
+## clud-bug — Claude PR review
+
+This repository uses [clud-bug](https://cludbug.dev) to review pull requests
+automatically. Three things matter when other agents (or future-you) work
+in this repo:
+
+### When you push fixes addressing prior Clud Bug review threads
+
+The bot resolves its own prior review threads on the next pass when it can
+verify the fix in the diff. You don't need to manually resolve threads it
+opened — push the fix, wait ~2 minutes, and check the PR. If a thread it
+left isn't auto-resolved after a fix, the bot judged the issue still open;
+read its latest review comment for what it's still flagging.
+
+### Strict mode
+
+Strict mode is **off** in this repo (advisory only). Toggle by editing `.claude/skills/.clud-bug.json`:
+
+```json
+{ "strictMode": true | false, ... }
+```
+
+The setting is read from the **base ref** of any open PR, so PRs cannot
+disable strict mode on themselves. Changes take effect on PRs opened after
+they merge to the base branch.
+
+### Where the skills live
+
+Project-aware review rules live in `.claude/skills/<name>/SKILL.md`. A
+small baseline kit ships with every install — see
+`.claude/skills/.clud-bug.json` for the current set. Add more via
+`clud-bug add <source/name>` (from skills.sh) or by dropping your own
+`.md` files there. They auto-load into the reviewer.
+
+### Editing the workflow
+
+Anthropic's `claude-code-action` refuses to run on PRs that modify its own
+workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
+their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
+
+_Installed at clud-bug v0.5.10._
+<!-- clud-bug-end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,48 @@
 <!-- logmind-stub: AI agent instructions for this project live in AGENTS.md -->
 See [AGENTS.md](AGENTS.md) for project-specific AI agent instructions, including
 the decision-logging requirement (logmind) and required reading.
+
+<!-- clud-bug-start -->
+<!-- clud-bug-block-version: v1 -->
+## clud-bug — Claude PR review
+
+This repository uses [clud-bug](https://cludbug.dev) to review pull requests
+automatically. Three things matter when other agents (or future-you) work
+in this repo:
+
+### When you push fixes addressing prior Clud Bug review threads
+
+The bot resolves its own prior review threads on the next pass when it can
+verify the fix in the diff. You don't need to manually resolve threads it
+opened — push the fix, wait ~2 minutes, and check the PR. If a thread it
+left isn't auto-resolved after a fix, the bot judged the issue still open;
+read its latest review comment for what it's still flagging.
+
+### Strict mode
+
+Strict mode is **off** in this repo (advisory only). Toggle by editing `.claude/skills/.clud-bug.json`:
+
+```json
+{ "strictMode": true | false, ... }
+```
+
+The setting is read from the **base ref** of any open PR, so PRs cannot
+disable strict mode on themselves. Changes take effect on PRs opened after
+they merge to the base branch.
+
+### Where the skills live
+
+Project-aware review rules live in `.claude/skills/<name>/SKILL.md`. A
+small baseline kit ships with every install — see
+`.claude/skills/.clud-bug.json` for the current set. Add more via
+`clud-bug add <source/name>` (from skills.sh) or by dropping your own
+`.md` files there. They auto-load into the reviewer.
+
+### Editing the workflow
+
+Anthropic's `claude-code-action` refuses to run on PRs that modify its own
+workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
+their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
+
+_Installed at clud-bug v0.5.10._
+<!-- clud-bug-end -->

--- a/docs/decisions-branches/feat__refresh-to-v4-templates-self-mod.md
+++ b/docs/decisions-branches/feat__refresh-to-v4-templates-self-mod.md
@@ -1,0 +1,10 @@
+## 2026-05-26 11:00 - Self-mod ceremony: refresh this repo to v4 templates + composite @v0.5.10
+
+**Reasoning:** PR #57 shipped v0.5.10 (per-skill check-runs) and the npm-publish workflow tagged. This repo's own clud-bug-review.yml was still v2 / @v0.5.8 — first opportunity to exercise v0.5.7's refresh-mode in production. `clud-bug update` correctly bumped marker v2 → v4, swapped composite ref @v0.5.8 → @v0.5.10, added the checks: write permission for BB.3 check-runs, and added Bash(cat .claude/skills/*/SKILL.md) to allowedTools so the v0.5.9 per-skill scan prompt actually has the tool it needs. Also installed the clud-bug-collaboration baseline (which this repo predates) and created the bare manifest. Refresh-mode preserved all five workflows correctly — no clobber on customized files.
+
+**Alternatives considered:** Wait for the weekly self-update cron (Mondays 12:00 UTC) — would land the same diff but blocks BB.3 in-production verification by another week with no upside. Rejected: dogfooding is the whole point.
+
+**Implications:**
+- First in-production exercise of refresh-mode (v0.5.7), composite-action @v0.5.10, and the v0.5.9 per-skill scan output structure end-to-end. The PR will trigger the expected claude-code-action 401 self-mod guard; merging requires the Repository-admin bypass we set up in PR #55. No code change in clud-bug itself — this is purely the rendered-output sync.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — Self-mod ceremony: refresh this repo to v4 templates + composite @v0.5.10 *(feat/refresh-to-v4-templates-self-mod)* — [decisions-branches/feat__refresh-to-v4-templates-self-mod.md](decisions-branches/feat__refresh-to-v4-templates-self-mod.md)
 - **2026-05-18** — Stream BB.3: per-skill check-runs in composite action (v0.5.10) *(feat/per-skill-check-runs-v0.5.10)* — [decisions-branches/feat__per-skill-check-runs-v0.5.10.md](decisions-branches/feat__per-skill-check-runs-v0.5.10.md)
 - **2026-05-18** — Stream BB.1+BB.2: skill routing via review_mode + per-skill review output (v0.5.9) *(feat/skill-routing-v0.5.9)* — [decisions-branches/feat__skill-routing-v0.5.9.md](decisions-branches/feat__skill-routing-v0.5.9.md)
 - **2026-05-18** — Self-mod ceremony: render v2 templates into this repo own clud-bug-review.yml *(feat/render-v2-templates-self-mod)* — [decisions-branches/feat__render-v2-templates-self-mod.md](decisions-branches/feat__render-v2-templates-self-mod.md)


### PR DESCRIPTION
## Summary

First in-production exercise of v0.5.7's refresh-mode + v0.5.10's BB.3 composite action. Mechanical output of `node bin/clud-bug.js update` against this repo's v2 install — no code change in clud-bug itself, just the rendered output sync. Same shape as PR #55.

### What refreshed

- **`.github/workflows/clud-bug-review.yml`**: marker `v2` → `v4`, composite ref `@v0.5.8` → `@v0.5.10`, `+checks: write` permission for BB.3 per-skill check-runs, `+Bash(cat .claude/skills/*/SKILL.md)` so the v0.5.9 per-skill scan prompt has the tool it needs.
- **`.claude/skills/.clud-bug.json`**: bare manifest created (this repo predates the manifest format).
- **`.claude/skills/clud-bug-collaboration/`**: baseline shipped in v0.5.1 that wasn't installed here.
- **`AGENTS.md` / `CLAUDE.md` / `.cursorrules`**: agent-docs block refreshed by `clud-bug update` (committed in the preceding `logmind:` commit).
- **`docs/timeline.md`**: regenerated to include today's decision entry.

### What this validates end-to-end

- Refresh-mode (v0.5.7): correctly bumps marker-bearing files, leaves markerless ones, prints the from→to transition.
- Composite action @v0.5.10 (v0.5.8 + BB.3): emits gate + per-skill check-runs.
- v0.5.9 per-skill scan prompt actually runs (with the now-correct allowlist).

### Expected: clud-bug-review check fails 401

This PR edits `.github/workflows/clud-bug-review.yml`, so `claude-code-action` will refuse to review (self-mod guard — by design). The Repository-admin bypass on the `reporulez-default` ruleset (configured in PR #55) handles the merge.

### Notes on BB.3 in this PR

The manifest is bare — no `strictSkills` set, so the new check-runs codepath is a no-op for this PR. BB.3 will be exercised end-to-end whenever a PR opts in via `strictSkills`. That's a separate policy decision, not part of this mechanical refresh.

## Test plan

- [ ] All non-bot checks pass (actionlint, check-decisions, check-derived-docs, check-links, test, vercel)
- [ ] claude-review reads the diff and confirms it's a mechanical render
- [ ] clud-bug-review fails 401 (expected self-mod guard)
- [ ] Admin-bypass merge succeeds via the ruleset bypass set up in PR #55
- [ ] After merge: next PR opened against main shows v0.5.10 review behavior + per-skill scan block

🤖 Generated with [Claude Code](https://claude.com/claude-code)