### PR TITLE
ceremony: bump this repo to v9 templates + @v0.5.15 composite (self-mod)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
   "installed": [],
-  "lastUpdate": "2026-05-26T17:42:55.441Z",
-  "lastUpdateVersion": "0.5.14",
+  "lastUpdate": "2026-05-26T19:43:54.597Z",
+  "lastUpdateVersion": "0.5.15",
   "strictMode": true,
   "strictSkills": [
     "critical-issues-only",

--- a/.cursorrules
+++ b/.cursorrules
@@ -44,5 +44,5 @@ Anthropic's `claude-code-action` refuses to run on PRs that modify its own
 workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
 their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
 
-_Installed at clud-bug v0.5.14._
+_Installed at clud-bug v0.5.15._
 <!-- clud-bug-end -->

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v8
+# clud-bug-template-version: v9
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -282,6 +282,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.13
+        uses: thrillmot/clud-bug/.github/actions/strict-mode-gate@v0.5.15
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,5 +94,5 @@ Anthropic's `claude-code-action` refuses to run on PRs that modify its own
 workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
 their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
 
-_Installed at clud-bug v0.5.14._
+_Installed at clud-bug v0.5.15._
 <!-- clud-bug-end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,5 +44,5 @@ Anthropic's `claude-code-action` refuses to run on PRs that modify its own
 workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
 their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
 
-_Installed at clud-bug v0.5.14._
+_Installed at clud-bug v0.5.15._
 <!-- clud-bug-end -->

--- a/docs/decisions-branches/ceremony__self-mod-bump-to-v0.5.15.md
+++ b/docs/decisions-branches/ceremony__self-mod-bump-to-v0.5.15.md
@@ -1,0 +1,10 @@
+## 2026-05-26 15:44 - Self-mod ceremony: bump this repo to v9 templates + @v0.5.15 composite
+
+**Reasoning:** Across-repo sweep: ensure all thrillmot repos with clud-bug installed (except logmind) are current at v0.5.15 latest. This repo was at v0.5.14 (v8 templates / @v0.5.13 composite) after the PR #66 self-mod. v0.5.15 added the release-discipline test for composite-pin lock-step and bumped templates v8 -> v9 / composite @v0.5.13 -> @v0.5.15 (no functional change to composite or lib/skills.js — pure mechanical bump per the new lock-step rule).
+
+**Alternatives considered:** Wait for Monday self-update cron to bring this repo to v0.5.15 automatically. Rejected: we are sweeping all repos now to consolidate, and waiting a week defers validation by exactly that long.
+
+**Implications:**
+- After merge, this repo is the reference implementation of the v0.5.15 release-discipline contract: composite pin = package.json version. Next PR opened against main will validate v0.5.15 end-to-end (the release-discipline test ran on PR #67 already, so the rule is known to enforce; this self-mod just lands the install state).
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — Self-mod ceremony: bump this repo to v9 templates + @v0.5.15 composite *(ceremony/self-mod-bump-to-v0.5.15)* — [decisions-branches/ceremony__self-mod-bump-to-v0.5.15.md](decisions-branches/ceremony__self-mod-bump-to-v0.5.15.md)
 - **2026-05-26** — Add release-discipline test for composite-pin lock-step (v0.5.15) *(feat/composite-pin-lockstep-test-v0.5.15)* — [decisions-branches/feat__composite-pin-lockstep-test-v0.5.15.md](decisions-branches/feat__composite-pin-lockstep-test-v0.5.15.md)
 - **2026-05-26** — Self-mod ceremony: bump this repo to v8 templates + @v0.5.13 composite (unmask sort fix) *(ceremony/self-mod-bump-to-v0.5.14)* — [decisions-branches/ceremony__self-mod-bump-to-v0.5.14.md](decisions-branches/ceremony__self-mod-bump-to-v0.5.14.md)
 - **2026-05-26** — Bump composite pin v0.5.12 -> v0.5.13 in templates (v0.5.14 shipping-gap fix) *(fix/composite-pin-v0.5.14)* — [decisions-branches/fix__composite-pin-v0.5.14.md](decisions-branches/fix__composite-pin-v0.5.14.md)


### PR DESCRIPTION
## Summary

Self-mod ceremony. Mechanical output of `node bin/clud-bug.js update` against this repo's v8 install. Brings this repo to current at v0.5.15.

- `.github/workflows/clud-bug-review.yml`: marker `v8` → `v9`, composite `@v0.5.13` → `@v0.5.15`
- `.claude/skills/.clud-bug.json`: manifest stamp bump to v0.5.15
- `AGENTS.md` / `CLAUDE.md` / `.cursorrules`: agent-docs block reference bumped

### Expected: clud-bug-review check fails 401

Self-mod guard fires on `.github/workflows/clud-bug-review.yml` edits. Merge with admin bypass.

## Test plan

- [ ] Infra checks pass
- [ ] claude-review confirms mechanical render
- [ ] clud-bug-review fails 401 (expected)
- [ ] Admin-bypass merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)