### PR TITLE
fix: bump composite pin @v0.5.12 → @v0.5.13 in templates (v0.5.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.5.14] — 2026-05-26
+
+### Fixed (shipping gap from v0.5.13)
+
+- **Composite ref bumped `@v0.5.12` → `@v0.5.13`** in `workflow.yml.tmpl`, `workflow-ts.yml.tmpl`, `workflow-py.yml.tmpl`. v0.5.13 shipped a sort fix in `lib/skills.js` (`selectReviewHeader` / `selectReviewBody` now sort newest-first explicitly) — but the templates kept the `@v0.5.12` composite pin. The composite resolves `lib/skills.js` from `${{ github.action_path }}/../../../lib/skills.js`, which is the composite's own checkout at the pinned tag. So at `@v0.5.12`, the composite kept loading the OLD `lib/skills.js` without the sort fix — meaning v0.5.13's fix was on npm but unreachable from any deployed workflow.
+- **Template marker bumped `v7` → `v8`** to trigger v0.5.7's refresh-mode on existing v7 installs. Existing strictMode installs auto-upgrade and finally pick up the gate fix that was supposed to land in v0.5.13.
+- No code or test changes — `lib/skills.js` is byte-identical to v0.5.13. The fix is purely the version pin in templates.
+
+### Process note
+
+This is the second time a fix in `lib/skills.js` shipped without the matching composite pin bump (v0.5.10 → v0.5.12 had the same pattern, but the bump was bundled into v0.5.12's PR). When `lib/skills.js` changes for the composite's use case, the templates MUST bump the composite pin in lock-step — otherwise installs run the old code. Worth adding a test that asserts the composite pin in templates matches the current package.json version.
+
 ## [0.5.13] — 2026-05-26
 
 ### Fixed (caught by PR #64 dogfood after the prompt change)
@@ -207,6 +219,7 @@ Installs predating PR #52 have markerless workflows. The first `clud-bug update`
 - **Bot-authored PRs are now handled gracefully.** PRs from `dependabot[bot]`, `renovate[bot]`, or forks (where GitHub deliberately doesn't pass repository secrets) used to fail loudly red — wrong signal. Now a guard step detects the case, posts a one-line advisory comment ("Clud Bug skipped — bot/fork PR cannot access secrets"), and exits 0. Check stays green; the skip is visible. Owner-authored PRs without the secret still fail loud.
 - **Site polish (carries over from the unreleased entry):** alive bug emoji (layered breathe + twitch + scuttle animations), Plate label gloss, thrillmot footer credit.
 
+[0.5.14]: https://github.com/thrillmot/clud-bug/compare/v0.5.13...v0.5.14
 [0.5.13]: https://github.com/thrillmot/clud-bug/compare/v0.5.12...v0.5.13
 [0.5.12]: https://github.com/thrillmot/clud-bug/compare/v0.5.11...v0.5.12
 [0.5.11]: https://github.com/thrillmot/clud-bug/compare/v0.5.10...v0.5.11

--- a/docs/decisions-branches/fix__composite-pin-v0.5.14.md
+++ b/docs/decisions-branches/fix__composite-pin-v0.5.14.md
@@ -1,0 +1,10 @@
+## 2026-05-26 13:37 - Bump composite pin v0.5.12 -> v0.5.13 in templates (v0.5.14 shipping-gap fix)
+
+**Reasoning:** v0.5.13 shipped the selectReviewHeader/Body sort fix in lib/skills.js but forgot to bump the composite ref pin in templates from @v0.5.12 to @v0.5.13. The composite resolves lib/skills.js from its own checkout at the pinned tag — so installs of v0.5.13 still ran composite @v0.5.12 which has the OLD lib/skills.js without the sort fix. Net effect: the v0.5.13 fix was on npm but UNREACHABLE from any deployed workflow. Same gap a v0.5.10 → v0.5.12 bump would have created if I had not bundled the template pin into the v0.5.12 PR (which I did then but forgot here). v0.5.14 is a one-line-per-template fix: @v0.5.12 -> @v0.5.13 in all 3 review templates + marker v7 -> v8 + version bump + CHANGELOG. No code or test changes (lib/skills.js byte-identical to v0.5.13).
+
+**Alternatives considered:** Roll back v0.5.13 + retag. Rejected: destructive, messy, npm cannot unpublish in a clean way. Ship-forward is the discipline of every other patch release in this stream. Also considered: add a test that asserts the composite pin in templates matches package.json version to prevent the next recurrence. Deferred to v0.5.15+ — not blocking on this hotfix; keeping v0.5.14 tight to ship fast.
+
+**Implications:**
+- Existing v7 installs auto-upgrade to v8 via refresh-mode on next clud-bug update, finally picking up the gate-ordering fix that was supposed to land in v0.5.13. This is the SECOND time a lib/skills.js change shipped without the matching composite pin bump (v0.5.10 -> v0.5.12 bump was bundled into v0.5.12 PR; v0.5.13 forgot it). Worth instituting a pre-release checklist: when lib/skills.js changes for composite use cases, templates MUST bump the composite pin in lock-step. The test the CHANGELOG mentions would automate this check.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — Bump composite pin v0.5.12 -> v0.5.13 in templates (v0.5.14 shipping-gap fix) *(fix/composite-pin-v0.5.14)* — [decisions-branches/fix__composite-pin-v0.5.14.md](decisions-branches/fix__composite-pin-v0.5.14.md)
 - **2026-05-26** — Instruct bot to post inline review threads (v0.5.13) — close the conversation-resolution loop *(feat/inline-review-threads-v0.5.13)* — [decisions-branches/feat__inline-review-threads-v0.5.13.md](decisions-branches/feat__inline-review-threads-v0.5.13.md)
 - **2026-05-26** — Self-mod ceremony: bump this repo from @v0.5.10 (KNOWN-BROKEN) to @v0.5.12 composite *(ceremony/self-mod-bump-to-v0.5.12)* — [decisions-branches/ceremony__self-mod-bump-to-v0.5.12.md](decisions-branches/ceremony__self-mod-bump-to-v0.5.12.md)
 - **2026-05-26** — Stream BB.4: skill-first marketing copy refresh (README + npm + site hero) *(docs/skill-first-marketing-bb4)* — [decisions-branches/docs__skill-first-marketing-bb4.md](decisions-branches/docs__skill-first-marketing-bb4.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v7
+# clud-bug-template-version: v8
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -281,6 +281,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.12
+        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.13
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v7
+# clud-bug-template-version: v8
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -282,6 +282,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.12
+        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.13
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v7
+# clud-bug-template-version: v8
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -316,6 +316,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.12
+        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.13
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -60,7 +60,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // Workflow refreshed
     const wf = await readFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'utf8');
     assert.match(wf, /allowedTools/);
-    assert.match(wf, /^# clud-bug-template-version: v7/);
+    assert.match(wf, /^# clud-bug-template-version: v8/);
     // Baseline rewritten with current shipped content
     const baseline = await readFile(join(dir, '.claude/skills/critical-issues-only/SKILL.md'), 'utf8');
     assert.match(baseline, /critical-issues-only/);
@@ -75,7 +75,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // The refreshed workflow records a from/to version note.
     const wfChange = r.changed.find((c) => c.label === 'review workflow');
     assert.equal(wfChange.from, 'v0');
-    assert.equal(wfChange.to, 'v7');
+    assert.equal(wfChange.to, 'v8');
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
## Summary

**Shipping gap fix.** v0.5.13 shipped the `selectReviewHeader` / `selectReviewBody` ordering fix in `lib/skills.js`, but the templates kept `strict-mode-gate@v0.5.12`. The composite resolves `lib/skills.js` from `\${{ github.action_path }}/../../../lib/skills.js` — which is its OWN checkout at the pinned tag. So at `@v0.5.12`, the composite loaded the OLD `lib/skills.js` without the sort fix. v0.5.13's fix has been on npm but unreachable from any deployed workflow.

This is the second time a `lib/skills.js` change shipped without the matching composite pin bump (v0.5.10 → v0.5.12 had the same gap, but the bump was bundled into v0.5.12's PR). When `lib/skills.js` changes for the composite's use case, templates MUST bump the composite pin in lock-step.

### Fix

Pure pin bump, no code change:

- `templates/workflow.yml.tmpl`: `@v0.5.12` → `@v0.5.13`, marker `v7` → `v8`
- `templates/workflow-ts.yml.tmpl`: same
- `templates/workflow-py.yml.tmpl`: same
- `test/update.test.js`: bumped v7 → v8 marker assertion
- `package.json`: 0.5.13 → 0.5.14
- `lib/skills.js`: **unchanged** (byte-identical to v0.5.13)

Existing v7 installs auto-upgrade to v8 via v0.5.7's refresh-mode and finally pick up the gate-ordering fix.

### Process note (for v0.5.15+)

Worth adding a test that asserts the composite ref in `templates/workflow*.yml.tmpl` matches the current `package.json` version. Would have caught this gap automatically. Deferred to next release; keeping v0.5.14 tight to ship the fix fast.

## Test plan

- [ ] All non-bot checks pass
- [ ] claude-review confirms pure pin bump
- [ ] After merge + npm publish: self-mod PR on this repo brings the workflow to v8 / @v0.5.13 composite
- [ ] After self-mod merge: first PR on this repo opens with the gate ACTUALLY working on multi-round reviews (round-2 "— clean" should clear the gate; pre-v0.5.14 it stayed shadowed by round-1 "— critical findings")

🤖 Generated with [Claude Code](https://claude.com/claude-code)