### PR TITLE
chore(skills): refresh bundled clud-bug-collaboration from agent-skills@d3466c3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.2] — 2026-05-27
+
+### Changed
+
+- **Bundled `clud-bug-collaboration` SKILL.md refreshed** from `thrillmade/agent-skills@d3466c3`. `BASELINE_SKILLS_REF` in `lib/skills.js` pinned to the same commit so the install-time fetch path and the bundled offline-fallback path resolve to byte-identical content. Auto-synced by `agent-skills/.github/workflows/notify-clud-bug.yml`.
+
+
 ## [0.6.1] — 2026-05-27
 
 ### Fixed

--- a/lib/skills.js
+++ b/lib/skills.js
@@ -15,7 +15,7 @@ const MANIFEST_VERSION = 1;
 // skill content, bump BASELINE_SKILLS_REF below in the same clud-bug PR
 // that ships the corresponding bundled fallback update.
 // See thrillmade/agent-skills — skills.sh `skills/<name>/SKILL.md` layout.
-const BASELINE_SKILLS_REF = '436963ed37cbd9c6a9b7a07e907d5a0a432fab59';
+const BASELINE_SKILLS_REF = 'd3466c3863b78b2f170b2a04612c68c8e2616e4d';
 const AGENT_SKILLS_BASE = process.env.CLUD_BUG_AGENT_SKILLS_BASE
   ?? `https://raw.githubusercontent.com/thrillmade/agent-skills/${BASELINE_SKILLS_REF}/skills`;
 const SKILL_FETCH_TIMEOUT_MS = 5000;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/skills/baseline/clud-bug-collaboration.md
+++ b/templates/skills/baseline/clud-bug-collaboration.md
@@ -72,55 +72,6 @@ When you write a custom skill, follow the SKILL.md frontmatter format
 Generic advice gets ignored; rules with examples and quoted-line evidence
 move the bot's behavior.
 
-### Example: a good custom skill
-
-Don't write generic prose like "be careful with database code." That's
-not actionable. Instead, anchor to specific files + behaviors:
-
-````markdown
----
-name: db-query-review
-description: How to review changes under lib/db/. Always flag missing parameterization, N+1 query patterns, and missing transaction boundaries on multi-statement writes.
----
-
-# Reviewing lib/db/ changes
-
-When the diff touches `lib/db/queries.ts` or any file under `lib/db/`,
-apply these rules:
-
-## Always flag
-
-1. **SQL string interpolation** — anything that builds a query via `+`,
-   template literals, or `string.format` rather than parameterized
-   queries. Example to flag:
-
-   ```ts
-   // BAD — flag this
-   db.query(`SELECT * FROM users WHERE id = ${userId}`)
-   // GOOD — uses parameterization
-   db.query('SELECT * FROM users WHERE id = ?', [userId])
-   ```
-
-2. **N+1 patterns** — flag any `await` inside a `for`/`map` loop that
-   calls `db.query` or `db.queryOne`. The fix is usually a single
-   `WHERE id IN (...)` query or a join.
-
-3. **Multi-statement writes without `db.transaction`** — if a diff
-   adds two or more `db.query` calls that all write, demand a
-   transaction wrapper. Quote the lines.
-
-## Style of finding
-
-Cite the specific line. "This is a SQL injection risk" alone isn't
-enough — quote the unsafe interpolation directly and propose the
-parameterized alternative.
-````
-
-That's what "evidence-anchored" looks like: specific file paths, runnable
-code examples for both bad and good, and explicit instructions on what
-to quote in the finding. The bot loads this and uses it as concrete
-review criteria, not vague guidance.
-
 ## When you edit `.github/workflows/clud-bug-*.yml`
 
 `anthropics/claude-code-action` **refuses to run on PRs that modify its


### PR DESCRIPTION
Automated bundled-copy sync from `thrillmade/agent-skills`.

**Source SKILL.md:** https://github.com/thrillmade/agent-skills/blob/d3466c3863b78b2f170b2a04612c68c8e2616e4d/skills/clud-bug-collaboration/SKILL.md
**Source commit:** https://github.com/thrillmade/agent-skills/commit/d3466c3863b78b2f170b2a04612c68c8e2616e4d

## Changes applied

- `templates/skills/baseline/clud-bug-collaboration.md` ← byte-for-byte copy of the source above.
- `lib/skills.js` — `BASELINE_SKILLS_REF` bumped to `d3466c3863b78b2f170b2a04612c68c8e2616e4d` so the install-time fetch from `thrillmade/agent-skills` and the bundled offline-fallback both resolve to identical content.
- `package.json` — patch version bump to `0.6.2`.
- `CHANGELOG.md` — entry under [Unreleased] documenting the refresh.

## How this was generated

`agent-skills/.github/workflows/notify-clud-bug.yml` (`workflow_dispatch`) — invoked manually during the smoke-test phase. A future change to that workflow will add an `on: push` auto-trigger once the produced PRs are confirmed sane.