### PR TITLE
fix(v0.6.12): self-update.yml.tmpl YAML literal-block bug — unblocks workflow_dispatch propagation (Phase 0.A.11)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.11
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.12
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.12] — 2026-05-28
+
+### Fixed — `clud-bug-self-update.yml` YAML literal-block bug breaking `workflow_dispatch`
+
+`templates/self-update.yml.tmpl` had a blank line embedded inside a
+multi-line `--body "..."` argument to `gh pr create`, nested inside a
+`run: |` block. GitHub Actions' YAML parser ended the block scalar at
+the blank line and rejected the next non-blank line as an unexpected
+top-level value:
+
+```
+HTTP 422: failed to parse workflow: (Line: 90, Col: 1): Unexpected
+value 'Review the diff. To stay on this version permanently, ...'
+```
+
+Consequence: **`workflow_dispatch` failed on every consuming repo** —
+the scheduled weekly run still worked (no parse needed at trigger
+time), but on-demand triggers were blocked. Discovered while trying
+to manually propagate v0.6.11 (Sonnet pin) to consuming repos. Pin
+drift across the org: agent-skills @v0.5.16, reporulez @v0.5.15,
+rezgen @v0.5.16, logmind @v0.6.7 — all weeks behind.
+
+Fix: construct the body via `printf` outside the YAML literal block,
+then pass via shell variable. Removes the YAML-fragile blank line
+entirely.
+
+### Net diff
+
+- `templates/self-update.yml.tmpl` — 4 lines replaced with 7 (printf
+  build + 3-line comment explaining why).
+- Composite-pin bumped v0.6.11 → v0.6.12.
+
+### Note on propagation after this ships
+
+Consuming repos installed before v0.6.12 still carry the broken
+`clud-bug-self-update.yml`. Two ways to recover:
+1. **Locally**: `npx clud-bug@latest update` in the repo (this
+   re-renders the workflow from the fixed template).
+2. **Wait for scheduled run**: next Monday 12:00 UTC the cron
+   trigger fires and opens a self-update PR — which would install
+   the v0.6.12 template, fixing the bug going forward.
+
 ## [0.6.11] — 2026-05-28
 
 ### Changed — pin clud-bug-review to Claude Sonnet 4.6 (Phase 0.A.8)

--- a/docs/decisions-branches/feat__0.A.11-fix-self-update-yaml-literal.md
+++ b/docs/decisions-branches/feat__0.A.11-fix-self-update-yaml-literal.md
@@ -1,0 +1,8 @@
+## 2026-05-28 11:43 - v0.6.12: fix self-update.yml.tmpl YAML literal-block bug — unblocks workflow_dispatch propagation
+
+**Reasoning:** Phase 0.A.11. While trying to manually propagate v0.6.11 (Sonnet pin) to consuming repos via 'gh workflow run clud-bug-self-update.yml', every repo failed with HTTP 422: 'failed to parse workflow: (Line: 90, Col: 1): Unexpected value ...Review the diff...'. Root cause: v0.6.11 self-update.yml.tmpl had a literal blank line embedded inside a multi-line --body argument to gh pr create, inside a run: | block. GitHub Actions' YAML parser ended the block scalar at the blank line. Scheduled cron triggers still worked (no parse at trigger time), but workflow_dispatch was blocked. Pin drift across the org as a result: agent-skills @v0.5.16, reporulez @v0.5.15, rezgen @v0.5.16, logmind @v0.6.7 — weeks behind. Fix: build the PR body via printf outside the YAML block, then pass via shell variable. Removes the YAML-fragile blank line entirely. +1 test asserts the printf-based build is present AND the buggy literal blank-line pattern doesn't reappear. Composite pin bumped v0.6.11 → v0.6.12. 211 tests pass.
+
+**Implications:**
+- After v0.6.12 ships: (1) npx clud-bug@latest update in each consuming repo locally re-renders the fixed workflow. (2) Next Monday's scheduled cron will open a self-update PR carrying the fixed template forward. workflow_dispatch will work again only AFTER one of those two paths lands the fixed file.
+
+---

--- a/docs/decisions-branches/feat__0.A.11-fix-self-update-yaml-literal.md
+++ b/docs/decisions-branches/feat__0.A.11-fix-self-update-yaml-literal.md
@@ -6,3 +6,8 @@
 - After v0.6.12 ships: (1) npx clud-bug@latest update in each consuming repo locally re-renders the fixed workflow. (2) Next Monday's scheduled cron will open a self-update PR carrying the fixed template forward. workflow_dispatch will work again only AFTER one of those two paths lands the fixed file.
 
 ---
