### PR TITLE
feat(v0.6.11): pin clud-bug-review to Claude Sonnet 4.6 — ~80% cost reduction vs Opus 4.7 (Phase 0.A.8)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.10
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.11
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.11] — 2026-05-28
+
+### Changed — pin clud-bug-review to Claude Sonnet 4.6 (Phase 0.A.8)
+
+> Reuses the slot that v0.6.9 was originally reserved for in the plan.
+
+clud-bug-review was running on **`claude-opus-4-7`** (Opus 4.7) —
+confirmed via log audit on logmind PR #72's run. Per Anthropic
+[cost docs](https://code.claude.com/docs/en/costs):
+
+> "Sonnet handles most coding tasks well and costs less than Opus.
+> Reserve Opus for complex architectural decisions."
+
+PR review fits Sonnet's profile, not Opus's. Pricing delta:
+
+| Model | Input | Cached read |
+|---|---|---|
+| Opus 4.7 | $15/MTok | $1.50/MTok |
+| **Sonnet 4.6** | **$3/MTok** | **$0.30/MTok** |
+
+**~80% cost reduction** on every review, on top of the caching wins
+from v0.6.3. A 50,000-token review (typical for a medium PR) drops
+from $0.75 → $0.15 — and that's the uncached-input case. Cached
+reviews drop ~$0.075 → ~$0.015.
+
+### How
+
+Added `--model claude-sonnet-4-6` to `claude_args` in all 3 workflow
+templates. Consuming repos pick up the pin on next composite-pin
+update (Dependabot or `clud-bug update`). Per-repo override remains
+available by editing the rendered workflow.
+
+### Net diff
+
+3 templates × 1 line each + composite-pin bump v0.6.10 → v0.6.11.
+
 ## [0.6.10] — 2026-05-28
 
 ### Added — incremental-diff review on fix-push (Phase 0.A.10 — HIGH-VALUE)

--- a/docs/decisions-branches/feat__0.A.8-pin-sonnet-model.md
+++ b/docs/decisions-branches/feat__0.A.8-pin-sonnet-model.md
@@ -1,0 +1,8 @@
+## 2026-05-28 10:04 - v0.6.11: pin clud-bug-review to Sonnet 4.6 — ~80% cost reduction vs Opus 4.7 (Phase 0.A.8)
+
+**Reasoning:** Log audit on logmind PR #72 confirmed clud-bug-review was running on claude-opus-4-7 (Opus 4.7), the most expensive Claude model. Per Anthropic cost docs: 'Sonnet handles most coding tasks well and costs less than Opus. Reserve Opus for complex architectural decisions.' PR review fits Sonnet's profile, not Opus's. Pin via --model claude-sonnet-4-6 in claude_args across all 3 workflow templates. Pricing delta: Opus 4.7 /MTok input → Sonnet 4.6 /MTok = ~80% reduction per review. Caching multipliers compound on top. v0.6.9 was reserved for this in the plan; shipping as v0.6.11 since v0.6.10 already shipped (0.A.10). Composite pin bumped v0.6.10 → v0.6.11. +1 test asserts all 3 templates pin Sonnet. 210 tests pass.
+
+**Implications:**
+- Per-repo override remains available by editing the rendered workflow if a consumer wants Opus for a specific reason. Future model defaults from claude-code-action no longer drift the org's bill.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -52,6 +52,7 @@ clud-bug
 │   │   ├── ci__unify-publish-and-promote.md
 │   │   ├── docs__skill-first-marketing-bb4.md
 │   │   ├── feat__0.A.1-extract-prompts.md
+│   │   ├── feat__0.A.10-incremental-diff-review.md
 │   │   ├── feat__0.A.2-prompt-caching.md
 │   │   ├── feat__0.A.3-prompt-budgets.md
 │   │   ├── feat__0.A.4-comment-compression.md

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-28** — v0.6.11: pin clud-bug-review to Sonnet 4.6 — ~80% cost reduction vs Opus 4.7 (Phase 0.A.8) *(feat/0.A.8-pin-sonnet-model)* — [decisions-branches/feat__0.A.8-pin-sonnet-model.md](decisions-branches/feat__0.A.8-pin-sonnet-model.md)
 - **2026-05-28** — PR #100 fix: anchor prior-summary detection to ## 🐛 Clud Bug review header (not LAST claude[bot] body) *(feat/0.A.10-incremental-diff-review)* — [decisions-branches/feat__0.A.10-incremental-diff-review.md](decisions-branches/feat__0.A.10-incremental-diff-review.md)
 - **2026-05-28** — v0.6.10: incremental-diff review on fix-push (Phase 0.A.10 — HIGH-VALUE) *(feat/0.A.10-incremental-diff-review)* — [decisions-branches/feat__0.A.10-incremental-diff-review.md](decisions-branches/feat__0.A.10-incremental-diff-review.md)
 - **2026-05-28** — v0.6.8: --max-turns 15 + MAX_THINKING_TOKENS=8000 in workflow templates (Phase 0.A.7) *(feat/0.A.7-max-turns-thinking-tokens)* — [decisions-branches/feat__0.A.7-max-turns-thinking-tokens.md](decisions-branches/feat__0.A.7-max-turns-thinking-tokens.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -73,6 +73,7 @@ jobs:
           track_progress: true
           show_full_output: true
           claude_args: |
+            --model claude-sonnet-4-6
             --max-turns 15
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
           prompt: |
@@ -84,6 +85,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.10
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.11
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -73,6 +73,7 @@ jobs:
           track_progress: true
           show_full_output: true
           claude_args: |
+            --model claude-sonnet-4-6
             --max-turns 15
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
           prompt: |
@@ -84,6 +85,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.10
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.11
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -121,6 +121,7 @@ jobs:
           # measure caching effectiveness post-rollout (per v0.6.3 plan).
           show_full_output: true
           claude_args: |
+            --model claude-sonnet-4-6
             --max-turns 15
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
           prompt: |
@@ -144,6 +145,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.10
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.11
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/prompts.test.js
+++ b/test/prompts.test.js
@@ -330,6 +330,26 @@ test('all 3 rendered workflow templates allow git diff + git merge-base (v0.6.10
   }
 });
 
