### PR TITLE
feat: release-discipline test for composite pin lock-step (v0.5.15)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.12
+#   - uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.15
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.5.15] — 2026-05-26
+
+### Added (release discipline)
+
+- **`test/release-discipline.test.js` enforces composite-pin lock-step in CI.** Two assertions:
+  1. The `strict-mode-gate@vX.Y.Z` pin in all 3 review templates (`workflow.yml.tmpl`, `workflow-ts.yml.tmpl`, `workflow-py.yml.tmpl`) must equal the current `package.json` version. Catches the exact gap that caused v0.5.13's sort fix to ship to npm unreachable from any deployed workflow (required v0.5.14 hotfix solely to bump the pin).
+  2. All 3 review templates must agree on the same pin. Catches the case where someone edits one template and forgets the other two.
+- **Cost of the lock-step rule:** every release now bumps the composite pin even if `.github/actions/strict-mode-gate/action.yml` didn't change in that release — one line per template + the marker bump. Acceptable price for eliminating the silent-fix-not-reachable class of bug that bit twice this stream (v0.5.10→v0.5.12 caught and bundled; v0.5.13→v0.5.14 missed and hotfixed).
+- **`action.yml` header doc fixed** to point at `@v0.5.15` (was `@v0.5.12`). Reader copy-pasting the usage example would have landed on the KNOWN-BROKEN ref pre-fix. Flagged by clud-bug-review on PR #65.
+
+### Changed
+
+- **Composite pin bumped `@v0.5.13` → `@v0.5.15`** in all 3 review templates (per the new lock-step rule). No-op for the composite's behavior — `action.yml` and `lib/skills.js` are byte-identical to v0.5.14. Pure mechanical bump.
+- **Template marker bumped `v8` → `v9`** so v0.5.7's refresh-mode propagates the pin to existing v8 installs.
+
 ## [0.5.14] — 2026-05-26
 
 ### Fixed (shipping gap from v0.5.13)
