### PR TITLE
feat(v0.6.10): incremental-diff review on fix-push (Phase 0.A.10 — HIGH-VALUE)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.8
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.10
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,65 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.10] — 2026-05-28
+
+### Added — incremental-diff review on fix-push (Phase 0.A.10 — HIGH-VALUE)
+
+> v0.6.9 intentionally skipped — reserved for the 0.A.8 model-pin
+> spike. v0.6.10 ships the HIGHEST-VALUE Phase A follow-up per plan.
+
+clud-bug now fetches only the **delta since its prior review** on
+fix-pushes, instead of re-ingesting the full PR diff every time. State
+lives in the prior summary comment as an HTML marker:
+
+```html
+<!-- last-reviewed-sha: <sha> -->
+```
+
+### How it works
+
+On every review pass, the prompt instructs Claude to:
+
+1. **Detect prior state** — grep prior `claude[bot]` comment bodies
+   for `last-reviewed-sha: <sha>`.
+2. **Verify ancestry** — `git merge-base --is-ancestor <prior_sha> $HEAD_SHA`.
+   Force-push or rebase invalidates ancestry → fall back to full diff.
+3. **Branch the fetch**:
+   - Marker present AND ancestor intact → `git diff <prior_sha>..$HEAD_SHA | head -c "$MAX_DIFF_BYTES"`.
+   - Missing OR not an ancestor → `gh pr diff "$PR_NUMBER" | head -c "$MAX_DIFF_BYTES"` (current behavior).
+4. **Emit the marker** at the end of every summary comment so the next
+   pass can do the same handshake.
+
+### Estimated savings
+
+A 4-push PR (initial 10 KB diff + 3 fix-pushes of 1 KB each) currently
+ingests ~40 KB across 4 reviews. With delta-only: ~13 KB. **~67%
+reduction on the diff section across the PR's lifetime.** Larger churny
+PRs save proportionally more.
+
+### Fallback discipline
+
+- **First review** has no marker → full diff (unchanged behavior).
+- **Force-push / rebase** breaks ancestry → full diff (correct).
+- **Span check**: if a delta-review surfaces a finding that might
+  affect unchanged code outside the delta, Claude is instructed to do
+  a one-time full `gh pr diff` to verify before flagging.
+
+### Workflow template changes
+
+- Added `HEAD_SHA: ${{ github.event.pull_request.head.sha }}` to env
+  block in all 3 templates.
+- Added `Bash(git diff:*)` and `Bash(git merge-base:*)` to allowedTools
+  in all 3 templates.
+- Composite-pin bumped `v0.6.8 → v0.6.10` (skipping v0.6.9).
+
+### Tests
+
+- `test/prompts.test.js`: prompt contains incremental-diff detection
+  instructions; prompt instructs Claude to emit the `last-reviewed-sha`
+  marker; all 3 rendered workflow templates declare `HEAD_SHA` env var,
+  the new git allowedTools, and pin the composite at `v0.6.10`.
+
 ## [0.6.8] — 2026-05-28
 
 ### Added — `--max-turns 15` + `MAX_THINKING_TOKENS=8000` in workflow templates (Phase 0.A.7)

