### PR TITLE
feat: pin claude-code-action via {{CCA_VERSION}} + route audit/self-update through renderFile (v0.5.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,25 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
-### Pending (separate PR)
-- Pinning `anthropics/claude-code-action@v1` via `{{CCA_VERSION}}` placeholder substitution. Requires routing `audit.yml.tmpl` + `self-update.yml.tmpl` through `renderFile` (currently raw `readFile`).
+## [0.5.11] — 2026-05-26
+
+### Added
+
+- **`anthropics/claude-code-action` is now pinned to a specific tag** in every shipped workflow. Templates use `@{{CCA_VERSION}}` instead of the floating `@v1` major. The pin lives in `lib/render.js`'s new `DEFAULTS` map (currently `v1.0.133` — the latest stable at release time). Bumping the pin requires a clud-bug release, which makes upstream action upgrades visible in the CHANGELOG and lets users with their own forks opt to a different version. Closes the Unreleased item that's been carried since v0.5.6.
+- **`audit.yml.tmpl` and `self-update.yml.tmpl` now flow through `renderFile`** (were raw `readFile` pre-v0.5.11). Required to make `{{CCA_VERSION}}` substitution land in audit alongside review. Self-update has no CCA reference today but is routed through `renderFile` for parity so future tokens propagate uniformly without another refactor.
+- **`DEFAULTS` exported from `lib/render.js`.** Single source of truth for template substitution defaults. The v0.6 App will reuse this map to render workflows in its own runtime, keeping the pin contract identical across CLI + App.
+
+### Changed
+
+- **Template markers bumped:**
+  - `workflow.yml.tmpl`, `workflow-ts.yml.tmpl`, `workflow-py.yml.tmpl`: `v4` → `v5`
+  - `audit.yml.tmpl`: `v1` → `v2` (first content change since markers were introduced in v0.5.6)
+  - `self-update.yml.tmpl`: stays `v1` (no content change; the `readFile` → `renderFile` switch is internal to clud-bug, byte-identical output today)
+- Existing v4/v1 installs auto-upgrade to v5/v2 via v0.5.7's refresh-mode on the next `clud-bug update`.
+
+### Internal
+
+- 4 new tests in `test/render.test.js` pin the DEFAULTS contract: CCA_VERSION format (`vMAJOR.MINOR.PATCH`), substitution from defaults when caller omits it, caller-override precedence, missing-var guard still fires for non-defaulted tokens.
 
 ## [0.5.10] — 2026-05-18
 
@@ -139,6 +156,7 @@ Installs predating PR #52 have markerless workflows. The first `clud-bug update`
 - **Bot-authored PRs are now handled gracefully.** PRs from `dependabot[bot]`, `renovate[bot]`, or forks (where GitHub deliberately doesn't pass repository secrets) used to fail loudly red — wrong signal. Now a guard step detects the case, posts a one-line advisory comment ("Clud Bug skipped — bot/fork PR cannot access secrets"), and exits 0. Check stays green; the skip is visible. Owner-authored PRs without the secret still fail loud.
 - **Site polish (carries over from the unreleased entry):** alive bug emoji (layered breathe + twitch + scuttle animations), Plate label gloss, thrillmot footer credit.
 
+[0.5.11]: https://github.com/thrillmot/clud-bug/compare/v0.5.10...v0.5.11
 [0.5.10]: https://github.com/thrillmot/clud-bug/compare/v0.5.9...v0.5.10
 [0.5.9]: https://github.com/thrillmot/clud-bug/compare/v0.5.8...v0.5.9
 [0.5.8]: https://github.com/thrillmot/clud-bug/compare/v0.5.7...v0.5.8

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -183,7 +183,9 @@ async function runInit(args) {
 
   // Install the audit workflow alongside the per-PR review one.
   // Manual-trigger by default; users opt into the cron by uncommenting.
-  const auditTmpl = await readFile(join(TEMPLATES, 'audit.yml.tmpl'), 'utf8');
+  // Routed through renderFile so {{CCA_VERSION}} substitution pins
+  // claude-code-action consistently with the review workflow.
+  const auditTmpl = await renderFile(join(TEMPLATES, 'audit.yml.tmpl'), {});
   const auditPath = join(cwd, '.github', 'workflows', 'clud-bug-audit.yml');
   await writeFile(auditPath, auditTmpl);
   log(`    wrote ${rel(cwd, auditPath)}`);
@@ -191,7 +193,9 @@ async function runInit(args) {
   // Install the self-update workflow. Cron weekly Mondays 12:00 UTC; opens
   // a PR if a newer clud-bug version is published. Disable by deleting the
   // file or pinning via .claude/skills/.clud-bug.json.
-  const selfUpdateTmpl = await readFile(join(TEMPLATES, 'self-update.yml.tmpl'), 'utf8');
+  // Routed through renderFile for parity (no CCA ref today but future
+  // tokens should propagate uniformly).
+  const selfUpdateTmpl = await renderFile(join(TEMPLATES, 'self-update.yml.tmpl'), {});
   const selfUpdatePath = join(cwd, '.github', 'workflows', 'clud-bug-self-update.yml');
   await writeFile(selfUpdatePath, selfUpdateTmpl);
   log(`    wrote ${rel(cwd, selfUpdatePath)}`);

--- a/docs/decisions-branches/feat__cca-version-pinning.md
+++ b/docs/decisions-branches/feat__cca-version-pinning.md
@@ -1,0 +1,10 @@
+## 2026-05-26 11:25 - Pin claude-code-action via {{CCA_VERSION}} substitution + route audit/self-update through renderFile (v0.5.11)
+
+**Reasoning:** Carried Unreleased CHANGELOG item since v0.5.6: workflows pinned anthropics/claude-code-action@v1 (the floating major tag), so upstream action releases could silently land in installed workflows mid-cycle. The fix needed two coordinated changes: (a) add a CCA_VERSION substitution token to all 4 templates that reference the action, and (b) route audit.yml.tmpl and self-update.yml.tmpl through renderFile() (they were raw readFile, so substitution had no effect). Implemented as a single PR with a DEFAULTS export from lib/render.js so the pin lives in one place and the v0.6 App can reuse the same map.
+
+**Alternatives considered:** SHA-pin instead of tag-pin (would catch tag-mutation attacks). Rejected for v0.5.11: tag pins are more readable, semantically meaningful, and match the rest of the GitHub ecosystem convention. SHA-pinning is a defense-in-depth followup worth considering for v0.6.x but not blocking; users can SHA-pin in their own forks today by editing the rendered workflow. Also considered: pinning to @v1.0 minor floating tag. Rejected: GitHub Action tag refs do not do semver range matching; @v1.0 either does not exist as a tag or floats, depending on how the action publishes. Exact tag is the only honest contract.
+
+**Implications:**
+- Bumping CCA_VERSION is now a clud-bug release event — visible in CHANGELOG, picked up by refresh-mode via the v5/v2 marker bump. Existing installs auto-upgrade on next clud-bug update. Future App runtime reads the same DEFAULTS.CCA_VERSION so CLI + App stay in lockstep. Pin is currently v1.0.133 (latest stable as of 2026-05-26); update procedure is one-line edit in lib/render.js + version bump + ship.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — Pin claude-code-action via {{CCA_VERSION}} substitution + route audit/self-update through renderFile (v0.5.11) *(feat/cca-version-pinning)* — [decisions-branches/feat__cca-version-pinning.md](decisions-branches/feat__cca-version-pinning.md)
 - **2026-05-26** — Opt this repo into strictMode + strictSkills for the 4 baselines (dogfood BB.3) *(chore/strict-skills-opt-in-baselines)* — [decisions-branches/chore__strict-skills-opt-in-baselines.md](decisions-branches/chore__strict-skills-opt-in-baselines.md)
 - **2026-05-26** — Self-mod ceremony: refresh this repo to v4 templates + composite @v0.5.10 *(feat/refresh-to-v4-templates-self-mod)* — [decisions-branches/feat__refresh-to-v4-templates-self-mod.md](decisions-branches/feat__refresh-to-v4-templates-self-mod.md)
 - **2026-05-18** — Stream BB.3: per-skill check-runs in composite action (v0.5.10) *(feat/per-skill-check-runs-v0.5.10)* — [decisions-branches/feat__per-skill-check-runs-v0.5.10.md](decisions-branches/feat__per-skill-check-runs-v0.5.10.md)

--- a/lib/render.js
+++ b/lib/render.js
@@ -2,12 +2,26 @@ import { readFile } from 'node:fs/promises';
 
 const PLACEHOLDER_RE = /\{\{([A-Z_]+)\}\}/g;
 
+// Default values for substitution tokens that every template uses.
+// Callers can override per-render by passing the same key in `vars`.
+//
+// CCA_VERSION pins `anthropics/claude-code-action` to a specific tag in
+// every shipped workflow. Without this, templates resolved `@v1` (the
+// floating major), so upstream changes could silently land in installed
+// workflows mid-cycle. Bumping the pin requires a clud-bug release, which
+// makes the upgrade visible + lets users opt out by pinning a different
+// version in their own forked workflow.
+export const DEFAULTS = {
+  CCA_VERSION: 'v1.0.133',
+};
+
 export function render(template, vars) {
+  const merged = { ...DEFAULTS, ...vars };
   return template.replace(PLACEHOLDER_RE, (match, key) => {
-    if (!(key in vars)) {
+    if (!(key in merged)) {
       throw new Error(`Missing template variable: ${key}`);
     }
-    return vars[key];
+    return merged[key];
   });
 }
 

--- a/lib/update.js
+++ b/lib/update.js
@@ -51,16 +51,20 @@ export async function runUpdate({
   await maybeRefreshVersioned(join(cwd, '.github/workflows/clud-bug-review.yml'), newReview, changed, unchanged, skipped, 'review workflow');
 
   // 2. Re-render audit workflow if it's installed (init from v0.3+ ships it).
+  // Routed through renderFile (was raw readFile pre-v0.5.11) so
+  // {{CCA_VERSION}} substitution lands in audit alongside review.
   const auditPath = join(cwd, '.github/workflows/clud-bug-audit.yml');
   if (await pathExists(auditPath)) {
-    const newAudit = await readFile(join(templatesDir, 'audit.yml.tmpl'), 'utf8');
+    const newAudit = await renderFile(join(templatesDir, 'audit.yml.tmpl'), {});
     await maybeRefreshVersioned(auditPath, newAudit, changed, unchanged, skipped, 'audit workflow');
   }
 
   // 2b. Re-render self-update workflow if installed (init from v0.4+ ships it).
+  // Routed through renderFile for parity — no CCA ref in self-update today
+  // but future tokens should propagate uniformly without another refactor.
   const selfUpdatePath = join(cwd, '.github/workflows/clud-bug-self-update.yml');
   if (await pathExists(selfUpdatePath)) {
-    const newSelfUpdate = await readFile(join(templatesDir, 'self-update.yml.tmpl'), 'utf8');
+    const newSelfUpdate = await renderFile(join(templatesDir, 'self-update.yml.tmpl'), {});
     await maybeRefreshVersioned(selfUpdatePath, newSelfUpdate, changed, unchanged, skipped, 'self-update workflow');
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/templates/audit.yml.tmpl
+++ b/templates/audit.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v1
+# clud-bug-template-version: v2
 name: Clud Bug 🐛 Audit
 
 # A scheduled / on-demand walk through the whole habitat (or a recent slice).
@@ -89,7 +89,7 @@ jobs:
           git push -u origin "$BRANCH"
           echo "stub_written=true" >> "$GITHUB_OUTPUT"
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@{{CCA_VERSION}}
         if: steps.prep.outputs.stub_written == 'true'
         env:
           AUDIT_DATE: ${{ steps.prep.outputs.date }}

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v4
+# clud-bug-template-version: v5
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -50,7 +50,7 @@ jobs:
           echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
           exit 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@{{CCA_VERSION}}
         if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v4
+# clud-bug-template-version: v5
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -50,7 +50,7 @@ jobs:
           echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
           exit 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@{{CCA_VERSION}}
         if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v4
+# clud-bug-template-version: v5
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -75,7 +75,7 @@ jobs:
           echo "::error::Without it, Clud Bug review is a silent no-op."
           exit 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@{{CCA_VERSION}}
         # Skip the action when guard already posted the bot/fork advisory.
         if: steps.guard.outputs.skip != 'true'
         env:

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -5,6 +5,7 @@ import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
+import { DEFAULTS } from '../lib/render.js';
 
 const CLI = join(dirname(dirname(fileURLToPath(import.meta.url))), 'bin', 'clud-bug.js');
 
@@ -56,6 +57,20 @@ test('init --offline --accept-all in a fresh repo writes workflow + manifest', a
     assert.equal(r.status, 0, `init failed: ${r.stderr}`);
     const wf = await readFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'utf8');
     assert.match(wf, /allowedTools/);
+    // v0.5.11 regression guard: review workflow must carry the resolved
+    // CCA pin, not a literal placeholder. PR #60 found that audit + self-
+    // update slipped past for several releases via raw readFile — same
+    // guard belongs on the review-workflow init path so any future
+    // renderFile → readFile regression on bin/clud-bug.js fails loud.
+    const ccaPin = DEFAULTS.CCA_VERSION.replace(/\./g, '\\.');
+    assert.match(wf, new RegExp(`claude-code-action@${ccaPin}`));
+    assert.doesNotMatch(wf, /\{\{CCA_VERSION\}\}/);
+    // Same guard on the audit + self-update workflows the init writes.
+    const audit = await readFile(join(dir, '.github/workflows/clud-bug-audit.yml'), 'utf8');
+    assert.match(audit, new RegExp(`claude-code-action@${ccaPin}`));
+    assert.doesNotMatch(audit, /\{\{CCA_VERSION\}\}/);
+    const selfUpd = await readFile(join(dir, '.github/workflows/clud-bug-self-update.yml'), 'utf8');
+    assert.doesNotMatch(selfUpd, /\{\{[A-Z_]+\}\}/);
     const manifest = JSON.parse(await readFile(join(dir, '.claude/skills/.clud-bug.json'), 'utf8'));
     assert.equal(manifest.installed.length, 4, 'should install 4 baseline skills');
     assert.ok(manifest.installed.every(e => e.kind === 'baseline'));

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { render, pickTemplate } from '../lib/render.js';
+import { render, pickTemplate, DEFAULTS } from '../lib/render.js';
 
 test('render fills single placeholder', () => {
   const out = render('hello {{NAME}}', { NAME: 'world' });
@@ -43,4 +43,35 @@ test('pickTemplate falls back to Python when no JS/TS', () => {
 test('pickTemplate falls back to generic for other languages', () => {
   assert.equal(pickTemplate(['go']), 'workflow.yml.tmpl');
   assert.equal(pickTemplate([]), 'workflow.yml.tmpl');
+});
+
+// --- v0.5.11: DEFAULTS map + CCA_VERSION pinning ---
+// Templates use {{CCA_VERSION}} to pin anthropics/claude-code-action. The
+// DEFAULTS map in render.js provides the pin, so callers don't have to
+// thread it through every renderFile call. Bumping the pin is a clud-bug
+// release event (visible in CHANGELOG, picked up by refresh-mode).
+
+test('DEFAULTS exports a non-empty CCA_VERSION pin', () => {
+  assert.equal(typeof DEFAULTS.CCA_VERSION, 'string');
+  // Must look like a real version tag, not "v1" (the floating major we are
+  // explicitly pinning away from). Format: vMAJOR.MINOR.PATCH.
+  assert.match(DEFAULTS.CCA_VERSION, /^v\d+\.\d+\.\d+$/);
+});
+
+test('render substitutes CCA_VERSION from DEFAULTS when caller omits it', () => {
+  const out = render('uses: anthropics/claude-code-action@{{CCA_VERSION}}', {});
+  assert.equal(out, `uses: anthropics/claude-code-action@${DEFAULTS.CCA_VERSION}`);
+});
+
+test('render lets caller override DEFAULTS via explicit vars', () => {
+  // Defense in depth: a downstream caller (e.g. the v0.6 App) may need to
+  // override the pin without editing render.js. Caller-supplied vars win.
+  const out = render('@{{CCA_VERSION}}', { CCA_VERSION: 'v9.9.9' });
+  assert.equal(out, '@v9.9.9');
+});
+
+test('render still throws on a placeholder not in DEFAULTS or vars', () => {
+  // Adding DEFAULTS must not weaken the missing-var guard for tokens
+  // that aren't in the defaults map.
+  assert.throws(() => render('{{NOT_DEFAULTED}}', {}), /Missing template variable: NOT_DEFAULTED/);
 });

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -5,6 +5,7 @@ import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { runUpdate } from '../lib/update.js';
+import { DEFAULTS } from '../lib/render.js';
 
 const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const TEMPLATES = join(REPO_ROOT, 'templates');
@@ -152,8 +153,19 @@ test('runUpdate: re-renders audit + self-update workflows when installed (stale 
     const audit = await readFile(join(dir, '.github/workflows/clud-bug-audit.yml'), 'utf8');
     assert.match(audit, /Clud Bug 🐛 Audit/);
     assert.ok(r.changed.some((c) => c.label === 'audit workflow'));
+    // v0.5.11 regression guard: audit must flow through renderFile so
+    // {{CCA_VERSION}} substitution lands. The pre-v0.5.11 readFile path
+    // would leak the literal placeholder into installed workflows. Both
+    // bots on PR #60 caught the test gap — pin the wiring at this layer.
+    const ccaPin = DEFAULTS.CCA_VERSION.replace(/\./g, '\\.');
+    assert.match(audit, new RegExp(`claude-code-action@${ccaPin}`));
+    assert.doesNotMatch(audit, /\{\{CCA_VERSION\}\}/);
     const selfUpd = await readFile(join(dir, '.github/workflows/clud-bug-self-update.yml'), 'utf8');
     assert.match(selfUpd, /Self-Update/);
     assert.ok(r.changed.some((c) => c.label === 'self-update workflow'));
+    // Same regression guard for self-update — no CCA ref today but the
+    // file must not contain ANY unsubstituted {{X}} placeholders, which
+    // would indicate renderFile silently regressed back to readFile.
+    assert.doesNotMatch(selfUpd, /\{\{[A-Z_]+\}\}/);
   } finally { await rm(dir, { recursive: true, force: true }); }
 });

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -59,7 +59,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // Workflow refreshed
     const wf = await readFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'utf8');
     assert.match(wf, /allowedTools/);
-    assert.match(wf, /^# clud-bug-template-version: v4/);
+    assert.match(wf, /^# clud-bug-template-version: v5/);
     // Baseline rewritten with current shipped content
     const baseline = await readFile(join(dir, '.claude/skills/critical-issues-only/SKILL.md'), 'utf8');
     assert.match(baseline, /critical-issues-only/);
@@ -74,7 +74,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // The refreshed workflow records a from/to version note.
     const wfChange = r.changed.find((c) => c.label === 'review workflow');
     assert.equal(wfChange.from, 'v0');
-    assert.equal(wfChange.to, 'v4');
+    assert.equal(wfChange.to, 'v5');
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
## Summary

Closes the `Unreleased` CHANGELOG item carried since v0.5.6. Templates pinned `anthropics/claude-code-action@v1` (the floating major), so upstream action releases could silently land in installed workflows. Two coordinated changes ship together:

### 1. `{{CCA_VERSION}}` substitution token in templates

Swapped `@v1` → `@{{CCA_VERSION}}` in the 4 templates that reference `claude-code-action`:
- `templates/workflow.yml.tmpl:78`
- `templates/workflow-ts.yml.tmpl:53`
- `templates/workflow-py.yml.tmpl:53`
- `templates/audit.yml.tmpl:92`

### 2. `DEFAULTS` map in `lib/render.js`

New export with `CCA_VERSION: 'v1.0.133'` — the current latest stable (verified at `gh release list --repo anthropics/claude-code-action`). `render()` merges DEFAULTS before applying caller-supplied `vars`, so callers don't have to remember to thread the pin through every render call. Caller-supplied vars win, so the v0.6 App can override per-install.

Bumping the pin is now a clud-bug release event — visible in CHANGELOG, picked up by refresh-mode via the marker bump. Update procedure is one-line edit in `lib/render.js` + version bump + ship.

### 3. `audit.yml.tmpl` + `self-update.yml.tmpl` flow through `renderFile`

Pre-v0.5.11 they used raw `readFile`, so `{{CCA_VERSION}}` substitution would have been silently ignored. Now both go through `renderFile()` in both code paths:
- `bin/clud-bug.js:186, 194` (init)
- `lib/update.js:56, 63` (update)

Self-update has no CCA ref today; it's routed for parity so future tokens propagate uniformly without another refactor.

### Template marker bumps

- `workflow.yml.tmpl`, `workflow-ts.yml.tmpl`, `workflow-py.yml.tmpl`: `v4` → `v5`
- `audit.yml.tmpl`: `v1` → `v2` (first content change since markers were introduced in v0.5.6)
- `self-update.yml.tmpl`: stays `v1` (byte-identical output today; the `readFile` → `renderFile` switch is internal)

Existing v4/v1 installs auto-upgrade via v0.5.7's refresh-mode on the next `clud-bug update`.

### Tests

135 pass (+4 new in `test/render.test.js`):
- `DEFAULTS.CCA_VERSION` exists + matches `vMAJOR.MINOR.PATCH` format
- Substitution from defaults when caller omits the var
- Caller-supplied vars override DEFAULTS
- Missing-var guard still fires for tokens not in DEFAULTS

`test/update.test.js` bumped from asserting `v4` to `v5` on refresh-mode.

### Why we picked tag-pin over SHA-pin

SHA-pin would catch tag-mutation attacks (a malicious actor force-pushing a tag to point at compromised code). Considered and deferred:
- Tag pin is more readable + semantically meaningful + matches the rest of the GitHub Actions ecosystem.
- SHA-pin is a defense-in-depth followup for v0.6.x; users can SHA-pin in their own forks today.
- The risk profile of `anthropics/claude-code-action` (Anthropic-owned, no community contributors with push, public release process) makes tag pin acceptable.

## What this PR also validates (BB.3 dogfood)

This is the **first PR after #59 merged** opting this repo into `strictMode: true` + `strictSkills: [4 baselines]`. Expected behavior:
- 4 new per-skill check-runs appear in the PR check list: `critical-issues-only`, `evidence-based-review`, `respect-existing-conventions`, `clud-bug-collaboration`
- `clud-bug-review` uses the strict-mode header variant (`## 🐛 Clud Bug review — clean` or `— critical findings`)
- Strict-mode gate fires for real — fails `clud-bug-review` on any critical finding

## Test plan

- [ ] All non-bot checks pass (actionlint, check-decisions, check-derived-docs, check-links, test, vercel)
- [ ] claude-review confirms tag-pin + renderFile routing
- [ ] **4 new per-skill check-runs appear** in PR check list (first BB.3 dogfood test)
- [ ] clud-bug-review uses strict-mode header
- [ ] After merge + npm publish: scratch `clud-bug init` produces workflows with `@v1.0.133`; scratch `clud-bug update` against a v4 install refreshes to v5 with the pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)