### PR TITLE
feat(v0.6.3): Anthropic prompt caching via APPEND_SYSTEM_PROMPT (biggest ROI of Phase A)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.2
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.3
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.3] — 2026-05-27
+
+### Changed — Anthropic prompt caching via `APPEND_SYSTEM_PROMPT` env var
+
+Route the 215-line review prompt into the Claude Code CLI's auto-cached
+system layer instead of the un-cached user-message body. Anthropic bills
+cached input tokens at **10% of standard input** (5-min TTL). Within a
+5-min window, the second+ PR review in any consuming repo hits cache.
+
+- **Templates updated** (workflow{,-ts,-py}.yml.tmpl): the prompt content (still produced by `reviewPrompt(...)`) moves from `with.prompt:` to `env.APPEND_SYSTEM_PROMPT`. The action's `src/entrypoints/run.ts` reads `process.env.APPEND_SYSTEM_PROMPT` and passes it to the SDK's `systemPrompt.append`, landing it inside the CLI's auto-cached system layer.
+- **User-message `prompt:`** is now a minimal directive ("Review this pull request following the discipline in your system prompt..."), not the full instruction block. The action wraps it with PR context (diff, comments) automatically.
+- **`show_full_output: true`** added to expose `cache_read_input_tokens` / `cache_creation_input_tokens` in the run's result JSON for measurement.
+- **Test (`test/prompts.test.js`, +1)**: assert `APPEND_SYSTEM_PROMPT` block is byte-identical across two synthetic reviews of the same repo (cache prerequisite — any per-PR data leaking into the prefix would invalidate the cache).
+
+### Critical pitfall avoided
+
+Per Anthropic docs, cached content must be byte-stable across requests
+(no PR numbers, timestamps, or SHAs in the prefix) and the prefix must
+clear ~1024 tokens. Our prompt is ~3,500 tokens of pure rules content
+— no dynamic data, well over the threshold.
+
+### Verification post-rollout
+
+After this lands and propagates, consuming repos' clud-bug reviews
+should show non-zero `cache_read_input_tokens` on the 2nd+ review in
+any 5-min window (visible via `gh run view --log` on a workflow run
+when `show_full_output: true` is set).
+
 ## [0.6.2] — 2026-05-27
 
 ### Changed — extract review prompt to `lib/prompts.js` (refactor only, behavior preserved)

--- a/docs/decisions-branches/feat__0.A.2-prompt-caching.md
+++ b/docs/decisions-branches/feat__0.A.2-prompt-caching.md
@@ -1,0 +1,12 @@
+## 2026-05-27 20:58 - Route clud-bug's review prompt into Claude Code CLI's auto-cached system layer via APPEND_SYSTEM_PROMPT env var
+
+**Reasoning:** Phase A.2 — the biggest-ROI PR per research (10% input cost on cache hits). The 215-line prompt is byte-stable per-repo and naturally cacheable. Path: env.APPEND_SYSTEM_PROMPT (read by claude-code-action's run.ts and threaded into SDK's systemPrompt.append). User-message prompt becomes minimal directive.
+
+**Alternatives considered:** Pass appendSystemPrompt via claude_args flag (shell-quote multi-line escaping is painful), Write prompt to a file + reference (no --append-system-prompt-file flag exists), Put prompt content in CLAUDE.md (would pollute user-facing docs)
+
+**Implications:**
+- Cache hits depend on byte-stable prefix; CI tests assert byte-equality
+- show_full_output: true added to expose cache_*_input_tokens for measurement
+- Next downstream PRs (0.A.3 budgets, 0.A.4 comment format) build on this structure
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — Route clud-bug's review prompt into Claude Code CLI's auto-cached system layer via APPEND_SYSTEM_PROMPT env var *(feat/0.A.2-prompt-caching)* — [decisions-branches/feat__0.A.2-prompt-caching.md](decisions-branches/feat__0.A.2-prompt-caching.md)
 - **2026-05-27** — Extract clud-bug review prompt to lib/prompts.js (single source of truth) *(feat/0.A.1-extract-prompts)* — [decisions-branches/feat__0.A.1-extract-prompts.md](decisions-branches/feat__0.A.1-extract-prompts.md)
 - **2026-05-27** — chore: regen docs/file-structure.md (drop legacy Last updated line) *(chore/regen-derived-docs)* — [decisions-branches/chore__regen-derived-docs.md](decisions-branches/chore__regen-derived-docs.md)
 - **2026-05-27** — fix(vercel.json): guard ignoreCommand against bad VERCEL_GIT_PREVIOUS_SHA *(fix/vercel-ignore-bad-sha)* — [decisions-branches/fix__vercel-ignore-bad-sha.md](decisions-branches/fix__vercel-ignore-bad-sha.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -54,17 +54,25 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Stable prefix → CLI auto-cached system layer (10% cost on hits).
+          # See workflow.yml.tmpl for design notes.
+          APPEND_SYSTEM_PROMPT: |
+            {{REVIEW_PROMPT}}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
+          show_full_output: true
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md)"
           prompt: |
