### PR TITLE
chore: vercel.json + site URL refs + AGENTS.md v5-slim

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/site"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -30,7 +30,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.3.0"
+        run: pip install "logmind==0.3.1"
 
       - name: Check markdown link integrity
         run: logmind check-links

--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -41,7 +41,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.3.0"
+        run: pip install "logmind==0.3.1"
 
       - name: Verify docs/timeline.md is current
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ files like `CLAUDE.md` or `.cursorrules` are stubs that point here so the
 guidance lives in one place.
 
 <!-- logmind-start -->
-<!-- logmind-block-version: v4-slim -->
+<!-- logmind-block-version: v5-slim -->
 ## Decision logging — `logmind log` is the commit primitive
 
 This project uses [logmind](https://logmind.dev) for decision logging. **`logmind log` replaces `git add`, `git commit`, and `git push`** for any change that carries a decision. Do not run those git commands directly when logging a decision — `logmind log` does all three in one step.
@@ -33,10 +33,10 @@ That's it. No follow-up `git add`, no follow-up `git commit`, no follow-up `git 
 
 ### The full skill
 
-The complete procedure (when something counts as a decision, branch routing, doctor, refresh patterns) lives in the **`logmind` agent skill** at https://github.com/thrillmot/agent-skills/tree/main/skills/logmind. Most agent runtimes auto-load it. If yours doesn't:
+The complete procedure (when something counts as a decision, branch routing, doctor, refresh patterns) lives in the **`logmind` agent skill** at https://github.com/thrillmade/agent-skills/tree/main/skills/logmind. Most agent runtimes auto-load it. If yours doesn't:
 
 ```bash
-npx skills add https://github.com/thrillmot/agent-skills --skill logmind
+npx skills add https://github.com/thrillmade/agent-skills --skill logmind
 ```
 
 ### Required reading before non-trivial work

--- a/docs/decisions-branches/chore__vercel-ignore-and-site-refs.md
+++ b/docs/decisions-branches/chore__vercel-ignore-and-site-refs.md
@@ -1,0 +1,12 @@
+## 2026-05-27 00:26 - chore: post-migration cleanup — vercel.json + site URL refs + AGENTS.md v5-slim + dependabot.yml
+
+**Reasoning:** Phase C post-migration cleanup for clud-bug. Bundled changes: (1) root vercel.json with VERCEL_GIT_PREVIOUS_SHA-aware ignoreCommand — stops Vercel from rate-limiting on every non-site PR (recent PRs #74, #75 failed with upgradeToPro=build-rate-limit). Mirror of logmind's v0.2.9 fix. (2) site/app/page.tsx + opengraph-image.tsx GitHub-org refs thrillmot/<repo> → thrillmade/<repo> — 4 refs missed by Move 5's bulk sed (didn't include .tsx in extension list). Personal-brand refs (thrillmot.com, @thrillmot test fixtures) intentionally preserved. (3) logmind v0.3.0 → v0.3.1 refresh via logmind init: AGENTS.md block v4-slim → v5-slim (canonicalizes embedded skill install URL to thrillmade), workflow pins updated to logmind==0.3.1. (4) .github/dependabot.yml present (was untracked locally, npm config covering / and /site).
+
+**Alternatives considered:** Wait for v0.4.0 notify redesign — different scope; these are independent cleanup items that should ship now, Skip vercel.json fix and let Vercel rate-limits stay — recurring failure on every non-site PR is real friction
+
+**Implications:**
+- Vercel deploys now skip non-site PRs automatically (no more build-rate-limit failures on routine work)
+- AGENTS.md block on this repo now reflects thrillmade canonical URLs; downstream agent runtimes loading the local AGENTS.md see the new install command
+- Step 5.5 (AGENTS.md refresh sweep) is now done for clud-bug — bundled here. Remaining: agent-skills, reporulez, tokenomics, rezgen
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — chore: post-migration cleanup — vercel.json + site URL refs + AGENTS.md v5-slim + dependabot.yml *(chore/vercel-ignore-and-site-refs)* — [decisions-branches/chore__vercel-ignore-and-site-refs.md](decisions-branches/chore__vercel-ignore-and-site-refs.md)
 - **2026-05-26** — chore: migrate to thrillmade org + update all GitHub-org refs *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)
 - **2026-05-26** — Relax classifyPerSkillOutcome for natural bot phrasings (v0.5.16, 1F) *(feat/classifier-relax-v0.5.16)* — [decisions-branches/feat__classifier-relax-v0.5.16.md](decisions-branches/feat__classifier-relax-v0.5.16.md)
 - **2026-05-26** — Propagate logmind v0.2.10 to this repo (1C, truly clean) *(chore/logmind-v0.2.10-propagation)* — [decisions-branches/chore__logmind-v0.2.10-propagation.md](decisions-branches/chore__logmind-v0.2.10-propagation.md)

--- a/site/app/opengraph-image.tsx
+++ b/site/app/opengraph-image.tsx
@@ -152,7 +152,7 @@ export default async function OG() {
           }}
         >
           <span>npx clud-bug init</span>
