### PR TITLE
chore: opt this repo into strictMode + strictSkills (dogfood BB.3)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -2,5 +2,12 @@
   "version": 1,
   "installed": [],
   "lastUpdate": "2026-05-26T14:59:41.127Z",
-  "lastUpdateVersion": "0.5.10"
+  "lastUpdateVersion": "0.5.10",
+  "strictMode": true,
+  "strictSkills": [
+    "critical-issues-only",
+    "evidence-based-review",
+    "respect-existing-conventions",
+    "clud-bug-collaboration"
+  ]
 }

--- a/docs/decisions-branches/chore__strict-skills-opt-in-baselines.md
+++ b/docs/decisions-branches/chore__strict-skills-opt-in-baselines.md
@@ -1,0 +1,10 @@
+## 2026-05-26 11:17 - Opt this repo into strictMode + strictSkills for the 4 baselines (dogfood BB.3)
+
+**Reasoning:** PR #58 just refreshed this repo to v4 templates + composite @v0.5.10, which has BB.3 per-skill check-runs wired up. The manifest was bare so the codepath was a no-op — first chance to actually exercise BB.3 end-to-end in production. Setting strictMode: true (master gate fails on critical findings; gate behavior we already wanted) and strictSkills to the 4 baselines so each baseline emits its own check-run in the PR check list. The per-skill check-runs are visible signal but not required to merge unless added to the reporulez-default ruleset (which we are deliberately not doing in this PR — surfacing the check-runs first, deciding whether to gate on them later).
+
+**Alternatives considered:** Just the 4 baselines as strictSkills (chosen). Smallest blast radius that still tests BB.3 end-to-end. Future PRs can add dedicated-mode skills like brand-voice-review if we install them here later.
+
+**Implications:**
+- First in-production exercise of v0.5.10 BB.3 on this repo. Validates: (a) checks: write permission emits check-runs correctly via Checks API, (b) classifyPerSkillOutcome + extractPerSkillLine handle real bot output, (c) the prompt block requiring a Per-skill scan section actually fires. No code change — manifest-only. If anything breaks downstream on installed repos that adopt strictSkills, this PR is the canary.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — Opt this repo into strictMode + strictSkills for the 4 baselines (dogfood BB.3) *(chore/strict-skills-opt-in-baselines)* — [decisions-branches/chore__strict-skills-opt-in-baselines.md](decisions-branches/chore__strict-skills-opt-in-baselines.md)
 - **2026-05-26** — Self-mod ceremony: refresh this repo to v4 templates + composite @v0.5.10 *(feat/refresh-to-v4-templates-self-mod)* — [decisions-branches/feat__refresh-to-v4-templates-self-mod.md](decisions-branches/feat__refresh-to-v4-templates-self-mod.md)
 - **2026-05-18** — Stream BB.3: per-skill check-runs in composite action (v0.5.10) *(feat/per-skill-check-runs-v0.5.10)* — [decisions-branches/feat__per-skill-check-runs-v0.5.10.md](decisions-branches/feat__per-skill-check-runs-v0.5.10.md)
 - **2026-05-18** — Stream BB.1+BB.2: skill routing via review_mode + per-skill review output (v0.5.9) *(feat/skill-routing-v0.5.9)* — [decisions-branches/feat__skill-routing-v0.5.9.md](decisions-branches/feat__skill-routing-v0.5.9.md)


### PR DESCRIPTION
## Summary

Tiny manifest-only edit. Opts this repo into the BB.3 per-skill check-runs codepath that shipped in v0.5.10 — first in-production exercise on our own PRs.

```diff
 {
   "version": 1,
   "installed": [],
   "lastUpdate": "2026-05-26T14:59:41.127Z",
-  "lastUpdateVersion": "0.5.10"
+  "lastUpdateVersion": "0.5.10",
+  "strictMode": true,
+  "strictSkills": [
+    "critical-issues-only",
+    "evidence-based-review",
+    "respect-existing-conventions",
+    "clud-bug-collaboration"
+  ]
 }
```

### What this changes at runtime

After merge, on every PR opened against `main`:
- The composite `strict-mode-gate` action (already on `@v0.5.10` from PR #58) reads `strictMode: true` from base ref and fails the `clud-bug-review` check on critical findings — gate behavior we already wanted.
- The composite emits 4 new check-runs via the GitHub Checks API, one per baseline (`critical-issues-only`, `evidence-based-review`, `respect-existing-conventions`, `clud-bug-collaboration`). Each check-run's conclusion is derived from the skill's line in the bot's `### Per-skill scan` block (success = "0 findings"/"n/a", failure = any other content, neutral = skill not mentioned).

The 4 new check-runs are **visible signal, not blocking** — they show up in the PR check list but aren't in the `reporulez-default` ruleset's `required_status_checks`. Deciding whether to gate on them is a separate policy decision for a future PR.

### What this validates end-to-end

- `checks: write` permission added in PR #58 actually emits check-runs.
- `classifyPerSkillOutcome` + `extractPerSkillLine` (lib/skills.js, v0.5.10) handle real bot output.
- The v0.5.9 prompt block requiring a Per-skill scan section actually fires.
- The whole BB stream is now exercised on this repo's own PRs.

### Why this isn't risky

- No code change.
- `strictMode: true` was always going to be the eventual gate; the bot was already advisory-mode on this repo despite shipping strict-mode-by-default to new installs (v0.4.0 grandfathered existing installs into advisory).
- If `strictMode` proves too aggressive on our own work, revert is a one-line manifest edit.

## Test plan

- [ ] All non-bot checks pass (actionlint, check-decisions, check-derived-docs, check-links, test, vercel)
- [ ] claude-review confirms manifest-only change
- [ ] clud-bug-review reads the new strictMode/strictSkills correctly (advisory on this PR since base manifest doesn't have them yet — gate fires next PR after merge)
- [ ] After merge: open a throwaway PR; observe 4 new check-runs in the PR's check list

🤖 Generated with [Claude Code](https://claude.com/claude-code)