+## 2026-05-28 12:50 - PR #102: regen docs/file-structure.md to fix doc-index drift caught by clud-bug review
+
+**Reasoning:** 🟡 finding: docs/file-structure.md index didn't include feat__0.A.11-fix-self-update-yaml-literal.md entry. Cosmetic but the in-tree directory listing would be wrong after merge. Fix: ran 'logmind file-structure --write' to regenerate the index. No code change.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -53,6 +53,7 @@ clud-bug
 │   │   ├── docs__skill-first-marketing-bb4.md
 │   │   ├── feat__0.A.1-extract-prompts.md
 │   │   ├── feat__0.A.10-incremental-diff-review.md
+│   │   ├── feat__0.A.11-fix-self-update-yaml-literal.md
 │   │   ├── feat__0.A.2-prompt-caching.md
 │   │   ├── feat__0.A.3-prompt-budgets.md
 │   │   ├── feat__0.A.4-comment-compression.md

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -59,6 +59,7 @@ clud-bug
 │   │   ├── feat__0.A.5-agents-md-trim.md
 │   │   ├── feat__0.A.6-ok-cli-output.md
 │   │   ├── feat__0.A.7-max-turns-thinking-tokens.md
+│   │   ├── feat__0.A.8-pin-sonnet-model.md
 │   │   ├── feat__agent-collab.md
 │   │   ├── feat__agent-skills-sha-bump.md
 │   │   ├── feat__cca-version-pinning.md

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-28** — PR #102: regen docs/file-structure.md to fix doc-index drift caught by clud-bug review *(feat/0.A.11-fix-self-update-yaml-literal)* — [decisions-branches/feat__0.A.11-fix-self-update-yaml-literal.md](decisions-branches/feat__0.A.11-fix-self-update-yaml-literal.md)
 - **2026-05-28** — v0.6.12: fix self-update.yml.tmpl YAML literal-block bug — unblocks workflow_dispatch propagation *(feat/0.A.11-fix-self-update-yaml-literal)* — [decisions-branches/feat__0.A.11-fix-self-update-yaml-literal.md](decisions-branches/feat__0.A.11-fix-self-update-yaml-literal.md)
 - **2026-05-28** — v0.6.11: pin clud-bug-review to Sonnet 4.6 — ~80% cost reduction vs Opus 4.7 (Phase 0.A.8) *(feat/0.A.8-pin-sonnet-model)* — [decisions-branches/feat__0.A.8-pin-sonnet-model.md](decisions-branches/feat__0.A.8-pin-sonnet-model.md)
 - **2026-05-28** — PR #100 fix: anchor prior-summary detection to ## 🐛 Clud Bug review header (not LAST claude[bot] body) *(feat/0.A.10-incremental-diff-review)* — [decisions-branches/feat__0.A.10-incremental-diff-review.md](decisions-branches/feat__0.A.10-incremental-diff-review.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-28** — v0.6.12: fix self-update.yml.tmpl YAML literal-block bug — unblocks workflow_dispatch propagation *(feat/0.A.11-fix-self-update-yaml-literal)* — [decisions-branches/feat__0.A.11-fix-self-update-yaml-literal.md](decisions-branches/feat__0.A.11-fix-self-update-yaml-literal.md)
 - **2026-05-28** — v0.6.11: pin clud-bug-review to Sonnet 4.6 — ~80% cost reduction vs Opus 4.7 (Phase 0.A.8) *(feat/0.A.8-pin-sonnet-model)* — [decisions-branches/feat__0.A.8-pin-sonnet-model.md](decisions-branches/feat__0.A.8-pin-sonnet-model.md)
 - **2026-05-28** — PR #100 fix: anchor prior-summary detection to ## 🐛 Clud Bug review header (not LAST claude[bot] body) *(feat/0.A.10-incremental-diff-review)* — [decisions-branches/feat__0.A.10-incremental-diff-review.md](decisions-branches/feat__0.A.10-incremental-diff-review.md)
 - **2026-05-28** — v0.6.10: incremental-diff review on fix-push (Phase 0.A.10 — HIGH-VALUE) *(feat/0.A.10-incremental-diff-review)* — [decisions-branches/feat__0.A.10-incremental-diff-review.md](decisions-branches/feat__0.A.10-incremental-diff-review.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/self-update.yml.tmpl
+++ b/templates/self-update.yml.tmpl
@@ -83,8 +83,13 @@ jobs:
           git add -A
           git commit -m "🐛 Clud Bug self-update: ${INSTALLED} → ${LATEST}"
           git push -u origin "$BRANCH"
+          # Build the PR body via printf so the embedded newlines don't break
+          # the YAML `run: |` literal-block parser. v0.6.11 and earlier put a
+          # blank line directly inside the --body string; some YAML parsers
+          # (GitHub Actions among them) ended the block scalar at that blank
+          # line and rejected the next line as an unexpected top-level value,
+          # which broke `workflow_dispatch` on every consuming repo.
+          BODY=$(printf 'Automated update from clud-bug %s → %s. Custom and skills.sh-installed specimens were left alone; only baseline specimens and the workflow templates were refreshed.\n\nReview the diff. To stay on this version permanently, add `"pinVersion": "%s"` to `.claude/skills/.clud-bug.json` before merging.' "${INSTALLED}" "${LATEST}" "${INSTALLED}")
           gh pr create \
             --title "🐛 Clud Bug self-update: ${INSTALLED} → ${LATEST}" \
-            --body "Automated update from clud-bug ${INSTALLED} → ${LATEST}. Custom and skills.sh-installed specimens were left alone; only baseline specimens and the workflow templates were refreshed.
-
-Review the diff. To stay on this version permanently, add \`\"pinVersion\": \"${INSTALLED}\"\` to \`.claude/skills/.clud-bug.json\` before merging."
+            --body "$BODY"

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -85,6 +85,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.11
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.12
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -85,6 +85,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.11
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.12
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -145,6 +145,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.11
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.12
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -75,3 +75,45 @@ test('render still throws on a placeholder not in DEFAULTS or vars', () => {
   // that aren't in the defaults map.
   assert.throws(() => render('{{NOT_DEFAULTED}}', {}), /Missing template variable: NOT_DEFAULTED/);
 });
+
+// --- 0.A.11 (v0.6.12): self-update.yml.tmpl YAML literal-block fix ---
+// v0.6.11 and earlier embedded a literal blank line inside a `--body "..."`
+// multi-line string nested in a `run: |` block. GitHub Actions' YAML parser
+// ended the block scalar at the blank line and rejected the next line as an
+// unexpected top-level value — `workflow_dispatch` failed with HTTP 422 on
+// every consuming repo. Fix: build the body via `printf` so the embedded
+// newlines live in shell, not YAML.
+
+test('templates/self-update.yml.tmpl: PR body is built via printf (no blank line inside `run: |` literal)', async () => {
+  const { readFile } = await import('node:fs/promises');
+  const { join } = await import('node:path');
+  const tmpl = await readFile(
+    join(import.meta.dirname, '..', 'templates', 'self-update.yml.tmpl'),
+    'utf8',
+  );
+  // Positive: the printf-based build is present.
+  assert.match(
+    tmpl,
+    /BODY=\$\(printf /,
+    'self-update.yml.tmpl must construct the PR body via `printf` (v0.6.12 fix). '
+      + 'A literal multi-line --body argument with a blank line inside breaks the '
+      + 'YAML `run: |` block scalar and fails workflow_dispatch with HTTP 422.',
+  );
+  // Negative: the buggy literal — `--body "Automated update from clud-bug` line
+  // immediately followed by a blank line and a `Review the diff` line — must
+  // not reappear. Locate the body line and assert there's no blank line
+  // immediately after it before any other content.
+  const lines = tmpl.split('\n');
+  const bodyLineIdx = lines.findIndex((l) =>
+    l.includes('--body "Automated update from clud-bug'),
+  );
+  if (bodyLineIdx !== -1) {
+    // If the v0.6.11 literal pattern reappears, the next line must NOT be blank.
+    assert.notEqual(
+      lines[bodyLineIdx + 1].trim(),
+      '',
+      'self-update.yml.tmpl regressed to v0.6.11 multi-line --body with embedded blank line. '
+        + 'Use printf to build the body in shell instead.',
+    );
+  }
+});


