### PR TITLE
chore: revert strictSkills to empty array (re-open of closed #72)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -4,10 +4,5 @@
   "lastUpdate": "2026-05-26T19:43:54.597Z",
   "lastUpdateVersion": "0.5.15",
   "strictMode": true,
-  "strictSkills": [
-    "critical-issues-only",
-    "evidence-based-review",
-    "respect-existing-conventions",
-    "clud-bug-collaboration"
-  ]
+  "strictSkills": []
 }

--- a/docs/decisions-branches/chore__empty-strictskills-v2.md
+++ b/docs/decisions-branches/chore__empty-strictskills-v2.md
@@ -1,0 +1,10 @@
+## 2026-05-26 16:50 - Revert strictSkills to empty array (was misconfigured for baselines, v2)
+
+**Reasoning:** Re-open of closed PR #72. PR #59 set strictSkills to the 4 baselines but those are review_mode: shared (one bundled Claude call), so per-skill check-runs were derived by grepping the bot Per-skill scan block lines. classifyPerSkillOutcome requires literal "0 findings" or "n/a"; natural phrasings like "0 critical findings" or "no findings to anchor" fail. Result: false-positive per-skill failures on clean PRs. Empty strictSkills = master clud-bug-review check is the only gate. Per-skill check-runs reappear when a dedicated-mode skill is installed.
+
+**Alternatives considered:** Keep current config + relax classifier. Deferred — classifier-too-literal fix is a v0.6 polish item; design alignment is the priority now.
+
+**Implications:**
+- Eliminates false-positive per-skill check-run failures on every clean PR. Master gate semantics preserved (strictMode: true). v0.5.x runtime never made strictSkills items into separate Claude calls anyway — the v0.6 App will be where that becomes meaningful.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — Revert strictSkills to empty array (was misconfigured for baselines, v2) *(chore/empty-strictskills-v2)* — [decisions-branches/chore__empty-strictskills-v2.md](decisions-branches/chore__empty-strictskills-v2.md)
 - **2026-05-26** — Skip Vercel preview deploys when no site/ files changed *(fix/vercel-skip-when-no-site-changes)* — [decisions-branches/fix__vercel-skip-when-no-site-changes.md](decisions-branches/fix__vercel-skip-when-no-site-changes.md)
 - **2026-05-26** — Self-mod ceremony: bump this repo to v9 templates + @v0.5.15 composite *(ceremony/self-mod-bump-to-v0.5.15)* — [decisions-branches/ceremony__self-mod-bump-to-v0.5.15.md](decisions-branches/ceremony__self-mod-bump-to-v0.5.15.md)
 - **2026-05-26** — Add release-discipline test for composite-pin lock-step (v0.5.15) *(feat/composite-pin-lockstep-test-v0.5.15)* — [decisions-branches/feat__composite-pin-lockstep-test-v0.5.15.md](decisions-branches/feat__composite-pin-lockstep-test-v0.5.15.md)


### PR DESCRIPTION
## Summary

Re-open of closed PR #72 (which actually went all-green right after I prematurely closed it for conflict-resolution-via-redo — apologies).

PR #59 set \`strictSkills\` to the 4 baselines. But baselines are all \`review_mode: shared\` — they run as ONE bundled Claude call. Per-skill check-runs are then derived by grepping the bot's "Per-skill scan" block lines; classifier requires literal "0 findings" / "n/a"; natural bot phrasings ("0 critical findings", "no findings to anchor", "0 pattern fights") all fail the regex.

Empty \`strictSkills\` = master \`clud-bug-review\` check is the only clud-bug gate. Per-skill check-runs reappear if/when a dedicated-mode skill is installed (e.g. \`clud-bug add thrillmot/agent-skills/brand-voice-review\`).

### What does NOT change
- \`strictMode: true\` preserved — master gate still fires on critical findings
- Bot review behavior unchanged
- Claude API token cost unchanged (per-skill check-runs were never separate Claude calls in v0.5.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)