-            {{REVIEW_PROMPT}}
+            Review this pull request following the discipline in your
+            system prompt — every rule about skill routing, comment
+            format, the strict-mode header, the two-surface review
+            shape, and the FIX-PUSH FLOW applies.
 
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.2
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -54,17 +54,25 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Stable prefix → CLI auto-cached system layer (10% cost on hits).
+          # See workflow.yml.tmpl for design notes.
+          APPEND_SYSTEM_PROMPT: |
+            {{REVIEW_PROMPT}}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
+          show_full_output: true
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md)"
           prompt: |
-            {{REVIEW_PROMPT}}
+            Review this pull request following the discipline in your
+            system prompt — every rule about skill routing, comment
+            format, the strict-mode header, the two-surface review
+            shape, and the FIX-PUSH FLOW applies.
 
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.2
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -80,13 +80,30 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # APPEND_SYSTEM_PROMPT lands inside the Claude Code CLI's auto-cached
+          # system layer (system prompt, tools, conversation history). Anthropic
+          # bills cached input tokens at 10% of standard input — within a 5-min
+          # window, the 2nd+ PR review in any consuming repo hits cache.
+          # See: src/entrypoints/run.ts in claude-code-action — `appendSystemPrompt:
+          # process.env.APPEND_SYSTEM_PROMPT` reads this var, threads it into the
+          # SDK's `systemPrompt.append`. Crucial: keep this content byte-stable
+          # across runs (no PR numbers, timestamps, SHAs) or the cache invalidates.
+          APPEND_SYSTEM_PROMPT: |
+            {{REVIEW_PROMPT}}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
+          # show_full_output: exposes cache_read_input_tokens /
+          # cache_creation_input_tokens in the run's result JSON so we can
+          # measure caching effectiveness post-rollout (per v0.6.3 plan).
+          show_full_output: true
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md)"
           prompt: |
-            {{REVIEW_PROMPT}}
+            Review this pull request following the discipline in your
+            system prompt — every rule about skill routing, comment
+            format, the strict-mode header, the two-surface review
+            shape, and the FIX-PUSH FLOW applies.
 
       # Strict-mode gate. Fails the check when the BASE ref's manifest
       # has { "strictMode": true } AND the latest clud-bug review's first
@@ -103,6 +120,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.2
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/prompts.test.js
+++ b/test/prompts.test.js
@@ -90,46 +90,70 @@ test('templateLanguage maps template filename to reviewPrompt language', () => {
   assert.equal(templateLanguage('whatever-else.yml.tmpl'), 'generic');
 });
 
