### PR TITLE
feat(v0.6.4): per-section prompt budgets (diff/comments/skills)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.3
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.4
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Claude caps each variable fetch with `head -c $MAX_*_BYTES`.
 
 - **80 KB diff** covers ~95% of real PRs (measured during the 2026-05-27 spike: median <10 KB, long-tail to 105 KB).
 - **20 KB comments** = ~20 most-recent comments at typical sizes. Skips clud-bug's own prior comments (those are handled via the FIX-PUSH FLOW reviewThreads GraphQL).
-- **4 KB per skill file** fits the baseline kit comfortably; user-added skills get truncated with a `[... N bytes elided ...]` marker.
+- **4 KB per skill file** fits the baseline kit comfortably; user-added skills above the cap get silently truncated by `head -c`. (A `[... N bytes elided ...]` marker would require a post-process step we haven't shipped; the prompt instead tells Claude to note any apparent truncation in the review.)
 
 ### Why soft enforcement (prompt instructions) vs hard caps (allowlist patterns)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.4] — 2026-05-27
+
+### Changed — per-section budgets cap the variable suffix (caching covered the stable prefix)
+
+Builds on v0.6.3's caching: the stable system-prompt prefix is cached at
+10% of standard input cost, but the variable per-PR content (diff,
+comments, skill files) is still billed at full rate on every review. This
+release adds prompt-level budget instructions + workflow env vars so
+Claude caps each variable fetch with `head -c $MAX_*_BYTES`.
+
+- **`lib/prompts.js`** — `reviewPrompt(...)` now emits a "Section budgets" subsection in the system prompt instructing Claude to cap fetches: `gh pr diff "$PR_NUMBER" | head -c "$MAX_DIFF_BYTES"`, `head -c "$MAX_SKILL_BYTES" .claude/skills/*/SKILL.md`, etc. Tells Claude to note any truncation in the review.
+- **`templates/workflow{,-ts,-py}.yml.tmpl`** — three new env vars on the action step: `MAX_DIFF_BYTES=80000`, `MAX_COMMENT_BYTES=20000`, `MAX_SKILL_BYTES=4000`. Plus `REPO_OWNER` / `REPO_NAME` so the comment-fetch pattern resolves. Consumers can override per-repo by setting these env vars in their workflow.
+- **`Bash(head:*)`** added to allowedTools so Claude can pipe outputs through `head -c` per the budget instructions.
+- **Tests** (`test/prompts.test.js`, +3): assert budget section in prompt, env vars in rendered templates, `Bash(head:*)` in allowedTools across all 3 templates.
+
+### Defaults rationale
+
+- **80 KB diff** covers ~95% of real PRs (measured during the 2026-05-27 spike: median <10 KB, long-tail to 105 KB).
+- **20 KB comments** = ~20 most-recent comments at typical sizes. Skips clud-bug's own prior comments (those are handled via the FIX-PUSH FLOW reviewThreads GraphQL).
+- **4 KB per skill file** fits the baseline kit comfortably; user-added skills get truncated with a `[... N bytes elided ...]` marker.
+
+### Why soft enforcement (prompt instructions) vs hard caps (allowlist patterns)
+
+Hard caps via allowedTools patterns would be brittle (would need to match every reasonable invocation of `gh pr diff` and reject the unbounded form). Soft caps via prompt instructions are flexible — Claude generally follows the instruction, and the prompt's caching means the instruction itself is free to ship. Phase 1's RTK rollout will provide hard enforcement at the bash-hook layer for the same fetches.
+
 ## [0.6.3] — 2026-05-27
 
 ### Changed — Anthropic prompt caching via `APPEND_SYSTEM_PROMPT` env var

--- a/docs/decisions-branches/feat__0.A.3-prompt-budgets.md
+++ b/docs/decisions-branches/feat__0.A.3-prompt-budgets.md
@@ -1,0 +1,12 @@
+## 2026-05-27 22:13 - Add per-section byte budgets to clud-bug's review prompt + workflow env vars
+
+**Reasoning:** Phase A.3 — caps the variable per-PR suffix (diff, comments, skills) that isn't covered by the v0.6.3 caching of the stable prefix. Defaults: 80KB diff, 20KB comments, 4KB per skill. Env-overridable per-repo. Soft enforcement via prompt instructions + Bash(head:*) allowedTool; hard enforcement deferred to Phase 1 RTK rollout.
+
+**Alternatives considered:** Hard allowlist patterns (reject unbounded gh pr diff), Pre-fetch in workflow run: steps with size caps
+
+**Implications:**
+- Default 80KB diff covers ~95% of PRs per spike measurement; consumers can raise via MAX_DIFF_BYTES env var
+- Bash(head:*) added to allowedTools — small attack surface expansion, mitigated by prompt scope
+- Builds on 0.A.2 caching: prompt-level instructions ship in the cached prefix at 10% cost
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -53,6 +53,7 @@ clud-bug
 │   │   ├── docs__skill-first-marketing-bb4.md
 │   │   ├── feat__0.A.1-extract-prompts.md
 │   │   ├── feat__0.A.2-prompt-caching.md
+│   │   ├── feat__0.A.3-prompt-budgets.md
 │   │   ├── feat__agent-collab.md
 │   │   ├── feat__agent-skills-sha-bump.md
 │   │   ├── feat__cca-version-pinning.md

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -52,6 +52,7 @@ clud-bug
 │   │   ├── ci__unify-publish-and-promote.md
 │   │   ├── docs__skill-first-marketing-bb4.md
 │   │   ├── feat__0.A.1-extract-prompts.md
+│   │   ├── feat__0.A.2-prompt-caching.md
 │   │   ├── feat__agent-collab.md
 │   │   ├── feat__agent-skills-sha-bump.md
 │   │   ├── feat__cca-version-pinning.md

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — Add per-section byte budgets to clud-bug's review prompt + workflow env vars *(feat/0.A.3-prompt-budgets)* — [decisions-branches/feat__0.A.3-prompt-budgets.md](decisions-branches/feat__0.A.3-prompt-budgets.md)
 - **2026-05-27** — Route clud-bug's review prompt into Claude Code CLI's auto-cached system layer via APPEND_SYSTEM_PROMPT env var *(feat/0.A.2-prompt-caching)* — [decisions-branches/feat__0.A.2-prompt-caching.md](decisions-branches/feat__0.A.2-prompt-caching.md)
 - **2026-05-27** — Extract clud-bug review prompt to lib/prompts.js (single source of truth) *(feat/0.A.1-extract-prompts)* — [decisions-branches/feat__0.A.1-extract-prompts.md](decisions-branches/feat__0.A.1-extract-prompts.md)
 - **2026-05-27** — chore: regen docs/file-structure.md (drop legacy Last updated line) *(chore/regen-derived-docs)* — [decisions-branches/chore__regen-derived-docs.md](decisions-branches/chore__regen-derived-docs.md)

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -57,6 +57,32 @@ ${focusBullets}
 Skip style suggestions, minor naming issues, or anything that
 doesn't affect correctness, security, or performance.
 
+Section budgets (token-frugal review — v0.6.4+):
+The workflow sets env vars MAX_DIFF_BYTES / MAX_COMMENT_BYTES /
+MAX_SKILL_BYTES. When fetching content via the Bash tool, cap each
+section with \`head -c\` to keep your context lean. Caching covers
+the stable system-prompt prefix (you're reading it now) at 10% of
+standard input cost, but variable per-PR content is NOT cached, so
+size discipline on those fetches pays back directly.
+
+  - PR diff: \`gh pr diff "$PR_NUMBER" | head -c "$MAX_DIFF_BYTES"\`
+    (default 80,000 bytes — covers ~95% of real PRs unbruised). If
+    the output looks truncated mid-line, note it in your review and
+    request the omitted hunks via \`gh pr diff "$PR_NUMBER" --name-only\`
+    + a targeted re-fetch of the specific files that need scrutiny.
+
+  - Skill files: \`head -c "$MAX_SKILL_BYTES" .claude/skills/<name>/SKILL.md\`
+    per file (default 4,000 bytes). Baseline skills fit easily;
+    bloated user-added skills get truncated.
+
+  - PR comments: \`gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$PR_NUMBER/comments?per_page=20" --jq '.[] | select(.user.login != "claude[bot]")' | head -c "$MAX_COMMENT_BYTES"\`
+    (default 20,000 bytes, 20 most-recent). Skips your own prior
+    comments — the FIX-PUSH FLOW handles those via reviewThreads
+    GraphQL instead.
+
+If you genuinely cannot review safely without the elided content,
+say so plainly in the summary comment instead of speculating.
+
 Skills are not background context — they are review rules with
 authority. Before flagging any finding, scan the loaded skills in
 .claude/skills/ for relevant guidance. If a skill applies, your
@@ -78,8 +104,8 @@ frontmatter at .claude/skills/<name>/SKILL.md. Two values:
 
 Before writing the review, scan each loaded skill's frontmatter
 (the first \`---\`-delimited block of its SKILL.md) to identify
-its review_mode. You can read them with:
-  cat .claude/skills/*/SKILL.md
+its review_mode. Read each one capped at MAX_SKILL_BYTES:
+  head -c "$MAX_SKILL_BYTES" .claude/skills/*/SKILL.md
 
 At the end of every review, append a single-line footer:
   Skills referenced: [skill-name-1, skill-name-2, ...]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -54,6 +54,12 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          # Per-section byte budgets — see workflow.yml.tmpl for design notes.
+          MAX_DIFF_BYTES: '80000'
+          MAX_COMMENT_BYTES: '20000'
+          MAX_SKILL_BYTES: '4000'
           # Stable prefix → CLI auto-cached system layer (10% cost on hits).
           # See workflow.yml.tmpl for design notes.
           APPEND_SYSTEM_PROMPT: |
@@ -63,7 +69,7 @@ jobs:
           track_progress: true
           show_full_output: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
           prompt: |
             Review this pull request following the discipline in your
             system prompt — every rule about skill routing, comment
@@ -73,6 +79,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.3
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -54,6 +54,12 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          # Per-section byte budgets — see workflow.yml.tmpl for design notes.
+          MAX_DIFF_BYTES: '80000'
+          MAX_COMMENT_BYTES: '20000'
+          MAX_SKILL_BYTES: '4000'
           # Stable prefix → CLI auto-cached system layer (10% cost on hits).
           # See workflow.yml.tmpl for design notes.
           APPEND_SYSTEM_PROMPT: |
@@ -63,7 +69,7 @@ jobs:
           track_progress: true
           show_full_output: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
           prompt: |
             Review this pull request following the discipline in your
             system prompt — every rule about skill routing, comment
@@ -73,6 +79,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.3
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -80,6 +80,16 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          # Per-section byte budgets (v0.6.4). The system-prompt instructs
+          # Claude to cap each per-PR input fetch with `head -c`. Caching
+          # covers the stable system prefix; capping covers the variable
+          # suffix (diff, comments, skills). Override per-repo by setting
+          # these env vars in the consuming workflow if defaults don't fit.
+          MAX_DIFF_BYTES: '80000'
+          MAX_COMMENT_BYTES: '20000'
+          MAX_SKILL_BYTES: '4000'
           # APPEND_SYSTEM_PROMPT lands inside the Claude Code CLI's auto-cached
           # system layer (system prompt, tools, conversation history). Anthropic
           # bills cached input tokens at 10% of standard input — within a 5-min
@@ -98,7 +108,7 @@ jobs:
           # measure caching effectiveness post-rollout (per v0.6.3 plan).
           show_full_output: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
           prompt: |
             Review this pull request following the discipline in your
             system prompt — every rule about skill routing, comment
@@ -120,6 +130,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.3
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/prompts.test.js
+++ b/test/prompts.test.js
@@ -83,6 +83,51 @@ test('reviewPrompt includes the core review-discipline sections', () => {
   }
 });
 
+// --- 0.A.3: per-section budgets (v0.6.4) ---
+// The prompt instructs Claude to cap per-PR fetches with `head -c
+// $MAX_DIFF_BYTES` etc. Combined with the env vars + Bash(head:*)
+// allowedTool in the workflow templates, this caps the variable
+// (non-cached) suffix of each review.
+
+test('reviewPrompt includes per-section budget instructions', () => {
+  const out = reviewPrompt({ projectDescription: 'p' });
+  // Budget header section is present.
+  assert.match(out, /Section budgets \(token-frugal review/);
+  // Each of the three budget env vars is referenced.
+  assert.match(out, /MAX_DIFF_BYTES/);
+  assert.match(out, /MAX_COMMENT_BYTES/);
+  assert.match(out, /MAX_SKILL_BYTES/);
+  // The PR diff capping pattern is in the prompt.
+  assert.match(out, /gh pr diff "\$PR_NUMBER" \| head -c "\$MAX_DIFF_BYTES"/);
+});
+
+test('rendered workflow.yml.tmpl sets the three budget env vars', async () => {
+  const out = await renderFile(join(TEMPLATES, 'workflow.yml.tmpl'), {
+    REVIEW_PROMPT: reviewPrompt({ projectDescription: 'p', language: 'generic' }),
+  });
+  assert.match(out, /MAX_DIFF_BYTES: '80000'/);
+  assert.match(out, /MAX_COMMENT_BYTES: '20000'/);
+  assert.match(out, /MAX_SKILL_BYTES: '4000'/);
+  // REPO_OWNER and REPO_NAME are needed by the comment-fetch pattern.
+  assert.match(out, /REPO_OWNER: \$\{\{ github\.repository_owner \}\}/);
+  assert.match(out, /REPO_NAME: \$\{\{ github\.event\.repository\.name \}\}/);
+  // Bash(head:*) added to allowedTools so Claude can pipe through head.
+  assert.match(out, /Bash\(head:\*\)/);
+});
+
+test('rendered workflow-ts and workflow-py templates also set budget env vars', async () => {
+  for (const tmpl of ['workflow-ts.yml.tmpl', 'workflow-py.yml.tmpl']) {
+    const out = await renderFile(join(TEMPLATES, tmpl), {
+      REVIEW_PROMPT: reviewPrompt({
+        projectDescription: 'p',
+        language: tmpl.includes('-ts') ? 'ts' : 'py',
+      }),
+    });
+    assert.match(out, /MAX_DIFF_BYTES: '80000'/, `${tmpl} missing MAX_DIFF_BYTES`);
+    assert.match(out, /Bash\(head:\*\)/, `${tmpl} missing Bash(head:*) in allowedTools`);
+  }
+});
+
 test('templateLanguage maps template filename to reviewPrompt language', () => {
   assert.equal(templateLanguage('workflow-ts.yml.tmpl'), 'ts');
   assert.equal(templateLanguage('workflow-py.yml.tmpl'), 'py');


### PR DESCRIPTION
## Summary

Phase 0.A.3 of the token-cost compression roadmap.

Builds on v0.6.3's caching: the stable system-prompt prefix is cached at 10% of standard input cost, but the **variable per-PR content** (diff, comments, skill files) is still billed at full rate on every review. This PR adds prompt-level budget instructions + workflow env vars so Claude caps each variable fetch with \`head -c $MAX_*_BYTES\`.

## What's in the diff

- **\`lib/prompts.js\`** — \`reviewPrompt(...)\` emits a "Section budgets" subsection in the system prompt instructing Claude to cap fetches: \`gh pr diff "$PR_NUMBER" | head -c "$MAX_DIFF_BYTES"\`, \`head -c "$MAX_SKILL_BYTES" .claude/skills/*/SKILL.md\`, etc. Tells Claude to note any truncation in the review.
- **\`templates/workflow{,-ts,-py}.yml.tmpl\`** — three new env vars (\`MAX_DIFF_BYTES=80000\`, \`MAX_COMMENT_BYTES=20000\`, \`MAX_SKILL_BYTES=4000\`) + \`REPO_OWNER\` / \`REPO_NAME\` so the comment-fetch pattern resolves. Consumers can override per-repo by setting these env vars in their workflow.
- **\`Bash(head:*)\`** added to allowedTools so Claude can pipe outputs through \`head -c\` per the budget instructions.
- **Tests** (\`test/prompts.test.js\`, +3): assert budget section in prompt, env vars in rendered templates, \`Bash(head:*)\` in allowedTools across all 3 templates.

## Defaults rationale

- **80 KB diff** covers ~95% of real PRs (measured during the 2026-05-27 spike: median <10 KB, long-tail to 105 KB).
- **20 KB comments** = ~20 most-recent comments at typical sizes. Skips clud-bug's own prior comments (those are handled via the FIX-PUSH FLOW reviewThreads GraphQL).
- **4 KB per skill file** fits the baseline kit comfortably; user-added skills get truncated.

## Soft vs hard enforcement

This PR uses **soft enforcement** (prompt instructions + Claude follows them). Hard enforcement via allowlist patterns is brittle (would need to reject every unbounded invocation form). Phase 1's RTK rollout provides hard enforcement at the bash-hook layer for the same fetches.

## Quality preservation

- The 80 KB default is calibrated to cover 95%+ of real PRs unbruised — only the long-tail 5% see truncation.
- The prompt explicitly instructs Claude to NOTE truncation in the review and request omitted hunks via targeted re-fetch when material.
- Env-overridable for any consuming repo that needs a higher cap.
- No semantic info dropped from the prompt; the budgets just constrain how much variable content Claude PULLS in via Bash tool.

## Test plan

- [x] \`npm test\` — 184/184 pass (+3 new tests)
- [x] Manual verification: env vars present in all 3 rendered templates, Bash(head:*) in allowedTools, prompt contains the Section budgets header
- [x] Decision logged via \`logmind log\`

## Verification post-rollout

After merge + propagation, the next clud-bug-review on a tree-touching PR should show capped fetches in the workflow log (look for \`head -c\` invocations in the Bash tool log entries under \`show_full_output: true\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)