### PR TITLE
ceremony: bump deployed workflow @v0.6.1 → @v0.6.2 (follow-up to #92)

### DIFF
--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -282,6 +282,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.1
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,5 +105,5 @@ Anthropic's `claude-code-action` refuses to run on PRs that modify its own
 workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
 their own isolated PR — see [README](https://github.com/thrillmade/clud-bug#when-you-edit-the-workflow).
 
-_Installed at clud-bug v0.6.1._
+_Installed at clud-bug v0.6.2._
 <!-- clud-bug-end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,5 +44,5 @@ Anthropic's `claude-code-action` refuses to run on PRs that modify its own
 workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
 their own isolated PR — see [README](https://github.com/thrillmade/clud-bug#when-you-edit-the-workflow).
 
-_Installed at clud-bug v0.6.1._
+_Installed at clud-bug v0.6.2._
 <!-- clud-bug-end -->

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -51,6 +51,7 @@ clud-bug
 │   │   ├── ci__npm-publish-trusted.md
 │   │   ├── ci__unify-publish-and-promote.md
 │   │   ├── docs__skill-first-marketing-bb4.md
+│   │   ├── feat__0.A.1-extract-prompts.md
 │   │   ├── feat__agent-collab.md
 │   │   ├── feat__agent-skills-sha-bump.md
 │   │   ├── feat__cca-version-pinning.md
@@ -91,6 +92,7 @@ clud-bug
 │   ├── branch-protection.js
 │   ├── detect.js
 │   ├── edit-workflow.js
+│   ├── prompts.js
 │   ├── render.js
 │   ├── skills.js
 │   └── update.js
@@ -133,6 +135,7 @@ clud-bug
 │   ├── cli.test.js
 │   ├── detect.test.js
 │   ├── edit-workflow.test.js
+│   ├── prompts.test.js
 │   ├── release-discipline.test.js
 │   ├── render.test.js
 │   ├── skills.test.js


### PR DESCRIPTION
## Summary

Follows the established ceremony convention: PR #92 bumped what
consumers see (templates/ + package.json + composite-pin in actions),
but kept this repo's OWN deployed workflow ref pinned to the still-
existing v0.6.1 so #92 could pass its own clud-bug-review. Now that
v0.6.2 is tagged + on npm, this PR bumps the deployed refs.

## Diff

- \`.github/workflows/clud-bug-review.yml\`: strict-mode-gate@v0.6.1 → @v0.6.2
- \`CLAUDE.md\` / \`AGENTS.md\`: "Installed at clud-bug v0.6.2"
- \`docs/file-structure.md\`: auto-regen (new lib/prompts.js + test/prompts.test.js appear in tree)

## Test plan

- [x] All changes are trivial ref bumps; no test exercise needed
- [x] CI will exercise the new @v0.6.2 strict-mode-gate ref on this PR itself, verifying the tag is correctly published + reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)