-test('rendered workflow.yml.tmpl contains the prompt body indented under prompt: |', async () => {
-  // The renderFile pipeline must (a) substitute REVIEW_PROMPT and
-  // (b) preserve YAML indentation for the multi-line value via
-  // render.js's indent-aware logic.
+test('rendered workflow.yml.tmpl puts review prompt in APPEND_SYSTEM_PROMPT env var (0.A.2 caching path)', async () => {
+  // v0.A.2: review prompt moved from user-message `prompt:` to
+  // `APPEND_SYSTEM_PROMPT` env var so Claude Code CLI's auto-cache
+  // covers it. The user-message `prompt:` becomes a minimal directive.
   const out = await renderFile(join(TEMPLATES, 'workflow.yml.tmpl'), {
     REVIEW_PROMPT: reviewPrompt({
       projectDescription: 'TEST DESCRIPTION',
       language: 'generic',
     }),
   });
-  // Project description appears at the right indent under prompt: |
-  assert.match(out, /          prompt: \|\n            TEST DESCRIPTION\n/);
-  // Mid-prompt content is also at 12-space indent (continuation lines
-  // get the placeholder's leading whitespace from render.js). Sub-block
-  // markdown headers like "### Per-skill scan" sit at 14 spaces because
-  // the original prompt's sub-block had 2 extra leading spaces.
+  // Project description appears at the right indent under APPEND_SYSTEM_PROMPT: |
+  assert.match(out, /          APPEND_SYSTEM_PROMPT: \|\n            TEST DESCRIPTION\n/);
+  // Mid-prompt content at 12-space indent (env-var YAML block scalar).
+  // Sub-block markdown headers like "### Per-skill scan" sit at 14 spaces
+  // (original prompt's sub-block had 2 extra leading spaces).
   assert.match(out, /\n            Review this pull request for critical issues only/);
   assert.match(out, /\n {14}### Per-skill scan\n/);
+  // show_full_output: true is the measurement gate — exposes cache_*_input_tokens.
+  assert.match(out, /\n          show_full_output: true\n/);
+  // User-message prompt is now minimal — no longer the full 215-line block.
+  assert.match(out, /          prompt: \|\n            Review this pull request following the discipline/);
 });
 
-test('rendered workflow-ts.yml.tmpl contains TypeScript bullets', async () => {
+test('rendered workflow-ts.yml.tmpl contains TypeScript bullets in APPEND_SYSTEM_PROMPT', async () => {
   const out = await renderFile(join(TEMPLATES, 'workflow-ts.yml.tmpl'), {
     REVIEW_PROMPT: reviewPrompt({
       projectDescription: 'TS PROJECT',
       language: 'ts',
     }),
   });
+  // TS-specific bullet must appear under APPEND_SYSTEM_PROMPT, not prompt:
+  assert.match(out, /APPEND_SYSTEM_PROMPT: \|/);
   assert.match(out, /\n            - TypeScript type safety issues/);
+  assert.match(out, /\n          show_full_output: true\n/);
 });
 
-test('rendered workflow-py.yml.tmpl contains Python bullets (no generic test-coverage)', async () => {
+test('rendered workflow-py.yml.tmpl contains Python bullets (no generic test-coverage) in APPEND_SYSTEM_PROMPT', async () => {
   const out = await renderFile(join(TEMPLATES, 'workflow-py.yml.tmpl'), {
     REVIEW_PROMPT: reviewPrompt({
       projectDescription: 'PY PROJECT',
       language: 'py',
     }),
   });
+  assert.match(out, /APPEND_SYSTEM_PROMPT: \|/);
   assert.match(out, /\n            - Incorrect exception handling/);
   // Python variant should NOT include the generic "Broken or missing test coverage" line.
   assert.doesNotMatch(out, /\n            - Broken or missing test coverage/);
+});
+
+test('APPEND_SYSTEM_PROMPT content is byte-stable across reviews of different PRs (cache prerequisite)', async () => {
+  // Caching only works if the cached prefix is BYTE-IDENTICAL across runs.
+  // Two synthetic reviews of the same repo (same projectDescription, same
+  // language) must produce byte-identical APPEND_SYSTEM_PROMPT sections.
+  // Any per-PR data (numbers, timestamps, SHAs) leaking into the prefix
+  // would invalidate the cache.
+  const out1 = await renderFile(join(TEMPLATES, 'workflow.yml.tmpl'), {
+    REVIEW_PROMPT: reviewPrompt({ projectDescription: 'X', language: 'generic' }),
+  });
+  const out2 = await renderFile(join(TEMPLATES, 'workflow.yml.tmpl'), {
+    REVIEW_PROMPT: reviewPrompt({ projectDescription: 'X', language: 'generic' }),
+  });
+  // Extract just the APPEND_SYSTEM_PROMPT block from each rendered template.
+  const extractAppend = (s) => s.match(/APPEND_SYSTEM_PROMPT: \|\n([\s\S]*?)\n        with:/m)[1];
+  assert.equal(extractAppend(out1), extractAppend(out2));
 });
 
 // --- Indent-aware render.js behavior (added in v0.6.2 alongside prompts.js) ---


### PR DESCRIPTION
## Summary

Phase 0.A.2 of the token-cost compression roadmap. **Biggest ROI of the set** per the research spike.

Routes clud-bug's 215-line review prompt into the Claude Code CLI's auto-cached system layer instead of the un-cached user-message body. Anthropic bills cached input tokens at **10% of standard input** (5-min TTL). Within a 5-min window, the second+ PR review in any consuming repo hits cache.

## Mechanism

Per the background-agent audit of \`anthropics/claude-code-action\`:
- The action does NOT use \`cache_control\` itself.
- The Claude Code CLI underneath **auto-caches its system layer** (system prompt, tool definitions, conversation history).
- \`src/entrypoints/run.ts\` reads \`process.env.APPEND_SYSTEM_PROMPT\` and threads it into the SDK's \`systemPrompt.append\` — which lands inside the CLI's auto-cached layer.
- That's the route: set \`APPEND_SYSTEM_PROMPT\` env var on the action step.

## What's in the diff

- **\`templates/workflow{,-ts,-py}.yml.tmpl\`**: the prompt content (still produced by \`reviewPrompt(...)\` from v0.6.2) moves from \`with.prompt:\` to \`env.APPEND_SYSTEM_PROMPT\`. User-message \`prompt:\` becomes a minimal directive — the action wraps it with PR context (diff, comments) automatically.
- **\`show_full_output: true\`** added so the run's result JSON exposes \`cache_read_input_tokens\` / \`cache_creation_input_tokens\` for measurement post-rollout.
- **Tests** (\`test/prompts.test.js\`, +1 new + 3 updated): new test asserts \`APPEND_SYSTEM_PROMPT\` block is byte-identical across two synthetic reviews of the same repo (cache prerequisite). Updated rendered-output assertions to look for the prompt in its new env-var location.
- **Version bump** 0.6.2 → 0.6.3 + composite-pin lock-step across templates + action.yml header.
- **CHANGELOG \`[0.6.3]\`** documents the caching path + critical byte-stability pitfall.

## Critical pitfalls (called out in CHANGELOG + template comments)

- No dynamic content in the cached prefix (no PR numbers, timestamps, SHAs).
- Whitespace byte-stable. \`\\n\\n\` ≠ \`\\n \\n\`.
- Prefix size must clear ~1024 tokens. Ours is ~3,500 tokens of pure rules → well over.

## Quality preservation

Same content, different location. The reviewer Claude sees the same instructions. Zero quality regression: the cached vs un-cached content is byte-identical.

## Test plan

- [x] \`npm test\` — 181/181 pass (+1 new byte-stability test)
- [x] Manually verified rendered output puts APPEND_SYSTEM_PROMPT block + show_full_output: true in the correct location across all 3 templates
- [x] \`reviewPrompt(...)\` output unchanged from v0.6.2 — just routed differently
- [x] Decision logged via \`logmind log\`

## Verification post-rollout

After this lands and propagates, consuming repos' clud-bug reviews should show non-zero \`cache_read_input_tokens\` on the 2nd+ review in any 5-min window (visible via \`gh run view --log\` on a workflow run with \`show_full_output: true\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)