--- a/docs/decisions-branches/feat__0.A.10-incremental-diff-review.md
+++ b/docs/decisions-branches/feat__0.A.10-incremental-diff-review.md
@@ -1,0 +1,8 @@
+## 2026-05-28 09:32 - v0.6.10: incremental-diff review on fix-push (Phase 0.A.10 — HIGH-VALUE)
+
+**Reasoning:** Highest-value Phase A follow-up per plan. On fix-push re-review, clud-bug fetches only the delta since its prior pass instead of the full PR diff. State lives in prior summary comment as <!-- last-reviewed-sha: <sha> --> HTML marker. Prompt now teaches Claude: (1) grep prior claude[bot] comments for the marker; (2) verify ancestry via git merge-base --is-ancestor (catches force-push/rebase); (3) branch — marker+ancestor → git diff <sha>..HEAD | head -c MAX_DIFF_BYTES; otherwise → gh pr diff full. Marker emission instruction added — every summary comment ends with <!-- last-reviewed-sha:  -->. Workflow templates: HEAD_SHA env var, Bash(git diff:*) + Bash(git merge-base:*) added to allowedTools. v0.6.9 intentionally skipped — reserved for 0.A.8 model-pin spike. Composite pin bumped v0.6.8 → v0.6.10. Existing strict-mode-gate composite-pin test refactored to read package.json (no drift past version bumps). +4 new tests = 207 pass.
+
+**Implications:**
+- Estimated savings: 4-push PR (10KB initial + 3×1KB fix-pushes) drops from ~40KB across 4 reviews to ~13KB (~67% diff-section reduction). Larger churny PRs save proportionally more. Edge case: span checks (delta finding might affect unchanged code) — prompt instructs Claude to do a one-time full gh pr diff to verify before flagging.
+
+---

--- a/docs/decisions-branches/feat__0.A.10-incremental-diff-review.md
+++ b/docs/decisions-branches/feat__0.A.10-incremental-diff-review.md
@@ -6,3 +6,11 @@
 - Estimated savings: 4-push PR (10KB initial + 3×1KB fix-pushes) drops from ~40KB across 4 reviews to ~13KB (~67% diff-section reduction). Larger churny PRs save proportionally more. Edge case: span checks (delta finding might affect unchanged code) — prompt instructs Claude to do a one-time full gh pr diff to verify before flagging.
 
 ---
+## 2026-05-28 09:54 - PR #100 fix: anchor prior-summary detection to ## 🐛 Clud Bug review header (not LAST claude[bot] body)
+
+**Reasoning:** clud-bug-review caught a real bug on PR #100: claude-code-action posts a [claude]: Claude Code is working… progress comment BEFORE the SDK runs. Telling Claude to find the marker in the LAST claude[bot] body would always hit that progress comment (no marker present), fall through to step 3's 'marker missing' branch, and trigger a full gh pr diff on every fix-push. The headline ~67% savings would never fire. Fix: prompt now instructs Claude to walk claude[bot] comments newest-first and select the FIRST whose body starts with ## 🐛 Clud Bug review (same anchor strict-mode gate uses via selectReviewHeader). Same hazard, same solution as PR #61's BB.3 fix. +2 tests: regression guard asserts the header-anchored selection + explicit progress-comment warning; ordering test asserts sort=created&direction=desc query params + newest-first instruction. 209 tests pass.
+
+**Implications:**
+- Tests are still substring-based (prompt is a string, not executable). The clud-bug 🟡 finding about a fixture-based test is valid future work — a Node test that constructs a 2-comment array (progress + summary) and asserts Claude's instructions unambiguously route to the summary would catch behavioral bugs. Out of scope for this fix; tracking as plan note.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -57,6 +57,7 @@ clud-bug
 │   │   ├── feat__0.A.4-comment-compression.md
 │   │   ├── feat__0.A.5-agents-md-trim.md
 │   │   ├── feat__0.A.6-ok-cli-output.md
