### PR TITLE
ceremony: bump this repo from @v0.5.10 (KNOWN-BROKEN) to @v0.5.12 composite (self-mod)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
   "installed": [],
-  "lastUpdate": "2026-05-26T14:59:41.127Z",
-  "lastUpdateVersion": "0.5.10",
+  "lastUpdate": "2026-05-26T16:14:16.643Z",
+  "lastUpdateVersion": "0.5.12",
   "strictMode": true,
   "strictSkills": [
     "critical-issues-only",

--- a/.cursorrules
+++ b/.cursorrules
@@ -20,7 +20,7 @@ read its latest review comment for what it's still flagging.
 
 ### Strict mode
 
-Strict mode is **off** in this repo (advisory only). Toggle by editing `.claude/skills/.clud-bug.json`:
+Strict mode is **on** in this repo (workflow check fails on critical findings). Toggle by editing `.claude/skills/.clud-bug.json`:
 
 ```json
 { "strictMode": true | false, ... }
@@ -44,5 +44,5 @@ Anthropic's `claude-code-action` refuses to run on PRs that modify its own
 workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
 their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
 
-_Installed at clud-bug v0.5.10._
+_Installed at clud-bug v0.5.12._
 <!-- clud-bug-end -->

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v4
+# clud-bug-template-version: v6
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -50,7 +50,7 @@ jobs:
           echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
           exit 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1.0.133
         if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -60,7 +60,7 @@ jobs:
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md)"
           prompt: |
-            This project is "clud-bug". Claude PR review with project-aware skills. CLI installs a working GitHub Actions workflow and curates skills from skills.sh. It's primarily javascript.
+            This project is "clud-bug". Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh. It's primarily javascript.
 
             Review this pull request for critical issues only. Focus on:
             - Bugs, logic errors, or incorrect behaviour
@@ -223,6 +223,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.10
+        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.12
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ read its latest review comment for what it's still flagging.
 
 ### Strict mode
 
-Strict mode is **off** in this repo (advisory only). Toggle by editing `.claude/skills/.clud-bug.json`:
+Strict mode is **on** in this repo (workflow check fails on critical findings). Toggle by editing `.claude/skills/.clud-bug.json`:
 
 ```json
 { "strictMode": true | false, ... }
@@ -94,5 +94,5 @@ Anthropic's `claude-code-action` refuses to run on PRs that modify its own
 workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
 their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
 
-_Installed at clud-bug v0.5.10._
+_Installed at clud-bug v0.5.12._
 <!-- clud-bug-end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ read its latest review comment for what it's still flagging.
 
 ### Strict mode
 
-Strict mode is **off** in this repo (advisory only). Toggle by editing `.claude/skills/.clud-bug.json`:
+Strict mode is **on** in this repo (workflow check fails on critical findings). Toggle by editing `.claude/skills/.clud-bug.json`:
 
 ```json
 { "strictMode": true | false, ... }
@@ -44,5 +44,5 @@ Anthropic's `claude-code-action` refuses to run on PRs that modify its own
 workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
 their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
 
-_Installed at clud-bug v0.5.10._
+_Installed at clud-bug v0.5.12._
 <!-- clud-bug-end -->

--- a/docs/decisions-branches/ceremony__self-mod-bump-to-v0.5.12.md
+++ b/docs/decisions-branches/ceremony__self-mod-bump-to-v0.5.12.md
@@ -1,0 +1,10 @@
+## 2026-05-26 12:14 - Self-mod ceremony: bump this repo from @v0.5.10 (KNOWN-BROKEN) to @v0.5.12 composite
+
+**Reasoning:** PR #61 fixed both strict-mode-gate and BB.3 per-skill check-runs body-start matching bugs. v0.5.12 shipped to npm. This repo own clud-bug-review.yml still pointed at @v0.5.10 since PR #58 last refresh — meaning every PR opened against main since #60 was reviewed by the KNOWN-BROKEN gate. Per-skill check-runs never emitted; strict mode silently passed. Running clud-bug update from the now-current 0.5.12 CLI refreshes the workflow to v6 templates with @v0.5.12 composite and @v1.0.133 CCA pin — exercising both v0.5.11 ({{CCA_VERSION}}) and v0.5.12 (gate + BB.3 fix) end-to-end on this repo own PRs.
+
+**Alternatives considered:** Wait for the Monday cron self-update PR. Rejected: defers the dogfood validation by up to a week. The fix exists in npm latest; this repo should be on it immediately to actually exercise the gate + check-runs in production.
+
+**Implications:**
+- First PR after merge will be the real dogfood test — bot should emit a "## 🐛 Clud Bug review" header that the gate correctly reads via selectReviewHeader, AND the 4 per-skill check-runs (critical-issues-only, evidence-based-review, respect-existing-conventions, clud-bug-collaboration) should actually appear in the PR check list via selectReviewBody. If either is silent, the v0.5.12 fix is incomplete. Expects 401 self-mod guard on THIS PR (claude-code-action refuses PRs that edit its own workflow file); merge with admin bypass already set up on the reporulez-default ruleset.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — Self-mod ceremony: bump this repo from @v0.5.10 (KNOWN-BROKEN) to @v0.5.12 composite *(ceremony/self-mod-bump-to-v0.5.12)* — [decisions-branches/ceremony__self-mod-bump-to-v0.5.12.md](decisions-branches/ceremony__self-mod-bump-to-v0.5.12.md)
 - **2026-05-26** — Stream BB.4: skill-first marketing copy refresh (README + npm + site hero) *(docs/skill-first-marketing-bb4)* — [decisions-branches/docs__skill-first-marketing-bb4.md](decisions-branches/docs__skill-first-marketing-bb4.md)
 - **2026-05-26** — Fix strict-mode-gate body-start matching bug (v0.5.12) *(fix/strict-mode-gate-preamble-v0.5.12)* — [decisions-branches/fix__strict-mode-gate-preamble-v0.5.12.md](decisions-branches/fix__strict-mode-gate-preamble-v0.5.12.md)
 - **2026-05-26** — Pin claude-code-action via {{CCA_VERSION}} substitution + route audit/self-update through renderFile (v0.5.11) *(feat/cca-version-pinning)* — [decisions-branches/feat__cca-version-pinning.md](decisions-branches/feat__cca-version-pinning.md)


### PR DESCRIPTION
## Summary

Self-mod ceremony. Mechanical output of `node bin/clud-bug.js update` against this repo's v4 install. Lands two coordinated v0.5.x fixes into this repo's own workflow:

- **v0.5.11 — `{{CCA_VERSION}}` pinning**: `claude-code-action@v1` → `@v1.0.133`
- **v0.5.12 — strict-mode-gate + BB.3 fix**: composite `@v0.5.10` (KNOWN-BROKEN) → `@v0.5.12`

### What refreshed

- `.github/workflows/clud-bug-review.yml`: marker `v4` → `v6` (skipped v5 since this repo never got a v5 self-mod). Now uses composite `@v0.5.12` + CCA `@v1.0.133`.
- `.claude/skills/.clud-bug.json`: manifest `lastUpdate` + `lastUpdateVersion` stamp.
- `AGENTS.md` / `CLAUDE.md` / `.cursorrules`: agent-docs block reference bumped from `v0.5.10` → `v0.5.12`.

### Why this matters (the dogfood payoff)

PR #58 was the prior self-mod (refresh to v4 templates + `@v0.5.10` composite). Every PR opened against `main` since #60 was reviewed by the **KNOWN-BROKEN** v0.5.10 gate — per-skill check-runs never emitted, strict mode silently passed. PRs #59/#60/#61/#62 all "passed" the gate without the gate actually doing its job, because the gate was the bug being fixed.

**After this merge:** the next PR on this repo gets reviewed by the corrected v0.5.12 composite. Expectations:
- `clud-bug-review` check status correctly reflects the bot's strict-mode header (gate actually fires on `— critical findings`)
- 4 per-skill check-runs (`critical-issues-only`, `evidence-based-review`, `respect-existing-conventions`, `clud-bug-collaboration`) actually appear in the PR check list

If either is silent on the next PR, the v0.5.12 fix is incomplete.

### Expected: clud-bug-review check fails 401

This PR edits `.github/workflows/clud-bug-review.yml`, so `claude-code-action` will refuse to review (self-mod guard — by design). Merge with the Repository-admin bypass on the `reporulez-default` ruleset (configured in PR #55).

### Notes

The bot reviewing THIS PR is still using the broken v0.5.10 composite (since this PR's HEAD still has the un-merged fix). So even if the strict-mode bot somehow gave a "— critical findings" review, the v0.5.10 gate wouldn't fail the check anyway. The fix becomes self-validating starting on the FIRST PR after this merges.

## Test plan

- [ ] All non-bot checks pass (actionlint, check-decisions, check-derived-docs, check-links, test, vercel)
- [ ] claude-review confirms mechanical render of v0.5.12 template
- [ ] clud-bug-review fails 401 (expected self-mod guard)
- [ ] Admin-bypass merge succeeds
- [ ] **First PR after merge:** 4 per-skill check-runs visible in PR check list (dogfood validation of BB.3 fix)
- [ ] **First PR after merge:** if bot writes "— critical findings", gate actually fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)