### PR TITLE
feat: add excludedBaselines manifest field (v0.6.0)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.5.16
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.0
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-05-27
+
+### Added
+
+- **`excludedBaselines: string[]` field in `.clud-bug.json`.** Lets a consumer repo opt out of any bundled baseline skill. Names listed there are (a) skipped when `runUpdate` iterates the bundled baseline dir, and (b) actively cleaned up: if `.claude/skills/<slug>/` exists, it's `rm -rf`'d in the same pass and surfaced in the `changed` list as `excluded baseline <name>: removed`. Idempotent — re-runs are no-ops once the dir is gone. The field passes through `readManifest` / `writeManifest` unchanged (existing `...data` / `...manifest` spreads carry it).
+- **Tests** (`test/update.test.js`, +2): one for the skip-on-write path, one for the migration cleanup path (pre-existing dir gets removed + reported in `changed`).
+
+### Why a minor bump (0.5.x → 0.6.0)
+
+New manifest field is additive but represents the first opt-out surface for bundled baselines — a deliberate API addition, not a bug fix. Existing manifests without the field behave identically to v0.5.x (the loop falls through to the existing write path). Test count: 167.
+
+### Motivation
+
+Pre-v0.6.0, the baseline-write loop in `lib/update.js` iterated the bundled baseline dir on every `clud-bug update` and unconditionally wrote each SKILL.md into `.claude/skills/<slug>/`. A consumer repo could `rm -rf` a baseline dir or remove its manifest entry, but the next update silently regenerated the dir from the bundled copy — making per-repo opt-out impossible. Surfaced concretely in `thrillmade/agent-skills`, which doesn't need `clud-bug-collaboration` because the repo *is* the skill catalog and the skill's "how to coexist with the clud-bug bot" guidance doesn't apply when there's no upstream-bot relationship.
+
 ## [0.5.16] — 2026-05-26
 
 ### Improved (UX)

--- a/docs/decisions-branches/feat__excluded-baselines.md
+++ b/docs/decisions-branches/feat__excluded-baselines.md
@@ -1,0 +1,12 @@
+## 2026-05-27 00:41 - Add excludedBaselines manifest field — per-repo opt-out of bundled baselines
+
+**Reasoning:** Pre-v0.6.0 every clud-bug update unconditionally re-wrote every bundled baseline SKILL.md to .claude/skills/<slug>/. Consumer repos could delete the dir or remove the manifest entry, but the next update silently regenerated. agent-skills surfaced this concretely: it doesn't need clud-bug-collaboration because the repo IS the skill catalog, and there's no way to make that drop stick. The manifest-driven exclusion makes per-repo opt-out durable across updates.
+
+**Alternatives considered:** Drop clud-bug-collaboration from clud-bug's baseline globally — rejected: other consumers may want it. Per-repo opt-out is the right granularity., Add a CLI flag like --no-clud-bug-collaboration — rejected: ephemeral; survives only one invocation. Manifest is the durable surface., Reuse 'installed' array by skipping entries already there — rejected: 'installed' is for skills clud-bug manages; excluded baselines aren't managed, they're suppressed. Different concept, separate field.
+
+**Implications:**
+- Cleanup pass also rms .claude/skills/<slug>/ on first run after the slug joins excludedBaselines — users don't have to manually delete the stale dir, and the removal surfaces in changed array as 'excluded baseline <name>: removed' for visibility.
+- Field passes through readManifest/writeManifest unchanged via existing ...data and ...manifest spreads; no schema-normalization code needed.
+- Minor bump 0.5.16 → 0.6.0; release-discipline.test.js enforced composite pin sync across the 3 review templates + the action.yml header example, all bumped together. Test count 167 (+2).
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — Add excludedBaselines manifest field — per-repo opt-out of bundled baselines *(feat/excluded-baselines)* — [decisions-branches/feat__excluded-baselines.md](decisions-branches/feat__excluded-baselines.md)
 - **2026-05-27** — chore: post-migration cleanup — vercel.json + site URL refs + AGENTS.md v5-slim + dependabot.yml *(chore/vercel-ignore-and-site-refs)* — [decisions-branches/chore__vercel-ignore-and-site-refs.md](decisions-branches/chore__vercel-ignore-and-site-refs.md)
 - **2026-05-26** — chore: migrate to thrillmade org + update all GitHub-org refs *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)
 - **2026-05-26** — Relax classifyPerSkillOutcome for natural bot phrasings (v0.5.16, 1F) *(feat/classifier-relax-v0.5.16)* — [decisions-branches/feat__classifier-relax-v0.5.16.md](decisions-branches/feat__classifier-relax-v0.5.16.md)

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir, stat } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, stat, rm } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { renderFile, pickTemplate } from './render.js';
 import { detect, buildDescriptionLine } from './detect.js';