@@ -219,6 +234,7 @@ Installs predating PR #52 have markerless workflows. The first `clud-bug update`
 - **Bot-authored PRs are now handled gracefully.** PRs from `dependabot[bot]`, `renovate[bot]`, or forks (where GitHub deliberately doesn't pass repository secrets) used to fail loudly red — wrong signal. Now a guard step detects the case, posts a one-line advisory comment ("Clud Bug skipped — bot/fork PR cannot access secrets"), and exits 0. Check stays green; the skip is visible. Owner-authored PRs without the secret still fail loud.
 - **Site polish (carries over from the unreleased entry):** alive bug emoji (layered breathe + twitch + scuttle animations), Plate label gloss, thrillmot footer credit.
 
+[0.5.15]: https://github.com/thrillmot/clud-bug/compare/v0.5.14...v0.5.15
 [0.5.14]: https://github.com/thrillmot/clud-bug/compare/v0.5.13...v0.5.14
 [0.5.13]: https://github.com/thrillmot/clud-bug/compare/v0.5.12...v0.5.13
 [0.5.12]: https://github.com/thrillmot/clud-bug/compare/v0.5.11...v0.5.12

--- a/docs/decisions-branches/feat__composite-pin-lockstep-test-v0.5.15.md
+++ b/docs/decisions-branches/feat__composite-pin-lockstep-test-v0.5.15.md
@@ -1,0 +1,10 @@
+## 2026-05-26 13:52 - Add release-discipline test for composite-pin lock-step (v0.5.15)
+
+**Reasoning:** Got bitten twice this session: v0.5.10 -> v0.5.12 caught the composite-pin gap in time (bundled the bump into v0.5.12 PR), but v0.5.13 missed it entirely (lib/skills.js sort fix shipped to npm unreachable from deployed workflows because templates still pinned @v0.5.12). v0.5.14 hotfixed it. The root cause: no automated check that the composite pin in templates matches the current package.json version. v0.5.15 adds test/release-discipline.test.js with two assertions: (1) strict-mode-gate@vX.Y.Z in all 3 review templates must equal package.json version, (2) all 3 templates must agree on the pin. CI fails any future PR that bumps package.json without bumping the composite pin in lock-step. Also fixes the action.yml header doc reference that still pointed at @v0.5.12 (clud-bug-review observation on PR #65).
+
+**Alternatives considered:** Soft check (pin must reference an existing tag, not necessarily equal version). Rejected: doesn nt prevent the shipping-gap class of bug — every old tag references an existing composite, so the soft check would still allow shipping a fix in v0.5.X with pin at @v0.5.(X-1). Also considered: skip the lock-step rule, rely on a manual release checklist. Rejected: process discipline that depends on me remembering is exactly what failed twice this session.
+
+**Implications:**
+- Every future release now has a mandatory composite-pin bump even if action.yml/lib/skills.js did not change in that release. Cost: one-line-per-template + marker bump on each PR. Benefit: eliminates the entire silent-fix-not-reachable class of bug. The lock-step rule becomes self-enforcing; any drift fails CI immediately. Also worth noting: this exercises the lock-step rule on its own release — v0.5.15 bumps the composite pin alongside package.json without any actual composite/lib-skills change.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — Add release-discipline test for composite-pin lock-step (v0.5.15) *(feat/composite-pin-lockstep-test-v0.5.15)* — [decisions-branches/feat__composite-pin-lockstep-test-v0.5.15.md](decisions-branches/feat__composite-pin-lockstep-test-v0.5.15.md)
 - **2026-05-26** — Self-mod ceremony: bump this repo to v8 templates + @v0.5.13 composite (unmask sort fix) *(ceremony/self-mod-bump-to-v0.5.14)* — [decisions-branches/ceremony__self-mod-bump-to-v0.5.14.md](decisions-branches/ceremony__self-mod-bump-to-v0.5.14.md)
 - **2026-05-26** — Bump composite pin v0.5.12 -> v0.5.13 in templates (v0.5.14 shipping-gap fix) *(fix/composite-pin-v0.5.14)* — [decisions-branches/fix__composite-pin-v0.5.14.md](decisions-branches/fix__composite-pin-v0.5.14.md)
 - **2026-05-26** — Instruct bot to post inline review threads (v0.5.13) — close the conversation-resolution loop *(feat/inline-review-threads-v0.5.13)* — [decisions-branches/feat__inline-review-threads-v0.5.13.md](decisions-branches/feat__inline-review-threads-v0.5.13.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmot/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v8
+# clud-bug-template-version: v9
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -281,6 +281,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.13
+        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.15
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v8
+# clud-bug-template-version: v9
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -282,6 +282,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.13
+        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.15
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v8
+# clud-bug-template-version: v9
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -316,6 +316,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.13
+        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.15
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/release-discipline.test.js
+++ b/test/release-discipline.test.js
@@ -63,6 +63,42 @@ test('release discipline: composite pin in templates matches package.json versio
   }
 });
 
+test('release discipline: action.yml header docstring example matches package.json version', async () => {
+  // The composite action's header has a usage-example comment block:
+  //   #   - uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@vX.Y.Z
+  // Readers copy-paste this when wiring the composite into their own
+  // workflows. If the example drifts behind the actual shipped pin,
+  // anyone following the docs lands on a stale (potentially broken)
+  // ref — exactly what bit on v0.5.10 → v0.5.12 (the @v0.5.10 ref had
+  // the strict-mode-gate body-start matching bug).
+  //
+  // clud-bug-review flagged this on PR #65 as a pre-existing drift
+  // (header still said @v0.5.12 while templates were on @v0.5.13).
+  // v0.5.15 fixes the header manually AND extends this test so the
+  // next release that bumps the templates without bumping the header
+  // fails CI immediately — making the lock-step rule self-policing
+  // for the most paste-able surface.
+  const pkg = JSON.parse(await readFile(join(REPO_ROOT, 'package.json'), 'utf8'));
+  const expectedRef = `strict-mode-gate@v${pkg.version}`;
+  const actionYml = await readFile(
+    join(REPO_ROOT, '.github', 'actions', 'strict-mode-gate', 'action.yml'),
+    'utf8',
+  );
+  const m = actionYml.match(/strict-mode-gate@(v[0-9]+\.[0-9]+\.[0-9]+)/);
+  assert.ok(m, 'action.yml has no strict-mode-gate ref in its header');
+  assert.equal(
+    `strict-mode-gate@${m[1]}`,
+    expectedRef,
+    `action.yml header usage-example ref out of sync with package.json.
+     Expected: ${expectedRef}
+     Found:    strict-mode-gate@${m[1]}
+     Fix: bump the @vX.Y.Z reference in the header comment block of
+     .github/actions/strict-mode-gate/action.yml to match the current
+     package.json version. The header is what readers paste; stale
+     examples lead users onto deprecated/buggy refs.`,
+  );
+});
+
 test('release discipline: composite pin matches across all 3 review templates', async () => {
   // Stronger property — even ignoring package.json, the three templates
   // must agree on the pin. Catches the case where someone edits one

--- a/test/release-discipline.test.js
+++ b/test/release-discipline.test.js
@@ -1,0 +1,88 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+// --- v0.5.15: lock-step contract between package.json and composite pin ---
+//
+// The composite strict-mode-gate action calls into lib/skills.js via:
+//   SKILLS_LIB="${{ github.action_path }}/../../../lib/skills.js"
+// `github.action_path` resolves to the composite's OWN checkout at the
+// pinned tag — NOT the consumer's repo, NOT the latest from main.
+//
+// So a workflow with `uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@vX`
+// loads `lib/skills.js` from the `vX` git tag. If we ship a fix to
+// `selectReviewHeader` / `selectReviewBody` / `extractFirstReviewHeaderLine` /
+// `isCriticalReviewHeader` / `extractPerSkillLine` / `classifyPerSkillOutcome`
+// in v0.5.Y but templates still pin `@v0.5.(Y-1)`, the deployed workflows
+// keep loading the OLD lib/skills.js — the fix is on npm but unreachable.
+//
+// Got bitten twice this session:
+//   - v0.5.13 shipped lib/skills.js sort fix without bumping the composite
+//     pin in templates. Required v0.5.14 hotfix solely to bump the pin.
+//   - v0.5.10 → v0.5.12 had the same gap but was caught and bundled into
+//     the v0.5.12 PR.
+//
+// This test makes the lock-step rule enforceable in CI: every release that
+// bumps package.json MUST also bump the composite pin in all 3 review
+// templates to the same version. Any drift fails the test.
+//
+// Cost: a no-op composite pin bump on releases where lib/skills.js didn't
+// change. Acceptable — it's one-line-per-template and prevents the silent-
+// fix-not-reachable class of bug entirely.
+
+test('release discipline: composite pin in templates matches package.json version', async () => {
+  const pkg = JSON.parse(await readFile(join(REPO_ROOT, 'package.json'), 'utf8'));
+  const expectedRef = `strict-mode-gate@v${pkg.version}`;
+
+  const templates = [
+    'workflow.yml.tmpl',
+    'workflow-ts.yml.tmpl',
+    'workflow-py.yml.tmpl',
+  ];
+
+  for (const tmpl of templates) {
+    const content = await readFile(join(REPO_ROOT, 'templates', tmpl), 'utf8');
+    const m = content.match(/strict-mode-gate@(v[0-9]+\.[0-9]+\.[0-9]+)/);
+    assert.ok(m, `${tmpl}: no strict-mode-gate composite ref found`);
+    const actualRef = `strict-mode-gate@${m[1]}`;
+    assert.equal(
+      actualRef,
+      expectedRef,
+      `${tmpl} composite ref out of sync with package.json.
+       Expected: ${expectedRef}
+       Found:    ${actualRef}
+       Fix: bump the composite pin in all 3 review templates to match
+       package.json version. The composite resolves lib/skills.js from
+       its own pinned-tag checkout, so any lib/skills.js fix shipped
+       without the matching pin bump is unreachable from deployed workflows.`,
+    );
+  }
+});
+
+test('release discipline: composite pin matches across all 3 review templates', async () => {
+  // Stronger property — even ignoring package.json, the three templates
+  // must agree on the pin. Catches the case where someone edits one
+  // template and forgets the other two.
+  const templates = [
+    'workflow.yml.tmpl',
+    'workflow-ts.yml.tmpl',
+    'workflow-py.yml.tmpl',
+  ];
+  const refs = await Promise.all(
+    templates.map(async (tmpl) => {
+      const content = await readFile(join(REPO_ROOT, 'templates', tmpl), 'utf8');
+      const m = content.match(/strict-mode-gate@(v[0-9]+\.[0-9]+\.[0-9]+)/);
+      return [tmpl, m ? m[1] : null];
+    }),
+  );
+  const unique = new Set(refs.map(([, ref]) => ref));
+  assert.equal(
+    unique.size,
+    1,
+    `All 3 review templates must pin the same composite version. Found:\n${refs.map(([t, r]) => `  ${t} → ${r}`).join('\n')}`,
+  );
+});

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -60,7 +60,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // Workflow refreshed
     const wf = await readFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'utf8');
     assert.match(wf, /allowedTools/);
-    assert.match(wf, /^# clud-bug-template-version: v8/);
+    assert.match(wf, /^# clud-bug-template-version: v9/);
     // Baseline rewritten with current shipped content
     const baseline = await readFile(join(dir, '.claude/skills/critical-issues-only/SKILL.md'), 'utf8');
     assert.match(baseline, /critical-issues-only/);
@@ -75,7 +75,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // The refreshed workflow records a from/to version note.
     const wfChange = r.changed.find((c) => c.label === 'review workflow');
     assert.equal(wfChange.from, 'v0');
-    assert.equal(wfChange.to, 'v8');
+    assert.equal(wfChange.to, 'v9');
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
## Summary

Add CI test that prevents the v0.5.13 shipping gap from recurring. Two assertions in new `test/release-discipline.test.js`:

1. **`strict-mode-gate@vX.Y.Z` pin must equal `package.json` version** across all 3 review templates. Any release that bumps `package.json` must bump the pin in lock-step or CI fails.
2. **All 3 review templates must agree on the same pin.** Catches the case where someone edits one template and forgets the others.

### Why now

Got bitten twice this session by the same class of bug:
- **v0.5.10 → v0.5.12**: caught the gap, bundled the pin bump into v0.5.12's PR. ✓
- **v0.5.13**: missed the bump entirely. Sort fix in `lib/skills.js` shipped to npm but composite at `@v0.5.12` resolves `lib/skills.js` from `v0.5.12` tag — so the fix was unreachable from any deployed workflow. **Required v0.5.14 hotfix solely to bump the pin.**

The root cause is that the composite resolves `lib/skills.js` from its own pinned-tag checkout, NOT from the consumer's repo or the latest main:

```yaml
SKILLS_LIB="${{ github.action_path }}/../../../lib/skills.js"
```

So any fix to `selectReviewHeader` / `selectReviewBody` / `extractFirstReviewHeaderLine` / `isCriticalReviewHeader` / `extractPerSkillLine` / `classifyPerSkillOutcome` must ship paired with a composite ref bump. Process discipline depending on me remembering this is exactly what failed twice.

### Cost / benefit

**Cost:** every future release bumps the composite pin even if `action.yml` and `lib/skills.js` are byte-identical to the prior release. One line per template + marker bump.

**Benefit:** eliminates the silent-fix-not-reachable class of bug. The lock-step rule becomes self-enforcing — any drift fails the test immediately on the release PR.

### Exercising the rule on its own release

v0.5.15 itself follows the rule: `package.json` bumped 0.5.14 → 0.5.15, composite pin bumped `@v0.5.13` → `@v0.5.15` in all 3 templates, marker `v8` → `v9`. No actual `action.yml` or `lib/skills.js` change — they're byte-identical to v0.5.14. Pure mechanical bump.

### Also fixed

- `.github/actions/strict-mode-gate/action.yml:6` header doc reference updated from `@v0.5.12` → `@v0.5.15` (clud-bug-review observation on PR #65). A reader pasting the usage example pre-fix would have landed on the KNOWN-BROKEN ref.

## Test plan

- [ ] All non-bot checks pass
- [ ] **New `test/release-discipline.test.js` passes** (2 new tests; total now 157)
- [ ] claude-review confirms test logic
- [ ] clud-bug-review applies the new lock-step rule to itself (the rule check IS the test)
- [ ] After merge + npm publish: scratch repo refreshes to v9 templates with `@v0.5.15` composite pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)