-          <span>github.com/thrillmot/clud-bug</span>
+          <span>github.com/thrillmade/clud-bug</span>
         </div>
 
         {/* Left margin: plate number + bug */}

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -33,7 +33,7 @@ export default async function Home() {
           </p>
           <pre className="install-box appear-3">npx clud-bug init</pre>
           <div className="actions appear-4">
-            <a href="https://github.com/thrillmot/clud-bug">View on GitHub</a>
+            <a href="https://github.com/thrillmade/clud-bug">View on GitHub</a>
             <span className="sep">·</span>
             <a href="#observations">Observations</a>
             <span className="sep">·</span>
@@ -204,13 +204,13 @@ export default async function Home() {
 
       <footer className="colophon">
         <span>
-          Open source. <a href="https://github.com/thrillmot/clud-bug/blob/main/LICENSE">MIT</a>.
+          Open source. <a href="https://github.com/thrillmade/clud-bug/blob/main/LICENSE">MIT</a>.
         </span>
         <span className="credit">
           a <a href="https://thrillmot.com" rel="noopener">thrillmot</a> project
         </span>
         <span>
-          <a href="https://github.com/thrillmot/clud-bug">github.com/thrillmot/clud-bug</a>
+          <a href="https://github.com/thrillmade/clud-bug">github.com/thrillmade/clud-bug</a>
         </span>
       </footer>
     </main>

--- a/site/lib/data.ts
+++ b/site/lib/data.ts
@@ -2,7 +2,7 @@
 // Cached + revalidated hourly so the page stays fully static between rebuilds.
 
 const REVALIDATE_SECONDS = 3600;
-const REPO = 'thrillmot/clud-bug';
+const REPO = 'thrillmade/clud-bug';
 
 export type LatestReview = {
   prNumber: number;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "if [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- site/; else false; fi"
+}


### PR DESCRIPTION
## Summary
Phase C post-migration cleanup. Five bundled changes, all small + independent:

1. **Root `vercel.json` with VERCEL_GIT_PREVIOUS_SHA ignoreCommand** — stops Vercel from rate-limiting on every non-site PR. Mirror of logmind's v0.2.9 fix. Recent PRs (#74, #75) failed with \`upgradeToPro=build-rate-limit\` from constant Hobby-tier deploy spam; this skips non-site PRs entirely.

2. **`site/app/page.tsx` + `opengraph-image.tsx` URL refs**: 4 \`thrillmot/<repo>\` → \`thrillmade/<repo>\` updates (View on GitHub link, footer URL, opengraph image url). Missed by Move 5's bulk sed (didn't include \`.tsx\` in the extension list). Personal-brand \`thrillmot.com\` refs intentionally preserved.

3. **AGENTS.md block: v4-slim → v5-slim** — logmind init refresh-mode picks up logmind v0.3.1's template with thrillmade-canonical skill install URLs.

4. **Workflow logmind pins: 0.3.0 → 0.3.1** — refreshed by logmind init's auto-pin update.

5. **`.github/dependabot.yml`** — npm config covering \`/\` and \`/site\` directories (was untracked locally, committing now).

## Test plan
- [x] \`logmind doctor\` reports Stack status: OK after refresh
- [ ] Vercel: PR triggers a deploy (touches site/) — verify it builds. Next non-site PR after merge should skip.
- [ ] AGENTS.md displays v5-slim block-version marker (visible in rendered file)
- [x] No remaining \`thrillmot/<repo>\` refs in \`site/app/*.tsx\`

## Self-mod
Doesn't touch clud-bug-review.yml or strict-mode-gate action — should pass clud-bug-review normally without admin bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)