### PR TITLE
ceremony: bump this repo to v8 templates + @v0.5.13 composite (unmask sort fix)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
   "installed": [],
-  "lastUpdate": "2026-05-26T16:14:16.643Z",
-  "lastUpdateVersion": "0.5.12",
+  "lastUpdate": "2026-05-26T17:42:55.441Z",
+  "lastUpdateVersion": "0.5.14",
   "strictMode": true,
   "strictSkills": [
     "critical-issues-only",

--- a/.cursorrules
+++ b/.cursorrules
@@ -44,5 +44,5 @@ Anthropic's `claude-code-action` refuses to run on PRs that modify its own
 workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
 their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
 
-_Installed at clud-bug v0.5.12._
+_Installed at clud-bug v0.5.14._
 <!-- clud-bug-end -->

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v6
+# clud-bug-template-version: v8
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -126,7 +126,45 @@ jobs:
             never at the cost of clarity, evidence, or the critical-issues-only
             discipline. Don't perform the bit; let the precision speak.
 
-            When you finish, post your review as a single PR comment.
+            Your review lives in TWO surfaces, in this order:
+
+            1. INLINE REVIEW THREADS — one per finding, anchored to the
+               file:line cited in the finding. Use the
+               mcp__github_inline_comment__create_inline_comment MCP tool
+               for each finding (critical, minor, AND per-skill section
+               findings). The body should be the finding text itself
+               (without the leading "- " bullet). This is what creates
+               *resolvable conversations* the author can mark resolved
+               when the fix lands; branch protection's
+               required_review_thread_resolution rule gates the merge on
+               these threads — without inline review comments, the gate
+               has nothing to gate on and the loop never closes.
+
+               Pass `confirmed: true` on every call to the tool. These
+               are final review comments, not test probes. Without
+               `confirmed: true` the tool defers each call to an
+               auto-classifier that decides post-hoc whether the comment
+               is "real" — and a classifier miscategorization re-opens
+               the exact silent-no-op failure mode this prompt is
+               designed to prevent.
+
+               Findings that genuinely don't anchor to a specific line
+               (cross-cutting observations, "missing test coverage for
+               the new endpoint as a whole", etc.) stay in the summary
+               comment only. The default should be: if you can name
+               file:line, post it inline. Only fall back to summary-only
+               when the finding spans many files or is structural.
+
+            2. SUMMARY PR COMMENT — one top-level comment via
+               `gh pr comment` that contains the H2 header, status line,
+               per-skill scan block, and per-skill findings sections.
+               This is what the strict-mode gate reads (it greps the
+               H2 header for "— critical findings"). The findings
+               sections here can be brief summaries that point to the
+               inline threads above, OR include the same finding text
+               for grep-ability — your call, but the master verdict
+               header MUST appear in this comment.
+
             The comment body MUST start with this exact line so the
             project's identity is visible (the bot account will say
             claude[bot], but the comment header brands it as Clud Bug):
@@ -199,30 +237,51 @@ jobs:
             critical-issues-only and pii-and-compliance lens at once), so
             bundling preserves that signal.
 
-            Post it via:
+            Post the summary via:
               gh pr comment "$PR_NUMBER" --body "<your review>"
 
-            If you previously reviewed this PR (you'll see prior claude[bot]
-            comments starting with "## 🐛 Clud Bug review"), resolve your
-            prior unresolved inline review threads where the flagged issue
-            is fixed in the current diff. List threads:
+            Each inline finding is posted separately via the
+            mcp__github_inline_comment__create_inline_comment tool
+            (with `confirmed: true` per surface 1 above). Ordering
+            within the review pass that matters for counter accuracy:
+            (a) post new inline findings, (b) resolve prior threads
+            whose issue is now fixed (FIX-PUSH FLOW below — this is
+            what feeds the "resolved from prior" counter), (c) post
+            the summary comment. The summary's "still open" and
+            "resolved from prior" counters depend on the resolve-
+            mutations in step (b), not on the new posts in (a) —
+            so step (b) MUST run before the summary, but step (a)
+            and (b) can run in either order.
+
+            FIX-PUSH FLOW (when prior claude[bot] threads exist):
+            If you see prior claude[bot] inline review threads from
+            earlier passes, list them and resolve the ones whose issue
+            is verifiably fixed in the current diff. This is what closes
+            the loop for the author — the "resolved from prior" counter
+            in the status block proves the bot read the fixes, not just
+            re-ran a fresh review.
+
+            List threads:
 
               gh api graphql -f query='{ repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") { pullRequest(number: '"$PR_NUMBER"') { reviewThreads(first: 30) { nodes { id isResolved comments(first: 1) { nodes { body author { login } } } } } } } }'
 
-            For each unresolved thread you (claude[bot]) authored where the
-            issue is now addressed:
+            For each unresolved thread you (claude[bot]) authored where
+            the issue is now addressed by the head diff:
 
               gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<id>"}) { thread { isResolved } } }'
 
-            Only resolve threads where the fix is verifiable in the diff.
-            Leave unresolved any thread whose issue still stands.
-            For line-specific issues, use the github_inline_comment MCP tool
-            with confirmed: true.
-            If there are no critical issues, post a one-line comment saying so.
+            Only resolve threads where the fix is verifiable in the
+            diff. Leave unresolved any thread whose issue still stands —
+            those become "still open" in the status block.
+
+            If there are no critical findings, you still post the summary
+            comment with the H2 header and "**This round:** 0 critical · …"
+            status line — strict mode + the status counters need the
+            comment to exist for every review pass.
 
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.12
+        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.13
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,5 +94,5 @@ Anthropic's `claude-code-action` refuses to run on PRs that modify its own
 workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
 their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
 