@@ -69,9 +69,23 @@ export async function runUpdate({
   }
 
   // 3. Refresh baseline skills (always controlled by clud-bug).
+  //    Slugs listed in manifest.excludedBaselines are skipped AND their
+  //    existing .claude/skills/<slug>/ dir is removed if present, so a repo
+  //    that opts out of a baseline doesn't end up regenerating it on every
+  //    update (the original symptom this field exists to fix).
+  const excluded = new Set(Array.isArray(manifest.excludedBaselines) ? manifest.excludedBaselines : []);
   const baseline = await loadBaseline(baselineDir, loadBaselineOpts);
   for (const skill of baseline) {
-    const skillPath = join(skillsDir, sanitize(skill.name), 'SKILL.md');
+    const slug = sanitize(skill.name);
+    if (excluded.has(skill.name) || excluded.has(slug)) {
+      const skillDir = join(skillsDir, slug);
+      if (await pathExists(skillDir)) {
+        await rm(skillDir, { recursive: true, force: true });
+        changed.push({ path: skillDir, label: `excluded baseline ${skill.name}: removed` });
+      }
+      continue;
+    }
+    const skillPath = join(skillsDir, slug, 'SKILL.md');
     await maybeWrite(skillPath, skill.content, changed, unchanged, `baseline ${skill.name}`);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.5.16",
+  "version": "0.6.0",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -281,6 +281,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.5.16
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -282,6 +282,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.5.16
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -316,6 +316,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.5.16
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -140,6 +140,68 @@ test('runUpdate: no-ops when files already match latest', async () => {
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 
+test('runUpdate: excludedBaselines skips writing the listed slug', async () => {
+  // A consumer repo can opt out of any bundled baseline by listing its
+  // slug in `excludedBaselines`. Without this, every `clud-bug update`
+  // regenerates the baseline file from the bundled copy regardless of
+  // local manifest state — the original symptom this field exists to fix.
+  const dir = await makeRepo({
+    'package.json': JSON.stringify({ name: 'demo' }),
+    '.github/workflows/clud-bug-review.yml': '# clud-bug-template-version: v0\n# stale\n',
+    '.claude/skills/.clud-bug.json': JSON.stringify({
+      version: 1,
+      installed: [{ slug: 'critical-issues-only', kind: 'baseline' }],
+      excludedBaselines: ['clud-bug-collaboration'],
+    }),
+  });
+  try {
+    await runUpdate({
+      cwd: dir, templatesDir: TEMPLATES, baselineDir: BASELINE, ourVersion: '0.6.0',
+      loadBaselineOpts: offlineLoadBaseline,
+    });
+    // Excluded baseline is NOT written.
+    await assert.rejects(
+      readFile(join(dir, '.claude/skills/clud-bug-collaboration/SKILL.md'), 'utf8'),
+      { code: 'ENOENT' },
+    );
+    // Non-excluded baseline is still written.
+    const kept = await readFile(join(dir, '.claude/skills/critical-issues-only/SKILL.md'), 'utf8');
+    assert.match(kept, /critical-issues-only/);
+    // Manifest's excludedBaselines survives the write (passthrough).
+    const manifest = JSON.parse(await readFile(join(dir, '.claude/skills/.clud-bug.json'), 'utf8'));
+    assert.deepEqual(manifest.excludedBaselines, ['clud-bug-collaboration']);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('runUpdate: excludedBaselines removes a pre-existing skill dir + reports in changed', async () => {
+  // Migration path: a repo that previously had the baseline installed,
+  // then added the slug to excludedBaselines, should have the dir cleaned
+  // up on the next update — not left behind for the user to rm by hand.
+  const dir = await makeRepo({
+    'package.json': JSON.stringify({ name: 'demo' }),
+    '.github/workflows/clud-bug-review.yml': '# clud-bug-template-version: v0\n# stale\n',
+    '.claude/skills/.clud-bug.json': JSON.stringify({
+      version: 1,
+      installed: [],
+      excludedBaselines: ['clud-bug-collaboration'],
+    }),
+    // Pre-existing stale baseline dir that the exclusion should sweep.
+    '.claude/skills/clud-bug-collaboration/SKILL.md': '# stale content from a prior install\n',
+  });
+  try {
+    const r = await runUpdate({
+      cwd: dir, templatesDir: TEMPLATES, baselineDir: BASELINE, ourVersion: '0.6.0',
+      loadBaselineOpts: offlineLoadBaseline,
+    });
+    await assert.rejects(
+      readFile(join(dir, '.claude/skills/clud-bug-collaboration/SKILL.md'), 'utf8'),
+      { code: 'ENOENT' },
+    );
+    const removal = r.changed.find((c) => c.label === 'excluded baseline clud-bug-collaboration: removed');
+    assert.ok(removal, 'expected the removal to surface in changed');
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
 test('runUpdate: re-renders audit + self-update workflows when installed (stale marker)', async () => {
   const dir = await makeRepo({
     'package.json': JSON.stringify({ name: 'demo' }),


### PR DESCRIPTION
## Summary

New \`excludedBaselines: string[]\` field in \`.clud-bug.json\` lets a consumer repo opt out of any bundled baseline skill durably across updates.

Before v0.6.0, the baseline-write loop in \`lib/update.js\` iterated the bundled baseline dir on every \`clud-bug update\` and unconditionally wrote each SKILL.md into \`.claude/skills/<slug>/\`. Removing the dir or its manifest entry was a no-op — the next update silently regenerated it. This made per-repo opt-out impossible.

Surfaced concretely in \`thrillmade/agent-skills\`: it doesn't need \`clud-bug-collaboration\` because the repo IS the skill catalog and the skill's "how to coexist with the clud-bug bot" guidance doesn't apply when there's no upstream-bot relationship.

## Changes

- **\`lib/update.js\`** — read \`manifest.excludedBaselines\`, skip writes for listed slugs, and \`rm -rf .claude/skills/<slug>/\` if the dir exists (migration cleanup pass, surfaced in \`changed\` as \`excluded baseline <name>: removed\`).
- **\`test/update.test.js\`** — +2 tests covering the skip-on-write path and the migration cleanup path.
- **\`package.json\`** — 0.5.16 → 0.6.0 (additive API surface; first opt-out for bundled baselines).
- **\`CHANGELOG.md\`** — v0.6.0 entry with motivation + migration notes.
- **Composite pin lock-step** — bumped \`strict-mode-gate@v0.5.16\` → \`@v0.6.0\` in the 3 review templates + \`action.yml\` header example, per the \`release-discipline.test.js\` contract.

## Design notes

- \`excludedBaselines\` is plural (matches \`installed\`).
- The field passes through \`readManifest\` / \`writeManifest\` unchanged via the existing \`...data\` / \`...manifest\` spreads — no schema-normalization code needed.
- Cleanup happens in \`update\`, not in a separate command. Idempotent: once the dir is gone, subsequent runs no-op.
- \`init\` is intentionally out of scope: a fresh init has no excludedBaselines to honor (the field is added post-init by the consumer repo). Re-init on an already-initialized repo is the same path as update for this concern; we can revisit if a user surfaces a real need.

## Test plan

- [x] \`node --test test/*.test.js\` — 167 pass (+2 new), 0 fail.
- [x] \`test/release-discipline.test.js\` confirms templates + action.yml ref match the new package.json version.
- [ ] Visual diff on \`lib/update.js\` and the new tests reads naturally.
- [ ] clud-bug-review surfaces no critical findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)