### PR TITLE
feat(v0.6.6): trim AGENTS.md clud-bug block from ~44 lines to ~10 (move detail to bundled skill)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.5
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.6
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.6] — 2026-05-27
+
+### Changed — `AGENTS.md` clud-bug block trimmed from ~44 lines to ~10
+
+The full collaboration rules (fix-push flow, skill structure, comment
+format, workflow-edit constraint, where-skills-live) moved out of the
+injected `AGENTS.md` block and into the bundled `clud-bug-collaboration`
+skill in `agent-skills`. That skill is auto-installed by `clud-bug
+init`/`update` and auto-loaded by `clud-bug-review`, so the information
+is fully preserved — it just lives in the right container now.
+
+What stays in the AGENTS.md block (repo-specific, can't move):
+- Pointer to the bundled skill.
+- Strict-mode toggle line (varies per consuming repo).
+- `_Installed at clud-bug vX.Y.Z._` footer.
+
+What moved to the skill (canonical, same content across all consuming repos):
+- Fix-push flow rules.
+- Strict-mode mechanics (base-ref read, can't disable on own PR).
+- Skill discovery + structure.
+- Workflow-edit constraint + `clud-bug edit-workflow` mechanism.
+
+### Why this compounds
+
+Every agent session in every consuming repo reads `AGENTS.md` at boot.
+Trimming the block from ~2,100 chars to ~720 chars means each session
+reads ~1,400 fewer chars from this file alone. Across 7+ consuming
+repos × many sessions/day, this is a meaningful recurring saving.
+
+### Block-version bump
+
+`<!-- clud-bug-block-version: -->` advances from `v1` to `v2` so existing
+consumers can detect the schema change in their checked-in `AGENTS.md`.
+The next `clud-bug update` rewrites the block to v2 idempotently.
+
+### Tests
+
+- `test/agents-md.test.js` (+2): assert block ≤800 chars, contains the
+  `clud-bug-collaboration` skill link, advances to `clud-bug-block-version:
+  v2`, and the dropped sections (fix-push flow, workflow-edit, skill
+  discovery) are not present in the new block.
+
 ## [0.6.5] — 2026-05-27
 
 ### Changed — write-time comment compression: stats header + severity prefix + collapsible reasoning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,22 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 ### Changed — `AGENTS.md` clud-bug block trimmed from ~44 lines to ~10
 
 The full collaboration rules (fix-push flow, skill structure, comment
-format, workflow-edit constraint, where-skills-live) moved out of the
-injected `AGENTS.md` block and into the bundled `clud-bug-collaboration`
-skill in `agent-skills`. That skill is auto-installed by `clud-bug
-init`/`update` and auto-loaded by `clud-bug-review`, so the information
-is fully preserved — it just lives in the right container now.
+format, workflow-edit constraint, where-skills-live) already live in the
+bundled `clud-bug-collaboration` skill — both the canonical version in
+`thrillmade/agent-skills` AND the local copy at
+`templates/skills/baseline/clud-bug-collaboration.md`. This PR
+**removes the duplicate copy** from the injected `AGENTS.md` block (and
+points at the skill instead), since the skill is already auto-installed
+by `clud-bug init`/`update` and auto-loaded by `clud-bug-review`. **No
+content is lost — duplication is.**
 
-What stays in the AGENTS.md block (repo-specific, can't move):
+What stays in the AGENTS.md block (repo-specific, can't dedupe):
 - Pointer to the bundled skill.
 - Strict-mode toggle line (varies per consuming repo).
 - `_Installed at clud-bug vX.Y.Z._` footer.
 
-What moved to the skill (canonical, same content across all consuming repos):
+What was duplicated in AGENTS.md and removed from the block (still lives
+in the skill, unchanged):
 - Fix-push flow rules.
 - Strict-mode mechanics (base-ref read, can't disable on own PR).
 - Skill discovery + structure.

--- a/docs/decisions-branches/feat__0.A.5-agents-md-trim.md
+++ b/docs/decisions-branches/feat__0.A.5-agents-md-trim.md
@@ -1,0 +1,12 @@
+## 2026-05-27 22:36 - Trim clud-bug's injected AGENTS.md block; move detail to bundled clud-bug-collaboration skill
+
+**Reasoning:** Phase A.5 — every agent session in every consuming repo reads AGENTS.md at boot. Trim block from ~44 lines (~2.1K chars) to ~10 lines (~720 chars). Full rules move to the bundled skill which auto-loads on review. Compounds across all sessions in all consuming repos.
+
+**Alternatives considered:** Keep block content as-is; rely on caching to make it cheap, Delete the block entirely
+
+**Implications:**
+- BLOCK_VERSION bumped v1 → v2 so consumers can detect schema change in their checked-in AGENTS.md
+- Strict-mode toggle stays inline (repo-specific, varies per consumer)
+- Next clud-bug update on consumers rewrites block to v2 idempotently
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -54,6 +54,7 @@ clud-bug
 │   │   ├── feat__0.A.1-extract-prompts.md
 │   │   ├── feat__0.A.2-prompt-caching.md
 │   │   ├── feat__0.A.3-prompt-budgets.md
+│   │   ├── feat__0.A.4-comment-compression.md
 │   │   ├── feat__agent-collab.md
 │   │   ├── feat__agent-skills-sha-bump.md
 │   │   ├── feat__cca-version-pinning.md

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — Trim clud-bug's injected AGENTS.md block; move detail to bundled clud-bug-collaboration skill *(feat/0.A.5-agents-md-trim)* — [decisions-branches/feat__0.A.5-agents-md-trim.md](decisions-branches/feat__0.A.5-agents-md-trim.md)
 - **2026-05-27** — Add stats header + severity-prefix + collapsible-reasoning comment format *(feat/0.A.4-comment-compression)* — [decisions-branches/feat__0.A.4-comment-compression.md](decisions-branches/feat__0.A.4-comment-compression.md)
 - **2026-05-27** — Add per-section byte budgets to clud-bug's review prompt + workflow env vars *(feat/0.A.3-prompt-budgets)* — [decisions-branches/feat__0.A.3-prompt-budgets.md](decisions-branches/feat__0.A.3-prompt-budgets.md)
 - **2026-05-27** — Route clud-bug's review prompt into Claude Code CLI's auto-cached system layer via APPEND_SYSTEM_PROMPT env var *(feat/0.A.2-prompt-caching)* — [decisions-branches/feat__0.A.2-prompt-caching.md](decisions-branches/feat__0.A.2-prompt-caching.md)

--- a/lib/agents-md.js
+++ b/lib/agents-md.js
@@ -8,7 +8,12 @@ import { join } from 'node:path';
 
 const START_MARKER = '<!-- clud-bug-start -->';
 const END_MARKER   = '<!-- clud-bug-end -->';
-const BLOCK_VERSION = 'v1';
+// v2 (clud-bug v0.6.6+): trimmed from ~44 lines to ~10. Full collaboration
+// rules moved to the bundled `clud-bug-collaboration` skill (always installed
+// alongside clud-bug), which clud-bug-review loads at review time. AGENTS.md
+// becomes a pointer + the strict-mode toggle (repo-specific, varies per
+// consumer). Compounds across every agent session in every consuming repo.
+const BLOCK_VERSION = 'v2';
 
 // Files we'll touch when present, plus files we'll create if missing.
 // AGENTS.md is the cross-tool canonical (logmind made it canonical too).
@@ -43,49 +48,20 @@ const TOUCH_IF_PRESENT = [
 export function renderBlock({ version, strictMode } = {}) {
   const versionLine = version ? `_Installed at clud-bug v${version}._` : '';
   const strictNote = strictMode === true
-    ? 'Strict mode is **on** in this repo (workflow check fails on critical findings).'
-    : 'Strict mode is **off** in this repo (advisory only).';
+    ? '**on** in this repo (workflow check fails on critical findings)'
+    : '**off** in this repo (advisory only)';
   return `${START_MARKER}
 <!-- clud-bug-block-version: ${BLOCK_VERSION} -->
 ## clud-bug — Claude PR review
 
-This repository uses [clud-bug](https://cludbug.dev) to review pull requests
-automatically. Three things matter when other agents (or future-you) work
-in this repo:
+This repo uses [clud-bug](https://cludbug.dev) for automatic PR reviews.
+Full collaboration rules — fix-push flow, skill structure, comment format,
+strict-mode mechanics, workflow-edit constraint — live in the bundled
+[\`clud-bug-collaboration\` skill](.claude/skills/clud-bug-collaboration/SKILL.md).
+Read that skill before pushing fixes addressing prior review threads.
 
-### When you push fixes addressing prior Clud Bug review threads
-
-The bot resolves its own prior review threads on the next pass when it can
-verify the fix in the diff. You don't need to manually resolve threads it
-opened — push the fix, wait ~2 minutes, and check the PR. If a thread it
-left isn't auto-resolved after a fix, the bot judged the issue still open;
-read its latest review comment for what it's still flagging.
-
-### Strict mode
-
-${strictNote} Toggle by editing \`.claude/skills/.clud-bug.json\`:
-
-\`\`\`json
-{ "strictMode": true | false, ... }
-\`\`\`
-
-The setting is read from the **base ref** of any open PR, so PRs cannot
-disable strict mode on themselves. Changes take effect on PRs opened after
-they merge to the base branch.
-
-### Where the skills live
-
-Project-aware review rules live in \`.claude/skills/<name>/SKILL.md\`. A
-small baseline kit ships with every install — see
-\`.claude/skills/.clud-bug.json\` for the current set. Add more via
-\`clud-bug add <source/name>\` (from skills.sh) or by dropping your own
-\`.md\` files there. They auto-load into the reviewer.
-
-### Editing the workflow
-
-Anthropic's \`claude-code-action\` refuses to run on PRs that modify its own
-workflow file. Use \`clud-bug edit-workflow\` to bundle workflow tweaks into
-their own isolated PR — see [README](https://github.com/thrillmade/clud-bug#when-you-edit-the-workflow).
+Strict mode is ${strictNote}. Toggle via \`.claude/skills/.clud-bug.json\`
+(read from PR **base ref**, so PRs can't disable strict-mode on themselves).
 
 ${versionLine}
 ${END_MARKER}`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -79,6 +79,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.5
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -79,6 +79,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.5
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -130,6 +130,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.5
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/agents-md.test.js
+++ b/test/agents-md.test.js
@@ -30,6 +30,38 @@ test('renderBlock: strictMode false renders advisory text', () => {
   assert.match(block, /Strict mode is \*\*off\*\*/);
 });
 
+// --- 0.A.5 (v0.6.6): block trim — full rules move to clud-bug-collaboration skill ---
+
+test('renderBlock v2: trimmed to a pointer + strict-mode toggle (≤600 chars)', () => {
+  // The full collaboration rules (fix-push, comment format, workflow-edit
+  // constraint, skill structure) moved to the bundled clud-bug-collaboration
+  // skill in agent-skills. AGENTS.md becomes a minimal pointer so every
+  // agent session in every consuming repo reads fewer bytes at session boot.
+  const block = renderBlock({ version: '0.6.6', strictMode: true });
+  // 800 char cap — generous ceiling vs the v1 ~2100-char block. v2 should
+  // come in well under (~720) but the precise number depends on the
+  // strict-mode text; future small edits shouldn't ratchet the threshold.
+  assert.ok(block.length <= 800, `block too long: ${block.length} chars`);
+  // Must point at the bundled skill explicitly so agents know where the
+  // detail moved.
+  assert.match(block, /clud-bug-collaboration/);
+  assert.match(block, /\.claude\/skills\/clud-bug-collaboration\/SKILL\.md/);
+  // Block-version annotation MUST advance with content trim so consumers
+  // can detect the schema change in their checked-in AGENTS.md.
+  assert.match(block, /clud-bug-block-version: v2/);
+  // Strict-mode toggle stays in the block (it's repo-specific and varies
+  // per consumer — can't move it to a canonical skill).
+  assert.match(block, /Strict mode is \*\*on\*\*/);
+});
+
+test('renderBlock v2: dropped sections do NOT appear anywhere in the block', () => {
+  const block = renderBlock({ version: '0.6.6', strictMode: true });
+  // These sections moved to the skill — should be GONE from AGENTS.md block.
+  assert.doesNotMatch(block, /When you push fixes addressing prior/);
+  assert.doesNotMatch(block, /Editing the workflow/);
+  assert.doesNotMatch(block, /Where the skills live/);
+});
+
 test('upsertBlock: appends when no prior block', () => {
   const before = '# AGENTS.md\n\nSome content.\n';
   const block = renderBlock({ strictMode: true });


### PR DESCRIPTION
## Summary

Phase 0.A.5 of the token-cost compression roadmap.

Every agent session in every consuming repo reads \`AGENTS.md\` at boot. The clud-bug-injected block was ~44 lines (~2,100 chars) — heavy for a single boot, and the same content appears in every consuming repo. v0.6.6 trims it to ~10 lines (~720 chars) by moving the full collaboration rules to the bundled \`clud-bug-collaboration\` skill that already ships with every install.

## What stays in the AGENTS.md block (repo-specific)

- Pointer to the bundled \`clud-bug-collaboration\` skill.
- Strict-mode toggle line (varies per consumer; this matters for new agent sessions).
- \`_Installed at clud-bug vX.Y.Z._\` footer.

## What moved to the skill (canonical, identical across consuming repos)

- Fix-push flow rules.
- Strict-mode mechanics (base-ref read, can't disable on own PR).
- Skill discovery + structure.
- Workflow-edit constraint + \`clud-bug edit-workflow\` mechanism.

The skill is auto-installed by \`clud-bug init\`/\`update\` and auto-loaded by \`clud-bug-review\`, so the information is fully preserved — just in the right container per the "stable context → skills, not AGENTS.md" principle from the research spike.

## Block-version bump v1 → v2

\`<!-- clud-bug-block-version: v2 -->\` advances so existing consumers can detect the schema change in their checked-in \`AGENTS.md\`. The next \`clud-bug update\` rewrites the block to v2 idempotently.

## Why this compounds

Trimming ~1,400 chars from every AGENTS.md across 7+ consuming repos × many sessions/day = meaningful recurring saving. Compounds with prior phase A wins:
- v0.6.3 caches the stable system-prompt prefix at 10%.
- v0.6.4 caps the variable per-PR suffix.
- v0.6.5 compresses what clud-bug *writes* (re-review ingest).
- **v0.6.6 compresses what every agent reads at boot.**

## Tests

- \`test/agents-md.test.js\` (+2 new): assert block ≤800 chars, contains the \`clud-bug-collaboration\` skill link, advances to \`v2\`, and the dropped sections are not present.
- 193/193 pass total.

## Test plan

- [x] \`npm test\` — 193/193 pass (+2 new)
- [x] Decision logged via \`logmind log\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)