-_Installed at clud-bug v0.5.12._
+_Installed at clud-bug v0.5.14._
 <!-- clud-bug-end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,5 +44,5 @@ Anthropic's `claude-code-action` refuses to run on PRs that modify its own
 workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
 their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
 
-_Installed at clud-bug v0.5.12._
+_Installed at clud-bug v0.5.14._
 <!-- clud-bug-end -->

--- a/docs/decisions-branches/ceremony__self-mod-bump-to-v0.5.14.md
+++ b/docs/decisions-branches/ceremony__self-mod-bump-to-v0.5.14.md
@@ -1,0 +1,10 @@
+## 2026-05-26 13:43 - Self-mod ceremony: bump this repo to v8 templates + @v0.5.13 composite (unmask sort fix)
+
+**Reasoning:** v0.5.14 shipped with the @v0.5.12 -> @v0.5.13 composite pin bump in templates. This self-mod ceremony brings this repo from v6 templates (@v0.5.12 composite, broken-ordering selectReviewHeader) to v8 templates (@v0.5.13 composite, correct-ordering selectReviewHeader). After merge, this repo will finally have the gate-ordering fix active on its own PRs — multi-round reviews where the bot resolves prior critical findings will correctly show clean on the second round instead of being shadowed by the round-1 critical comment.
+
+**Alternatives considered:** Skip the self-mod, wait for Monday cron self-update. Rejected: we are mid-dogfood-validation. Waiting a week means PR #66+ continues to suffer the shadowing bug.
+
+**Implications:**
+- After merge, the first multi-round-review PR on this repo will validate the v0.5.13 sort fix end-to-end. Expected behavior: round 1 finds N criticals, round 2 fix-push resolves N, gate reads round-2 clean comment correctly. Pre-v0.5.14 (current main) showed clud-bug-review fail on round 2 even with clean verdict because gate shadowed. Self-mod ceremony triggers the usual 401 self-mod guard; admin bypass.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — Self-mod ceremony: bump this repo to v8 templates + @v0.5.13 composite (unmask sort fix) *(ceremony/self-mod-bump-to-v0.5.14)* — [decisions-branches/ceremony__self-mod-bump-to-v0.5.14.md](decisions-branches/ceremony__self-mod-bump-to-v0.5.14.md)
 - **2026-05-26** — Bump composite pin v0.5.12 -> v0.5.13 in templates (v0.5.14 shipping-gap fix) *(fix/composite-pin-v0.5.14)* — [decisions-branches/fix__composite-pin-v0.5.14.md](decisions-branches/fix__composite-pin-v0.5.14.md)
 - **2026-05-26** — Instruct bot to post inline review threads (v0.5.13) — close the conversation-resolution loop *(feat/inline-review-threads-v0.5.13)* — [decisions-branches/feat__inline-review-threads-v0.5.13.md](decisions-branches/feat__inline-review-threads-v0.5.13.md)
 - **2026-05-26** — Self-mod ceremony: bump this repo from @v0.5.10 (KNOWN-BROKEN) to @v0.5.12 composite *(ceremony/self-mod-bump-to-v0.5.12)* — [decisions-branches/ceremony__self-mod-bump-to-v0.5.12.md](decisions-branches/ceremony__self-mod-bump-to-v0.5.12.md)


### PR DESCRIPTION
## Summary

Self-mod ceremony. Mechanical output of `node bin/clud-bug.js update` against this repo's v6 install (it was on v6 because PR #63 self-modded to v6/@v0.5.12 — never went to v7/@v0.5.12 because v0.5.13's pin-bump was missing). v0.5.14's pin-bump fix is now on npm; this PR finally lands it on our own dogfood workflow.

### What refreshed

- `.github/workflows/clud-bug-review.yml`: marker `v6` → `v8` (skipped v7 — that release shipped the prompt-text changes without bumping the composite pin, so a v6→v7→v8 walk would have stopped at the same broken composite v7 referenced; v8 is the first marker that ships with a correctly-pinned composite). Composite now `@v0.5.13` (with the sort fix); CCA still `@v1.0.133`.
- `.claude/skills/.clud-bug.json`: manifest stamp bump.
- `AGENTS.md` / `CLAUDE.md` / `.cursorrules`: agent-docs block reference bumped from `v0.5.12` → `v0.5.14`.

### Why this matters (the real dogfood)

PR #64 round 2 was the smoking gun: bot wrote "— clean" + "2 resolved from prior", but `clud-bug-review` STILL failed because the gate's `selectReviewHeader` walked oldest-first and read the stale round-1 "— critical findings" comment. v0.5.13 fixed the sort in `lib/skills.js`; v0.5.14 bumped the composite pin so deployed workflows actually load the fix; this self-mod brings THIS repo's workflow to the corrected `@v0.5.13` composite.

After merge, the next multi-round-review PR on this repo will validate the fix end-to-end. Pre-merge: gate fires on round-1 comment forever. Post-merge: gate correctly reads the latest round's verdict.

### Expected: clud-bug-review check fails 401

This PR edits `.github/workflows/clud-bug-review.yml`, so `claude-code-action` will refuse to review (self-mod guard — by design). Merge with the Repository-admin bypass on the `reporulez-default` ruleset.

## Test plan

- [ ] All non-bot checks pass (actionlint, check-decisions, check-derived-docs, check-links, test, vercel)
- [ ] claude-review confirms mechanical render
- [ ] clud-bug-review fails 401 (expected self-mod guard)
- [ ] Admin-bypass merge succeeds
- [ ] **First multi-round-review PR after merge:** round-2 "— clean" verdict actually clears the gate (was shadowed pre-v0.5.14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)