### PR TITLE
chore: propagate logmind v0.2.4 to this repo (1C)

### DIFF
--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -1,19 +1,20 @@
-# logmind-template-version: v1
+# logmind-template-version: v2
 name: doc link integrity
 
 # Fail PRs that introduce broken or orphaned markdown links so agents stay
 # in context when they follow [link](path.md) references between docs.
 # Installed by `logmind init`.
 
+# Runs unconditionally on every PR / main push — no `paths:` filter.
+# Filtered runs interact badly with `required_status_checks` rules:
+# GitHub treats a filter-skipped check as "expected but missing" and
+# blocks the merge forever. Running unconditionally is cheap (~15s
+# end-to-end) and keeps the gate predictable.
+
 on:
   pull_request:
-    paths:
-      - "**/*.md"
-      - ".logmind/config.yml"
   push:
     branches: [main, master]
-    paths:
-      - "**/*.md"
 
 jobs:
   check-links:
@@ -29,7 +30,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.2.1"
+        run: pip install "logmind==0.2.4"
 
       - name: Check markdown link integrity
         run: logmind check-links

--- a/.github/workflows/logmind-self-update.yml
+++ b/.github/workflows/logmind-self-update.yml
@@ -1,0 +1,123 @@
+# logmind-template-version: v1
+name: logmind self-update
+
+# Weekly check for a newer published logmind. If one exists, runs
+# `pip install --upgrade logmind && logmind init` (refresh mode — leaves
+# docs/ and .logmind/config.yml alone, refreshes stale workflow
+# templates) and opens a PR titled "logmind self-update: X.Y.Z → A.B.C".
+#
+# Reads the currently installed version from this repo's pinned
+# workflow line (`pip install "logmind==X.Y.Z"` in regen-timeline.yml,
+# shipped since logmind v0.2.1). Pre-v0.2.1 installs aren't pinned and
+# self-update will skip with a notice — re-run `logmind init` once
+# manually to upgrade past that.
+#
+# To pin to a specific logmind version and stop self-updates, add a
+# `pinVersion: "X.Y.Z"` field to `.logmind/config.yml`. The cron will
+# skip when that field is present.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * 1'   # Mondays 12:00 UTC
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Compare installed vs PyPI latest
+        id: compare
+        run: |
+          set -euo pipefail
+          # Installed version: parsed from the workflow pin line shipped
+          # since v0.2.1. If absent, skip with a clear notice.
+          REGEN_FILE=".github/workflows/regen-timeline.yml"
+          INSTALLED=""
+          if [ -f "$REGEN_FILE" ]; then
+            INSTALLED=$(grep -oE 'logmind==[0-9]+\.[0-9]+\.[0-9]+' "$REGEN_FILE" | head -1 | sed 's/logmind==//') || true
+          fi
+          if [ -z "$INSTALLED" ]; then
+            echo "::notice::Installed logmind version not detected (no pinned `pip install` in regen-timeline.yml). Re-run \`logmind init\` once locally to upgrade past pre-v0.2.1 installs, then self-update will work from then on."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Optional pin override from .logmind/config.yml.
+          PIN=""
+          if [ -f ".logmind/config.yml" ]; then
+            PIN=$(python3 -c "
+          import yaml, sys
+          try:
+              with open('.logmind/config.yml') as f:
+                  print((yaml.safe_load(f) or {}).get('pinVersion', '') or '')
+          except Exception:
+              print('')
+          " 2>/dev/null || echo "")
+          fi
+
+          LATEST=$(pip index versions logmind 2>/dev/null | grep -oE 'logmind \([0-9]+\.[0-9]+\.[0-9]+\)' | head -1 | sed 's/logmind (\(.*\))/\1/') || true
+          if [ -z "$LATEST" ]; then
+            # Fallback: PyPI JSON API
+            LATEST=$(curl -fsSL https://pypi.org/pypi/logmind/json | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])")
+          fi
+
+          echo "installed=$INSTALLED" >> "$GITHUB_OUTPUT"
+          echo "latest=$LATEST"       >> "$GITHUB_OUTPUT"
+          echo "pin=$PIN"              >> "$GITHUB_OUTPUT"
+          echo "Installed: $INSTALLED  Latest: $LATEST  Pin: ${PIN:-(none)}"
+
+          if [ -n "$PIN" ]; then
+            echo "::notice::Pinned to $PIN via .logmind/config.yml — skipping update check."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$INSTALLED" = "$LATEST" ]; then
+            echo "Already on latest ($INSTALLED). Nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Run logmind init + open PR
+        if: steps.compare.outputs.skip == 'false'
+        env:
+          INSTALLED: ${{ steps.compare.outputs.installed }}
+          LATEST:    ${{ steps.compare.outputs.latest }}
+          GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="logmind/self-update-${LATEST}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+
+          pip install --upgrade "logmind==${LATEST}"
+          # Refresh mode (v0.2.1+) rewrites stale workflow templates by
+          # `# logmind-template-version:` marker, leaves docs/ + .logmind/
+          # + agent files untouched. Idempotent.
+          logmind init --no-git --no-skill-install || logmind init
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "::notice::No file changes after logmind init — nothing to PR."
+            exit 0
+          fi
+          git commit -m "logmind self-update: ${INSTALLED} → ${LATEST}"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "logmind self-update: ${INSTALLED} → ${LATEST}" \
+            --body "Automated upgrade from logmind ${INSTALLED} → ${LATEST}.
+
+          Refresh mode (v0.2.1+) only touched workflow templates whose \`# logmind-template-version:\` marker is stale; \`docs/\`, \`.logmind/config.yml\`, and agent files were left alone.
+
+          Review the diff. To stop self-updates after this, add \`pinVersion: \"${LATEST}\"\` to \`.logmind/config.yml\` before merging."

--- a/docs/decisions-branches/chore__logmind-v0.2.4-propagation.md
+++ b/docs/decisions-branches/chore__logmind-v0.2.4-propagation.md
@@ -1,0 +1,10 @@
+## 2026-05-26 15:14 - Propagate logmind v0.2.4 to this repo (1C from the plan)
+
+**Reasoning:** PyPI latest is logmind v0.2.4 (shipped v0.2.2 paths-filter fix, v0.2.3 auto-regen timeline, v0.2.4 doctor command). My earlier pip index check returned stale-cached output saying 0.2.1 was latest; rechecking shows 0.2.4 is correct. logmind init in this repo refreshed check-doc-links.yml from v1 to v2 (drops the paths filter that was silently blocking merges on no-md PRs) and installed the new logmind-self-update.yml workflow (weekly Mondays cron that auto-PRs logmind upgrades). regen-timeline.yml unchanged — its template marker is still v1 upstream so refresh-mode skipped it, but the pin stays stale at logmind==0.2.1 (real issue but logmind-side; needs template marker bump on the next logmind release to propagate pin updates).
+
+**Alternatives considered:** Hand-edit regen-timeline.yml pin to 0.2.4 directly. Rejected: creates drift between this install and the template; next logmind init would either preserve the manual edit (treating it as customized) or stomp it back. Better to leave consistent with the template and file the pin-propagation gap as a logmind-side followup.
+
+**Implications:**
+- Closes 1C from the v0.6 plan (logmind v0.2.3 propagation — actually v0.2.4 since 3 releases happened in one go). logmind doctor command output now available — confirms two stale items: logmind 0.2.1 (regen-timeline pin) and clud-bug 0.5.14 (manifest lags actual v0.5.15 since no self-mod ceremony for v0.5.15 ran yet). The Monday cron in logmind-self-update.yml will close the logmind drift automatically next Monday; the clud-bug drift will close via either a manual self-mod or the weekly clud-bug-self-update cron.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — Propagate logmind v0.2.4 to this repo (1C from the plan) *(chore/logmind-v0.2.4-propagation)* — [decisions-branches/chore__logmind-v0.2.4-propagation.md](decisions-branches/chore__logmind-v0.2.4-propagation.md)
 - **2026-05-26** — Add release-discipline test for composite-pin lock-step (v0.5.15) *(feat/composite-pin-lockstep-test-v0.5.15)* — [decisions-branches/feat__composite-pin-lockstep-test-v0.5.15.md](decisions-branches/feat__composite-pin-lockstep-test-v0.5.15.md)
 - **2026-05-26** — Self-mod ceremony: bump this repo to v8 templates + @v0.5.13 composite (unmask sort fix) *(ceremony/self-mod-bump-to-v0.5.14)* — [decisions-branches/ceremony__self-mod-bump-to-v0.5.14.md](decisions-branches/ceremony__self-mod-bump-to-v0.5.14.md)
 - **2026-05-26** — Bump composite pin v0.5.12 -> v0.5.13 in templates (v0.5.14 shipping-gap fix) *(fix/composite-pin-v0.5.14)* — [decisions-branches/fix__composite-pin-v0.5.14.md](decisions-branches/fix__composite-pin-v0.5.14.md)


### PR DESCRIPTION
## Summary

Closes **1C** from the v0.6 plan. PyPI latest is now **logmind v0.2.4** (three releases happened between the original plan and now: v0.2.2 paths-filter fix, v0.2.3 auto-regen timeline, v0.2.4 doctor command).

### Refreshed

- **`.github/workflows/check-doc-links.yml`** — marker `v1` → `v2`. The v0.2.2 fix drops the `paths:` filter that was silently blocking merges on PRs without markdown changes (GitHub treats filter-skipped required checks as "expected but never reported"). Now runs unconditionally on every PR + push to main (~15s). Re-pinned to `logmind==0.2.4`.
- **`.github/workflows/logmind-self-update.yml`** — NEW. Weekly Mondays 12:00 UTC cron auto-PRs logmind upgrades. Mirror of clud-bug's self-update workflow.

### Unchanged (and why)

- **`.github/workflows/regen-timeline.yml`** — still pins `logmind==0.2.1`. The template marker is still `v1` upstream (logmind hasn't bumped it across the 0.2.2 → 0.2.4 releases), so logmind init's refresh-mode treats the file as current and doesn't update the pin. The pin staleness is real but it's a logmind-side issue (template needs a marker bump on next logmind release to propagate pin updates).

Decision deliberately did NOT hand-edit the pin: that would create drift between this install and the template; next `logmind init` would either preserve the manual edit or stomp it. Better to stay consistent and file the gap upstream.

### `logmind doctor` snapshot

The v0.2.4 release also shipped `logmind doctor` — a stack-status command:

```
logmind 0.2.1 installed · 0.2.4 latest · STALE
  regen-timeline.yml           v1   current
  check-doc-links.yml          v2   current
  logmind-self-update.yml      v1   current
  check-decisions.yml          v1   current

clud-bug 0.5.14 installed · 0.5.15 latest · STALE
  clud-bug-review.yml          v8   current
  strict mode                  on

Stack status: DRIFT
Suggested:
  pip install --upgrade logmind && logmind init
  npx clud-bug update
```

After this PR merges, the logmind 0.2.1 line should resolve naturally as the Monday cron fires and propagates the pin via a future logmind release. The clud-bug 0.5.14 → 0.5.15 line is a separate self-mod ceremony task (already on the queue).

## Test plan

- [ ] All non-bot checks pass (especially check-links — the test that was previously susceptible to the paths-filter bug)
- [ ] claude-review confirms the v0.2.4 template diff
- [ ] After merge: next non-markdown PR opens with check-links actually running (pre-fix it would have been skip-but-required)
- [ ] After merge: logmind-self-update.yml's Monday cron fires next Monday and proposes any further logmind upgrades automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)