+// --- 0.A.8 (v0.6.11): pin model to Sonnet 4.6 ---
+// Phase 0.A.8 spike confirmed claude-code-action's default lands on Opus 4.7
+// (~5x Sonnet's input cost). PR review fits Sonnet's profile per Anthropic
+// docs. Pin the model explicitly so we don't drift back to Opus on a future
+// claude-code-action default change.
+
+test('all 3 rendered workflow templates pin claude_args --model claude-sonnet-4-6 (v0.6.11+)', async () => {
+  for (const tmpl of ['workflow.yml.tmpl', 'workflow-ts.yml.tmpl', 'workflow-py.yml.tmpl']) {
+    const lang = tmpl.includes('-ts') ? 'ts' : tmpl.includes('-py') ? 'py' : 'generic';
+    const out = await renderFile(join(TEMPLATES, tmpl), {
+      REVIEW_PROMPT: reviewPrompt({ projectDescription: 'p', language: lang }),
+    });
+    assert.match(
+      out,
+      /--model claude-sonnet-4-6/,
+      `${tmpl} missing --model claude-sonnet-4-6 in claude_args (v0.6.11 — Phase 0.A.8 model pin)`,
+    );
+  }
+});
+
 test('templateLanguage maps template filename to reviewPrompt language', () => {
   assert.equal(templateLanguage('workflow-ts.yml.tmpl'), 'ts');
   assert.equal(templateLanguage('workflow-py.yml.tmpl'), 'py');


### PR DESCRIPTION
## Summary

**Log audit on logmind PR #72's run confirmed clud-bug-review was running on `claude-opus-4-7`** — the most expensive Claude model. Per Anthropic [cost docs](https://code.claude.com/docs/en/costs): *"Sonnet handles most coding tasks well and costs less than Opus. Reserve Opus for complex architectural decisions."*

PR review fits Sonnet's profile, not Opus's.

| Model | Input | Cached read |
|---|---|---|
| Opus 4.7 | $15/MTok | $1.50/MTok |
| **Sonnet 4.6** | **$3/MTok** | **$0.30/MTok** |

**~80% cost reduction** on every review. Compounds with the caching wins from v0.6.3.

## How

`--model claude-sonnet-4-6` added to `claude_args` across all 3 workflow templates. Per-repo override remains available by editing the rendered workflow. Composite-pin bumped `v0.6.10 → v0.6.11` (v0.6.9 was originally reserved for this task; ships as v0.6.11 because v0.6.10 already shipped).

## Test plan

- [x] `npm test` — 210 pass (+1 new asserting `--model claude-sonnet-4-6` in all 3 templates).
- [x] `release-discipline.test.js` enforces composite-pin / action.yml-header / package.json lock-step.
- [ ] Live test: this PR's own clud-bug-review will be the first to use Sonnet. Compare log model field vs prior Opus reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)