### PR TITLE
fix(vercel): skip preview deploys when no site/ files changed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,41 +7,52 @@ files like `CLAUDE.md` or `.cursorrules` are stubs that point here so the
 guidance lives in one place.
 
 <!-- logmind-start -->
-<!-- logmind-block-version: v3-slim -->
-## Decision logging — see the `logmind` skill
+<!-- logmind-block-version: v4-slim -->
+## Decision logging — `logmind log` is the commit primitive
 
-This project uses [logmind](https://logmind.dev). The full procedure
-(when to log, how to log, what counts as a decision, branch routing) lives
-in the **`logmind` agent skill** which your runtime should auto-load.
+This project uses [logmind](https://logmind.dev) for decision logging. **`logmind log` replaces `git add`, `git commit`, and `git push`** for any change that carries a decision. Do not run those git commands directly when logging a decision — `logmind log` does all three in one step.
 
-If the skill isn't loaded for some reason, install it once:
+```bash
+logmind log "decision summary" -r "why" -a "alternative" -i "implication"
+```
+
+That single command:
+
+1. Writes the decision file (default branch → `docs/decisions.md`, feature branch → `docs/decisions-branches/<branch>.md`).
+2. Regenerates `docs/timeline.md` (and `file-structure.md` on the default branch).
+3. **`git add`** every change in the working tree (default `--stage all` since v0.2.7).
+4. **`git commit`** with message `logmind: <decision>`.
+5. **`git push`** to remote.
+
+That's it. No follow-up `git add`, no follow-up `git commit`, no follow-up `git push`, no follow-up `logmind timeline --write`.
+
+### When NOT to use `logmind log`
+
+- **The change has no decision worth recording** (typo fix, formatting, dependency-only patch bump) — use plain `git commit` then.
+- **You have unrelated WIP in the working tree** you don't want to commit — pass `--stage scoped` to stage only the decision files (rare for automated agents; they should be working on one thing at a time).
+
+### The full skill
+
+The complete procedure (when something counts as a decision, branch routing, doctor, refresh patterns) lives in the **`logmind` agent skill** at https://github.com/thrillmot/agent-skills/tree/main/skills/logmind. Most agent runtimes auto-load it. If yours doesn't:
 
 ```bash
 npx skills add https://github.com/thrillmot/agent-skills --skill logmind
 ```
 
-### Project-specific paths
+### Required reading before non-trivial work
 
-- **[docs/timeline.md](docs/timeline.md)** — auto-generated chronological overview across all branches; start here.
-- Recent decisions on the default branch: **[docs/decisions.md](docs/decisions.md)**
-- Per-branch decisions (in-flight feature work): **docs/decisions-branches/**
-- Archived decisions: **[docs/decisions-archive.md](docs/decisions-archive.md)**
-- Project tree (regenerated on main-branch logs + post-PR-merge): **[docs/file-structure.md](docs/file-structure.md)**
-
-### Quick reference
+1. **[docs/timeline.md](docs/timeline.md)** — chronological overview across all branches; start here.
+2. **[docs/decisions.md](docs/decisions.md)** — recent decisions on the default branch.
+3. **`docs/decisions-branches/<your-branch>.md`** if present — earlier decisions on this branch.
+4. **[docs/file-structure.md](docs/file-structure.md)** — current project tree.
 
 ```bash
-logmind log "decision summary" -r "why" -a "alternative" -i "implication"
 logmind show               # recent decisions on the current branch
 logmind search "keyword"   # full-text across recent + archive
+logmind doctor             # check installed version + workflow template drift
 ```
 
-**Use `logmind log` for the commit, not `git add` + `git commit`.** The
-`log` command writes the decision file, stages the decision log + its
-companion files, and creates the commit in one step. Use
-`--stage all` to also stage the rest of the working tree.
-
-**Read `docs/decisions.md` and the matching `docs/decisions-branches/<branch>.md` (if any) before starting any non-trivial task.** The team has likely already decided things you'd otherwise re-litigate.
+The team has likely already decided things you'd otherwise re-litigate.
 <!-- logmind-end -->
 
 ## Project Overview

--- a/docs/decisions-branches/fix__vercel-skip-when-no-site-changes.md
+++ b/docs/decisions-branches/fix__vercel-skip-when-no-site-changes.md
@@ -1,0 +1,10 @@
+## 2026-05-26 16:38 - Skip Vercel preview deploys when no site/ files changed
+
+**Reasoning:** Vercel free-tier quota is 100 deploys/day. Most clud-bug PRs touch zero site/ files but still trigger a Vercel preview build per PR + per fix-push, eating quota fast. Hit the limit today shipping 13 PRs in one session. The fix is one line: site/vercel.json `ignoreCommand: git diff --quiet HEAD^ HEAD ./` — Vercel runs the command from the project root (site/), exit 0 means SKIP deploy, exit non-zero means deploy. The git diff exits 0 when no files under ./ changed in HEAD vs HEAD^. Surgical: only changes Vercel deploy gating; no impact on actual build/deploy when site/ DOES change.
+
+**Alternatives considered:** Set Vercel ignored build step via the Vercel dashboard (project settings). Rejected: not version-controlled, drifts from repo, anyone re-linking the project misses it.
+
+**Implications:**
+- Vercel previews now skip when no site/ changes. clud-bug PRs that only touch lib/, templates/, .github/, docs/ etc. will show Vercel as ignored (not failed). The exit-0 result is cosmetically a "deployment skipped" status in the PR check list rather than a fail. Doesn't affect production deploys from main — those run via Vercel's normal trigger.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — Skip Vercel preview deploys when no site/ files changed *(fix/vercel-skip-when-no-site-changes)* — [decisions-branches/fix__vercel-skip-when-no-site-changes.md](decisions-branches/fix__vercel-skip-when-no-site-changes.md)
 - **2026-05-26** — Self-mod ceremony: bump this repo to v9 templates + @v0.5.15 composite *(ceremony/self-mod-bump-to-v0.5.15)* — [decisions-branches/ceremony__self-mod-bump-to-v0.5.15.md](decisions-branches/ceremony__self-mod-bump-to-v0.5.15.md)
 - **2026-05-26** — Add release-discipline test for composite-pin lock-step (v0.5.15) *(feat/composite-pin-lockstep-test-v0.5.15)* — [decisions-branches/feat__composite-pin-lockstep-test-v0.5.15.md](decisions-branches/feat__composite-pin-lockstep-test-v0.5.15.md)
 - **2026-05-26** — Self-mod ceremony: bump this repo to v8 templates + @v0.5.13 composite (unmask sort fix) *(ceremony/self-mod-bump-to-v0.5.14)* — [decisions-branches/ceremony__self-mod-bump-to-v0.5.14.md](decisions-branches/ceremony__self-mod-bump-to-v0.5.14.md)

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./"
+}


### PR DESCRIPTION
## Summary

Vercel free-tier quota is **100 deploys/day**. Most clud-bug PRs touch zero \`site/\` files but still trigger a Vercel preview build per PR + per fix-push, eating quota fast. Hit the limit today shipping 13 PRs in one session (PR #70 shows the resulting fail).

### Fix

One-line `site/vercel.json`:

\`\`\`json
{
  "\$schema": "https://openapi.vercel.sh/vercel.json",
  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./"
}
\`\`\`

Vercel runs \`ignoreCommand\` from the project root (\`site/\`). Exit code semantics:
- **exit 0** → skip deploy
- **exit non-zero** → deploy

\`git diff --quiet HEAD^ HEAD ./\` exits 0 when there are no diffs under \`./\` (i.e. nothing under \`site/\`) between HEAD and HEAD^. So Vercel skips deploys for PRs that don't touch site files; deploys normally when they do.

### Effect

- PRs that only touch \`lib/\`, \`templates/\`, \`.github/\`, \`docs/\`, etc. → Vercel check shows "deployment skipped" (cosmetically passes), no quota consumed.
- PRs that touch \`site/\` (hero copy, /install page, etc.) → Vercel deploys normally.
- Production deploys from \`main\` → unaffected (Vercel's normal main-branch trigger fires; the ignoreCommand only applies to deploy decisions, not the main-branch promote).

### Why not a Vercel dashboard setting

Dashboard's "Ignored Build Step" achieves the same thing but isn't in git. Anyone re-linking the project from scratch (e.g. fresh team member, CI rotation) would silently lose it. The repo \`vercel.json\` is the version-controlled equivalent.

## Test plan

- [ ] All non-bot checks pass
- [ ] **Vercel check on THIS PR**: tricky — this PR DOES touch \`site/vercel.json\`, so the ignoreCommand exits non-zero and Vercel runs a build. That validates the file is well-formed.
- [ ] After merge: next PR with no \`site/\` changes (any clud-bug update or template PR) should show Vercel as "deployment skipped"

🤖 Generated with [Claude Code](https://claude.com/claude-code)