### PR TITLE
feat(v0.6.5): review-comment compression — stats header + severity prefix + collapsible reasoning

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.4
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.5
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.5] — 2026-05-27
+
+### Changed — write-time comment compression: stats header + severity prefix + collapsible reasoning
+
+The comments clud-bug *writes* get ingested by every subsequent re-review of
+the same PR (via the FIX-PUSH FLOW's `gh api ... comments` fetch). Compressing
+at write time means every future re-read in every consuming repo costs less.
+
+- **Stats header** (`Found: N 🔴 / N 🟡 / N 🟣`) leads every review comment immediately under `**This round:**`. Three severity tiers: 🔴 important (bugs/security/perf), 🟡 nit (suggestions), 🟣 pre-existing (issues that pre-date this PR). On the zero-findings case the header IS the entire substantive payload — agents re-ingesting the comment can short-circuit without parsing the body.
+- **Per-finding format**: each finding starts with a severity emoji + one-line claim + `file:line`. Long-form reasoning wraps in `<details><summary>Reasoning</summary>...</details>`. Humans see full detail via GitHub's native render; agent re-reads skip the collapsed section.
+- **NEW `extractStatsHeader(comment)` export** in `lib/skills.js`: parses the stats line into `{important, nit, preExisting}` or returns `null`. Strict on severity emoji (drift catches loudly), permissive on whitespace.
+- **Tests** (`test/prompts.test.js` +2, `test/skills.test.js` +5): assert the prompt instructions are present + the parser handles canonical / whitespace-variant / multi-digit / missing / non-string inputs.
+
+### Compounds effect
+
+Combined with v0.6.3 (caching the stable prefix) and v0.6.4 (capping the
+variable suffix), v0.6.5 compresses the third surface: the comments
+clud-bug writes that future re-reviews must ingest. Every byte trimmed
+here is paid back on every future re-review for the lifetime of the PR.
+
+### Anthropic Code Review parity
+
+The three-tier severity system is the same scheme Anthropic's own Code
+Review uses (🔴 Important / 🟡 Nit / 🟣 Pre-existing). Matching this on
+opt-in keeps users who switch between products consistent.
+
 ## [0.6.4] — 2026-05-27
 
 ### Changed — per-section budgets cap the variable suffix (caching covered the stable prefix)

--- a/docs/decisions-branches/feat__0.A.4-comment-compression.md
+++ b/docs/decisions-branches/feat__0.A.4-comment-compression.md
@@ -1,0 +1,12 @@
+## 2026-05-27 22:28 - Add stats header + severity-prefix + collapsible-reasoning comment format
+
+**Reasoning:** Phase A.4 — write-time compression for clud-bug review comments. Stats header (Found: N 🔴 / N 🟡 / N 🟣) lets re-review agents short-circuit on zero findings. Severity-prefix per finding + <details> for reasoning halves what next agent re-ingests. Matches Anthropic Code Review's three-tier severity system.
+
+**Alternatives considered:** Keep critical/minor binary split, Use color-only without emoji (worse for grep/scan)
+
+**Implications:**
+- Adds extractStatsHeader parser export — strict on emoji, permissive on whitespace
+- Per-finding <details> blocks: humans see native render, agents skip token-cheaply
+- Compounds with caching (0.A.2) + budgets (0.A.3): compresses third surface
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — Add stats header + severity-prefix + collapsible-reasoning comment format *(feat/0.A.4-comment-compression)* — [decisions-branches/feat__0.A.4-comment-compression.md](decisions-branches/feat__0.A.4-comment-compression.md)
 - **2026-05-27** — Add per-section byte budgets to clud-bug's review prompt + workflow env vars *(feat/0.A.3-prompt-budgets)* — [decisions-branches/feat__0.A.3-prompt-budgets.md](decisions-branches/feat__0.A.3-prompt-budgets.md)
 - **2026-05-27** — Route clud-bug's review prompt into Claude Code CLI's auto-cached system layer via APPEND_SYSTEM_PROMPT env var *(feat/0.A.2-prompt-caching)* — [decisions-branches/feat__0.A.2-prompt-caching.md](decisions-branches/feat__0.A.2-prompt-caching.md)
 - **2026-05-27** — Extract clud-bug review prompt to lib/prompts.js (single source of truth) *(feat/0.A.1-extract-prompts)* — [decisions-branches/feat__0.A.1-extract-prompts.md](decisions-branches/feat__0.A.1-extract-prompts.md)

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -212,6 +212,42 @@ On a first-time review, "resolved from prior" and "still
 open" are both 0. On follow-up reviews after a fix-push,
 "resolved from prior" should typically be positive.
 
+Stats header (required, immediately under **This round:**):
+Lead with ONE single-line stats header that uses severity emoji
+so agents re-reading this comment on a future review pass can
+triage at a glance (and skip parsing the body on the common
+zero-findings case). Three tiers:
+
+  🔴 important — bugs / security / perf / missing test coverage
+  🟡 nit       — minor suggestions, style nits, observations
+  🟣 pre-existing — issues that pre-date this PR (not its author's
+                    fault, but worth surfacing for awareness)
+
+Emit exactly this shape on the line immediately after **This round:**:
+
+  Found: N 🔴 / N 🟡 / N 🟣
+
+When all three are 0 the entire substantive body is optional —
+agents reading this header on a future re-review can stop here.
+
+Per-finding format (severity emoji + collapsible reasoning):
+Each finding in critical/minor/per-skill sections uses this
+write-time-compressed format. The summary line is the load-bearing
+claim; the long-form reasoning lives in a \`<details>\` block that
+humans expand inline (GitHub renders it natively) but future agent
+re-reads can skip token-cheaply.
+
+  🔴 [skill-name]: One-line claim (file:line).
+  <details><summary>Reasoning</summary>
+
+  Longer explanation: evidence anchors, suggested fix, edge cases.
+
+  </details>
+
+Use 🔴 for important findings (the ones strict-mode gates on),
+🟡 for nits, 🟣 for pre-existing issues. The severity emoji
+makes the finding's tier scannable without parsing prose.
+
 Per-skill scan block (required, immediately under the status line):
 After the **This round:** counters, emit a "### Per-skill scan"
 section with ONE line per loaded skill — even silent ones. This

--- a/lib/skills.js
+++ b/lib/skills.js
@@ -537,6 +537,29 @@ export function selectReviewBody(comments, botLogin) {
 // passing — which is the right posture: if the bot didn't post a review
 // with the strict-mode header, there's nothing for the gate to fail on.
 // "Loud failure for missing manifest" is handled upstream in the composite.
+// Extract the v0.6.5+ stats header line "Found: N 🔴 / N 🟡 / N 🟣"
+// from a review comment body. Returns {important, nit, preExisting} when
+// found, null otherwise. The header lets agents reading the comment on a
+// re-review triage at a glance — on the common zero-findings case, the
+// header IS the entire substantive payload, so an ingest can short-circuit
+// without parsing the body.
+//
+// The match is intentionally permissive on whitespace around the slashes
+// and tolerates 1+ digits for each count. Severity emoji are matched
+// literally — a future bot revision that changes the emoji would break
+// this parser loudly, which is the intended behavior (catches drift).
+export function extractStatsHeader(comment) {
+  if (typeof comment !== 'string' || !comment) return null;
+  const re = /Found:\s*(\d+)\s*🔴\s*\/\s*(\d+)\s*🟡\s*\/\s*(\d+)\s*🟣/u;
+  const m = comment.match(re);
+  if (!m) return null;
+  return {
+    important: parseInt(m[1], 10),
+    nit: parseInt(m[2], 10),
+    preExisting: parseInt(m[3], 10),
+  };
+}
+
 export function isCriticalReviewHeader(headerLine) {
   if (typeof headerLine !== 'string') return false;
   return /Clud Bug review — critical findings/.test(headerLine);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -79,6 +79,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.4
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -79,6 +79,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.4
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -130,6 +130,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.4
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/prompts.test.js
+++ b/test/prompts.test.js
@@ -115,6 +115,28 @@ test('rendered workflow.yml.tmpl sets the three budget env vars', async () => {
   assert.match(out, /Bash\(head:\*\)/);
 });
 
+// --- 0.A.4 (v0.6.5): stats header + severity-prefix comment format ---
+// Write-time compression: future re-reviews ingest prior clud-bug comments;
+// compact format = cheaper ingest. The prompt instructs Claude to lead with
+// "Found: N 🔴 / N 🟡 / N 🟣" and to use severity-emoji-prefix + collapsible
+// <details> reasoning for each finding.
+
+test('reviewPrompt instructs Claude to emit "Found: N 🔴 / N 🟡 / N 🟣" stats header', () => {
+  const out = reviewPrompt({ projectDescription: 'p' });
+  assert.match(out, /Found: N 🔴 \/ N 🟡 \/ N 🟣/u);
+  // The three severity tiers must be named: important, nit, pre-existing.
+  assert.match(out, /🔴 important/u);
+  assert.match(out, /🟡 nit/u);
+  assert.match(out, /🟣 pre-existing/u);
+});
+
+test('reviewPrompt instructs Claude to use severity-prefix + <details> per finding', () => {
+  const out = reviewPrompt({ projectDescription: 'p' });
+  // Per-finding format prompt language.
+  assert.match(out, /🔴 \[skill-name\]: One-line claim/u);
+  assert.match(out, /<details><summary>Reasoning<\/summary>/);
+});
+
 test('rendered workflow-ts and workflow-py templates also set budget env vars', async () => {
   for (const tmpl of ['workflow-ts.yml.tmpl', 'workflow-py.yml.tmpl']) {
     const out = await renderFile(join(TEMPLATES, tmpl), {

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -11,6 +11,7 @@ import {
   extractPerSkillLine, classifyPerSkillOutcome,
   selectReviewHeader, extractFirstReviewHeaderLine, isCriticalReviewHeader,
   selectReviewBody,
+  extractStatsHeader,
   _internal,
 } from '../lib/skills.js';
 
@@ -977,4 +978,38 @@ test('isCriticalReviewHeader: end-to-end with selectReviewHeader matches the v0.
   assert.equal(isCriticalReviewHeader(selectReviewHeader(failingComments, 'claude[bot]')), true);
   assert.equal(isCriticalReviewHeader(selectReviewHeader(passingComments, 'claude[bot]')), false);
   assert.equal(isCriticalReviewHeader(selectReviewHeader(noReviewYet, 'claude[bot]')), false);
+});
+
+// --- 0.A.4 (v0.6.5): extractStatsHeader for the "Found: N🔴 / N🟡 / N🟣" line ---
+// The stats header lets agents ingesting a prior clud-bug comment on
+// re-review skip the rest of the body on the zero-findings case.
+// extractStatsHeader parses the structured counts; the parser is
+// permissive on whitespace and strict on the severity emoji (drift
+// catches loudly).
+
+test('extractStatsHeader: parses the canonical "Found: N🔴 / N🟡 / N🟣" line', () => {
+  const comment = '## 🐛 Clud Bug review\n\n**This round:** 0 critical · 0 minor · 0 resolved from prior · 0 still open\n\nFound: 2 🔴 / 5 🟡 / 1 🟣\n\n### Per-skill scan\n';
+  assert.deepEqual(extractStatsHeader(comment), { important: 2, nit: 5, preExisting: 1 });
+});
+
+test('extractStatsHeader: returns null when no header present', () => {
+  const comment = '## 🐛 Clud Bug review\n\nThis round: 0 critical · 0 minor\n';
+  assert.equal(extractStatsHeader(comment), null);
+});
+
+test('extractStatsHeader: handles extra whitespace around slashes + counts', () => {
+  const comment = 'Found:  0 🔴  /  0 🟡  /  0 🟣 ';
+  assert.deepEqual(extractStatsHeader(comment), { important: 0, nit: 0, preExisting: 0 });
+});
+
+test('extractStatsHeader: multi-digit counts parse correctly', () => {
+  const comment = 'Found: 12 🔴 / 100 🟡 / 3 🟣';
+  assert.deepEqual(extractStatsHeader(comment), { important: 12, nit: 100, preExisting: 3 });
+});
+
+test('extractStatsHeader: handles empty / non-string inputs without throwing', () => {
+  assert.equal(extractStatsHeader(''), null);
+  assert.equal(extractStatsHeader(null), null);
+  assert.equal(extractStatsHeader(undefined), null);
+  assert.equal(extractStatsHeader(42), null);
 });


### PR DESCRIPTION
## Summary

Phase 0.A.4 of the token-cost compression roadmap. Compresses the comments clud-bug *writes* — so every subsequent re-review of the same PR (which ingests those comments via the FIX-PUSH FLOW) costs less.

## Three changes to the comment format

### 1. Stats header

Every review now leads with one machine-parseable line immediately under \`**This round:**\`:

\`\`\`
Found: N 🔴 / N 🟡 / N 🟣
\`\`\`

Three severity tiers: 🔴 important (bugs/security/perf), 🟡 nit (suggestions), 🟣 pre-existing (issues that pre-date this PR). On the zero-findings case the header IS the entire substantive payload — agents re-ingesting the comment can short-circuit without parsing the body.

### 2. Per-finding severity prefix + collapsible reasoning

Each finding becomes:

\`\`\`markdown
🔴 [skill-name]: One-line claim (file:line).
<details><summary>Reasoning</summary>

Longer explanation: evidence anchors, suggested fix, edge cases.

</details>
\`\`\`

Humans see full detail via GitHub's native \`<details>\` render. Agent re-reads skip the collapsed section token-cheaply.

### 3. New parser export: \`extractStatsHeader(comment)\`

Returns \`{important, nit, preExisting}\` or \`null\`. Strict on severity emoji (drift catches loudly), permissive on whitespace.

## What's in the diff

- **\`lib/prompts.js\`** — new "Stats header" and "Per-finding format" subsections in the review-discipline prompt.
- **\`lib/skills.js\`** — \`extractStatsHeader\` export with parser.
- **Tests** (\`test/prompts.test.js\` +2, \`test/skills.test.js\` +5): prompt-rule presence + parser canonical / whitespace-variant / multi-digit / missing / non-string inputs.
- **Version bump** 0.6.4 → 0.6.5 + composite-pin lock-step.

## Quality preservation

- The severity-tier system MATCHES Anthropic's own Code Review (🔴/🟡/🟣). Cross-product consistency.
- Human readers see EVERYTHING — \`<details>\` blocks render natively on GitHub.
- The strict-mode gate continues to read the \`## 🐛 Clud Bug review — critical findings\` header (unchanged).
- The per-skill scan block format is unchanged — \`extractPerSkillLine\` + \`classifyPerSkillOutcome\` work identically.

## Compounds effect

Combined with v0.6.3 (caching stable prefix at 10%) and v0.6.4 (capping variable suffix), v0.6.5 compresses the third surface: the comments clud-bug writes that future re-reviews must ingest. Every byte trimmed here is paid back on every future re-review for the lifetime of the PR.

## Test plan

- [x] \`npm test\` — 191/191 pass (+7 new)
- [x] Decision logged via \`logmind log\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)