+│   │   ├── feat__0.A.7-max-turns-thinking-tokens.md
 │   │   ├── feat__agent-collab.md
 │   │   ├── feat__agent-skills-sha-bump.md
 │   │   ├── feat__cca-version-pinning.md

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-28** — PR #100 fix: anchor prior-summary detection to ## 🐛 Clud Bug review header (not LAST claude[bot] body) *(feat/0.A.10-incremental-diff-review)* — [decisions-branches/feat__0.A.10-incremental-diff-review.md](decisions-branches/feat__0.A.10-incremental-diff-review.md)
 - **2026-05-28** — v0.6.10: incremental-diff review on fix-push (Phase 0.A.10 — HIGH-VALUE) *(feat/0.A.10-incremental-diff-review)* — [decisions-branches/feat__0.A.10-incremental-diff-review.md](decisions-branches/feat__0.A.10-incremental-diff-review.md)
 - **2026-05-28** — v0.6.8: --max-turns 15 + MAX_THINKING_TOKENS=8000 in workflow templates (Phase 0.A.7) *(feat/0.A.7-max-turns-thinking-tokens)* — [decisions-branches/feat__0.A.7-max-turns-thinking-tokens.md](decisions-branches/feat__0.A.7-max-turns-thinking-tokens.md)
 - **2026-05-27** — Add --quiet / CLUD_BUG_QUIET=1 mode to clud-bug CLI with RTK-style single-line ok output *(feat/0.A.6-ok-cli-output)* — [decisions-branches/feat__0.A.6-ok-cli-output.md](decisions-branches/feat__0.A.6-ok-cli-output.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-28** — v0.6.10: incremental-diff review on fix-push (Phase 0.A.10 — HIGH-VALUE) *(feat/0.A.10-incremental-diff-review)* — [decisions-branches/feat__0.A.10-incremental-diff-review.md](decisions-branches/feat__0.A.10-incremental-diff-review.md)
 - **2026-05-28** — v0.6.8: --max-turns 15 + MAX_THINKING_TOKENS=8000 in workflow templates (Phase 0.A.7) *(feat/0.A.7-max-turns-thinking-tokens)* — [decisions-branches/feat__0.A.7-max-turns-thinking-tokens.md](decisions-branches/feat__0.A.7-max-turns-thinking-tokens.md)
 - **2026-05-27** — Add --quiet / CLUD_BUG_QUIET=1 mode to clud-bug CLI with RTK-style single-line ok output *(feat/0.A.6-ok-cli-output)* — [decisions-branches/feat__0.A.6-ok-cli-output.md](decisions-branches/feat__0.A.6-ok-cli-output.md)
 - **2026-05-27** — Trim clud-bug's injected AGENTS.md block; move detail to bundled clud-bug-collaboration skill *(feat/0.A.5-agents-md-trim)* — [decisions-branches/feat__0.A.5-agents-md-trim.md](decisions-branches/feat__0.A.5-agents-md-trim.md)

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -65,11 +65,36 @@ the stable system-prompt prefix (you're reading it now) at 10% of
 standard input cost, but variable per-PR content is NOT cached, so
 size discipline on those fetches pays back directly.
 
-  - PR diff: \`gh pr diff "$PR_NUMBER" | head -c "$MAX_DIFF_BYTES"\`
-    (default 80,000 bytes — covers ~95% of real PRs unbruised). If
-    the output looks truncated mid-line, note it in your review and
-    request the omitted hunks via \`gh pr diff "$PR_NUMBER" --name-only\`
-    + a targeted re-fetch of the specific files that need scrutiny.
+  - PR diff (incremental on fix-push — v0.6.10+):
+    On a re-review (not first pass), fetch only the delta between
+    your prior pass and HEAD instead of the full PR. The handshake
+    state lives in your prior summary comment as an HTML marker:
+    \`<!-- last-reviewed-sha: <sha> -->\`. Detection in three steps:
+
+      1. Pull prior claude[bot] comment bodies and grep for the marker:
+         \`gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$PR_NUMBER/comments?per_page=100"\`
+         then look for \`last-reviewed-sha: <sha>\` in the LAST
+         claude[bot] body.
+
+      2. If a SHA was found, verify it's still in HEAD's ancestry:
+         \`git merge-base --is-ancestor <prior_sha> $HEAD_SHA\`
+         (exit 0 = yes, ancestry intact; non-zero = rebased/force-pushed).
+
+      3. Branch:
+           - Marker present AND ancestor intact (well-behaved fix-push):
+             \`git diff <prior_sha>..$HEAD_SHA | head -c "$MAX_DIFF_BYTES"\`
+           - Marker missing OR not an ancestor (first review or rebase):
+             \`gh pr diff "$PR_NUMBER" | head -c "$MAX_DIFF_BYTES"\`
+
+    Default cap is 80,000 bytes — covers ~95% of real PRs unbruised.
+    If output looks truncated mid-line, request the omitted hunks via
+    \`gh pr diff "$PR_NUMBER" --name-only\` + a targeted re-fetch.
+
+    Edge case — span check: if a delta-review surfaces a finding that
+    might affect unchanged code outside the delta (a fix-push edits a
+    function whose callers were fine in the prior pass), do a one-time
+    \`gh pr diff "$PR_NUMBER"\` to confirm before flagging. The
+    incremental view is for fast re-confirmation, not for blind trust.
 
   - Skill files: \`head -c "$MAX_SKILL_BYTES" .claude/skills/<name>/SKILL.md\`
     per file (default 4,000 bytes). Baseline skills fit easily;
@@ -111,6 +136,20 @@ At the end of every review, append a single-line footer:
   Skills referenced: [skill-name-1, skill-name-2, ...]
 If you genuinely cited none, list "[none]" and explain why no
 installed skill applied to this diff.
+
+Incremental-diff handshake (v0.6.10+) — emit the SHA marker:
+At the very end of the summary comment (after the Skills-referenced
+footer, on its own line), append the HTML marker that the next
+review pass will read to decide between full-diff vs incremental:
+
+  <!-- last-reviewed-sha: $HEAD_SHA -->
+
+(\`$HEAD_SHA\` is provided via the workflow env block; literal value
+goes in the comment, not the variable name.) The marker is silent
+to human readers (HTML comment) but load-bearing for cost: every
+subsequent fix-push review re-fetches only the delta since this
+SHA instead of the full PR. If you omit the marker, the next
+review falls back to a full \`gh pr diff\` — correct but wasteful.
 
 Strict-mode header (opt-in): if .claude/skills/.clud-bug.json
 contains { "strictMode": true }, the comment header you post

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -68,13 +68,27 @@ size discipline on those fetches pays back directly.
   - PR diff (incremental on fix-push — v0.6.10+):
     On a re-review (not first pass), fetch only the delta between
     your prior pass and HEAD instead of the full PR. The handshake
-    state lives in your prior summary comment as an HTML marker:
-    \`<!-- last-reviewed-sha: <sha> -->\`. Detection in three steps:
+    state lives in your PRIOR SUMMARY COMMENT as an HTML marker:
+    \`<!-- last-reviewed-sha: <sha> -->\`.
 
-      1. Pull prior claude[bot] comment bodies and grep for the marker:
-         \`gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$PR_NUMBER/comments?per_page=100"\`
-         then look for \`last-reviewed-sha: <sha>\` in the LAST
-         claude[bot] body.
+    CRITICAL — identifying the PRIOR SUMMARY (not the progress comment):
+    \`anthropics/claude-code-action\` posts an in-progress
+    \`[claude]: Claude Code is working…\` comment BEFORE this prompt
+    runs. That comment IS authored by claude[bot] but is NOT your
+    prior summary — it has no marker. Walking "the LAST claude[bot]
+    comment" would always land on the progress comment and the
+    handshake would never fire. Instead, identify the prior summary
+    by its HEADER LINE: it begins with \`## 🐛 Clud Bug review\`
+    (same anchor the strict-mode gate uses for classification).
+
+    Detection in three steps:
+
+      1. Fetch claude[bot] comments newest-first:
+         \`gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$PR_NUMBER/comments?per_page=100&sort=created&direction=desc"\`
+         Walk them in order; find the FIRST whose body starts
+         (after any \`**Claude finished …**\` preamble the action
+         prepends) with \`## 🐛 Clud Bug review\`. THAT is your prior
+         summary. In its body, look for \`last-reviewed-sha: <sha>\`.
 
       2. If a SHA was found, verify it's still in HEAD's ancestry:
          \`git merge-base --is-ancestor <prior_sha> $HEAD_SHA\`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.8",
+  "version": "0.6.10",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -56,6 +56,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
+          # HEAD_SHA (v0.6.10+) — see workflow.yml.tmpl for design notes.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           # Per-section byte budgets — see workflow.yml.tmpl for design notes.
           MAX_DIFF_BYTES: '80000'
           MAX_COMMENT_BYTES: '20000'
@@ -72,7 +74,7 @@ jobs:
           show_full_output: true
           claude_args: |
             --max-turns 15
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
           prompt: |
             Review this pull request following the discipline in your
             system prompt — every rule about skill routing, comment
@@ -82,6 +84,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.8
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.10
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -56,6 +56,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
+          # HEAD_SHA (v0.6.10+) — see workflow.yml.tmpl for design notes.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           # Per-section byte budgets — see workflow.yml.tmpl for design notes.
           MAX_DIFF_BYTES: '80000'
           MAX_COMMENT_BYTES: '20000'
@@ -72,7 +74,7 @@ jobs:
           show_full_output: true
           claude_args: |
             --max-turns 15
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
           prompt: |
             Review this pull request following the discipline in your
             system prompt — every rule about skill routing, comment
@@ -82,6 +84,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.8
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.10
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -82,6 +82,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
+          # HEAD_SHA (v0.6.10+) — emitted as `<!-- last-reviewed-sha: ... -->`
+          # marker at the end of every summary comment. The next review pass
+          # reads the marker and switches `gh pr diff` (full) → `git diff
+          # <prior_sha>..HEAD` (delta) when the SHA is still in HEAD's
+          # ancestry. Fix-push reviews ingest only the new bytes.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           # Per-section byte budgets (v0.6.4). The system-prompt instructs
           # Claude to cap each per-PR input fetch with `head -c`. Caching
           # covers the stable system prefix; capping covers the variable
@@ -116,7 +122,7 @@ jobs:
           show_full_output: true
           claude_args: |
             --max-turns 15
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
           prompt: |
             Review this pull request following the discipline in your
             system prompt — every rule about skill routing, comment
@@ -138,6 +144,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.8
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.10
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/prompts.test.js
+++ b/test/prompts.test.js
@@ -183,7 +183,16 @@ test('all 3 rendered workflow templates pass --max-turns 15 via claude_args', as
   }
 });
 