### PR DESCRIPTION
## Summary

`gh workflow run clud-bug-self-update.yml` failed with HTTP 422 on every consuming repo:

```
failed to parse workflow: (Line: 90, Col: 1): Unexpected value
'Review the diff. To stay on this version permanently, add ...'
```

Root cause: a literal blank line embedded inside a multi-line `--body "..."` argument to `gh pr create`, nested inside a `run: |` block. GitHub Actions' YAML parser ended the block scalar at the blank line and rejected the next non-blank line as an unexpected top-level value. **Scheduled cron triggers still worked** (no parse at trigger time), but **`workflow_dispatch` was blocked** on every consuming repo.

Pin drift across the org as a result:

| Repo | Installed | Latest |
|---|---|---|
| agent-skills | v0.5.16 | v0.6.11 |
| reporulez | v0.5.15 | v0.6.11 |
| rezgen | v0.5.16 | v0.6.11 |
| logmind | v0.6.7 | v0.6.11 |

**Fix**: build the PR body via `printf` outside the YAML literal block, then pass via shell variable. Removes the YAML-fragile blank line entirely.

## Test plan

- [x] `npm test` — 211 pass (+1 new).
- [x] New test asserts the `printf`-based build is present AND the buggy literal blank-line pattern doesn't reappear.
- [ ] After merge + tag: in each consuming repo locally, run `npx clud-bug@latest update` → re-renders the fixed workflow → push as a normal PR. `workflow_dispatch` will work again only after one of those PRs lands the fixed file.

## Why this is v0.6.12, not v1.0

Single-file fix to a workflow template; behavior of `clud-bug-review` itself unchanged. Composite-pin bumped `v0.6.11 → v0.6.12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)