-test('all 3 rendered workflow templates pin strict-mode-gate at v0.6.8', async () => {
+test('all 3 rendered workflow templates pin strict-mode-gate at the current package.json version', async () => {
+  // Reads package.json so the test never drifts past a version bump
+  // (release-discipline.test.js also asserts the same lock-step).
+  const pkg = JSON.parse(
+    await (await import('node:fs/promises')).readFile(
+      join(TEMPLATES, '..', 'package.json'),
+      'utf8',
+    ),
+  );
+  const expected = new RegExp(`strict-mode-gate@v${pkg.version.replace(/\./g, '\\.')}`);
   for (const tmpl of ['workflow.yml.tmpl', 'workflow-ts.yml.tmpl', 'workflow-py.yml.tmpl']) {
     const lang = tmpl.includes('-ts') ? 'ts' : tmpl.includes('-py') ? 'py' : 'generic';
     const out = await renderFile(join(TEMPLATES, tmpl), {
@@ -191,8 +200,87 @@ test('all 3 rendered workflow templates pin strict-mode-gate at v0.6.8', async (
     });
     assert.match(
       out,
-      /strict-mode-gate@v0\.6\.8/,
-      `${tmpl} composite-pin out of sync with package.json (v0.6.8)`,
+      expected,
+      `${tmpl} composite-pin out of sync with package.json (${pkg.version})`,
+    );
+  }
+});
+
+// --- 0.A.10 (v0.6.10): incremental-diff review on fix-push ---
+// Prompt teaches Claude to read the `<!-- last-reviewed-sha: <sha> -->`
+// marker in prior summary comments, verify ancestry via `git merge-base
+// --is-ancestor`, and branch between `git diff <sha>..HEAD` (delta) and
+// `gh pr diff` (full). The prompt also instructs Claude to emit the
+// marker on every new summary comment so the handshake compounds.
+
+test('reviewPrompt teaches Claude the incremental-diff handshake (read marker, check ancestor, branch)', () => {
+  const out = reviewPrompt({ projectDescription: 'p' });
+  // Marker shape Claude must parse (with the escaped HTML-comment syntax).
+  assert.match(
+    out,
+    /last-reviewed-sha: <sha>/,
+    'prompt must describe the `last-reviewed-sha: <sha>` marker shape',
+  );
+  // Ancestor check is the rebase/force-push fallback gate.
+  assert.match(
+    out,
+    /git merge-base --is-ancestor/,
+    'prompt must describe the `git merge-base --is-ancestor` ancestry check',
+  );
+  // Delta fetch when marker + ancestor both hold.
+  assert.match(
+    out,
+    /git diff <prior_sha>\.\.\$HEAD_SHA/,
+    'prompt must describe the `git diff <prior_sha>..$HEAD_SHA` delta fetch',
+  );
+  // Fallback to gh pr diff named explicitly.
+  assert.match(
+    out,
+    /gh pr diff "\$PR_NUMBER" \| head -c "\$MAX_DIFF_BYTES"/,
+    'prompt must keep the full-diff fallback for first-review / non-ancestor cases',
+  );
+});
+
+test('reviewPrompt instructs Claude to emit the SHA marker on every summary comment', () => {
+  const out = reviewPrompt({ projectDescription: 'p' });
+  // Marker template (literal $HEAD_SHA shown in instructions; Claude
+  // substitutes the actual value when posting).
+  assert.match(
+    out,
+    /<!-- last-reviewed-sha: \$HEAD_SHA -->/,
+    'prompt must instruct Claude to append the `<!-- last-reviewed-sha: $HEAD_SHA -->` marker',
+  );
+});
+
+test('all 3 rendered workflow templates expose HEAD_SHA env var (v0.6.10+)', async () => {
+  for (const tmpl of ['workflow.yml.tmpl', 'workflow-ts.yml.tmpl', 'workflow-py.yml.tmpl']) {
+    const lang = tmpl.includes('-ts') ? 'ts' : tmpl.includes('-py') ? 'py' : 'generic';
+    const out = await renderFile(join(TEMPLATES, tmpl), {
+      REVIEW_PROMPT: reviewPrompt({ projectDescription: 'p', language: lang }),
+    });
+    assert.match(
+      out,
+      /HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/,
+      `${tmpl} missing HEAD_SHA env var (v0.6.10)`,
+    );
+  }
+});
+
+test('all 3 rendered workflow templates allow git diff + git merge-base (v0.6.10+)', async () => {
+  for (const tmpl of ['workflow.yml.tmpl', 'workflow-ts.yml.tmpl', 'workflow-py.yml.tmpl']) {
+    const lang = tmpl.includes('-ts') ? 'ts' : tmpl.includes('-py') ? 'py' : 'generic';
+    const out = await renderFile(join(TEMPLATES, tmpl), {
+      REVIEW_PROMPT: reviewPrompt({ projectDescription: 'p', language: lang }),
+    });
+    assert.match(
+      out,
+      /Bash\(git diff:\*\)/,
+      `${tmpl} missing Bash(git diff:*) in allowedTools (v0.6.10)`,
+    );
+    assert.match(
+      out,
+      /Bash\(git merge-base:\*\)/,
+      `${tmpl} missing Bash(git merge-base:*) in allowedTools (v0.6.10)`,
     );
   }
 });

--- a/test/prompts.test.js
+++ b/test/prompts.test.js
@@ -241,6 +241,51 @@ test('reviewPrompt teaches Claude the incremental-diff handshake (read marker, c
   );
 });
 
+test('reviewPrompt teaches Claude to identify the PRIOR SUMMARY (not the in-progress comment)', () => {
+  // Regression for the v0.6.10 bug PR #100 caught at lib/prompts.js:74-77:
+  // anthropics/claude-code-action posts a `[claude]: Claude Code is
+  // working…` progress comment BEFORE the SDK runs. The "LAST claude[bot]
+  // body" wording landed on that comment, found no marker, and fell
+  // through to full-diff on every fix-push — handshake never fired.
+  // Fix: prompt must anchor selection to the `## 🐛 Clud Bug review`
+  // header (same anchor the strict-mode gate uses), NOT to "latest by
+  // claude[bot]".
+  const out = reviewPrompt({ projectDescription: 'p' });
+  // Header-anchored selection — the unambiguous source-of-truth identifier
+  // for a prior summary comment.
+  assert.match(
+    out,
+    /## 🐛 Clud Bug review/u,
+    'prompt must anchor prior-summary detection to the H2 header line, not "last claude[bot] comment"',
+  );
+  // Explicit warning about the progress comment so future edits to this
+  // section don't silently regress back to the buggy wording.
+  assert.match(
+    out,
+    /Claude Code is working/,
+    'prompt must explicitly warn Claude that the progress comment is NOT the prior summary',
+  );
+});
+
+test('reviewPrompt: detection walks claude[bot] comments newest-first (not arbitrary order)', () => {
+  // GitHub's REST /issues/:number/comments endpoint ignores
+  // direction=desc per `lib/skills.js:512-514` notes, so the prompt
+  // must pass the sort + direction params AND tell Claude to walk
+  // newest-first explicitly — otherwise selection is non-deterministic
+  // across multiple summary comments on the same PR.
+  const out = reviewPrompt({ projectDescription: 'p' });
+  assert.match(
+    out,
+    /sort=created&direction=desc/,
+    'prompt must request newest-first ordering via gh api query params',
+  );
+  assert.match(
+    out,
+    /newest-first/,
+    'prompt must explicitly tell Claude to walk newest-first when selecting the prior summary',
+  );
+});
+
 test('reviewPrompt instructs Claude to emit the SHA marker on every summary comment', () => {
   const out = reviewPrompt({ projectDescription: 'p' });
   // Marker template (literal $HEAD_SHA shown in instructions; Claude


### PR DESCRIPTION
## Summary

Highest-value Phase A follow-up per plan. clud-bug now fetches only the **delta since its prior review** on fix-pushes, instead of re-ingesting the full PR diff every time.

- **Handshake**: state lives in the prior summary comment as `<!-- last-reviewed-sha: <sha> -->`. Every review reads it; every review emits a fresh one.
- **Ancestor check**: `git merge-base --is-ancestor <sha> $HEAD_SHA` catches force-push/rebase → fall back to full diff.
- **Branch**: marker present AND ancestor intact → `git diff <sha>..$HEAD_SHA`. Otherwise → `gh pr diff` (unchanged behavior).
- **Workflow templates**: add `HEAD_SHA` env var + `Bash(git diff:*)`, `Bash(git merge-base:*)` to allowedTools.
- **Span check**: prompt instructs Claude to do a one-time full diff if a delta finding might affect unchanged code outside the delta.
- **Composite-pin** bumped `v0.6.8 → v0.6.10` (v0.6.9 reserved for 0.A.8 model-pin spike).

**Estimated savings**: 4-push PR with 10 KB initial diff + 3×1 KB fix-pushes drops from ~40 KB across 4 reviews to ~13 KB. **~67% diff-section reduction over a PR's lifetime.**

## Test plan

- [x] `npm test` — 207 pass (+4 new).
- [x] New tests: prompt contains the 3-step detection (marker / ancestor / branch), prompt instructs marker emission, all 3 workflow templates declare HEAD_SHA + new allowedTools.
- [x] Refactored existing strict-mode-gate composite-pin test to read package.json — no drift past version bumps.
- [x] `release-discipline.test.js` enforces lock-step across action.yml header + templates + package.json.
- [ ] Live test: this PR's own clud-bug-review will be the first to use the new prompt — observable on the next fix-push (delta vs full).

🤖 Generated with [Claude Code](https://claude.com/claude-code)