### PR TITLE
feat(v0.6.14): workflow-PR review skip — eliminates structural admin-bypass (Phase 0.5 / 0.0.W)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.13
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.14
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.14] — 2026-05-28
+
+### Added — workflow-only PR review skip (Phase 0.5 / 0.0.W)
+
+Eliminates the structural admin-bypass merges we did ~6 times during
+Phase 0 propagation. When a PR ONLY touches `clud-bug-*.yml` workflow
+files OR `.github/actions/strict-mode-gate/**`, the LLM review skips
+entirely — and the strict-mode gate skips with it.
+
+### Why
+
+`anthropics/claude-code-action` refuses to run on PRs that modify its
+own workflow file (security guard against self-neutering edits).
+Phase 0 hit this on every propagation cycle — the only path was
+admin-bypass merge. v0.6.14 makes the right thing automatic: the LLM
+call doesn't happen, the strict-mode gate has nothing to fail on,
+branch protection is satisfied by the skip, and the org saves the
+per-skipped-review cost (~$0.20–$0.30 × ~50–80 propagation PRs/year).
+
+### How
+
+New `paths-check` pre-flight job classifies the PR diff. If ALL
+changed files match the allow-list (`.github/workflows/clud-bug-*.yml`
+or `.github/actions/strict-mode-gate/**`), it sets
+`outputs.is_workflow_only=true`. The `clud-bug-review` job carries
+`needs: paths-check` + `if: needs.paths-check.outputs.is_workflow_only != 'true'`.
+
+### Security guarantee
+
+The classifier requires EVERY changed file to match the allow-list. A
+mixed PR (workflow + code) still runs the review normally — no path
+to sneak unrelated changes through by bundling them with a workflow
+tweak.
+
+### Net diff
+
+3 templates × ~30 lines (new `paths-check` job + `needs:` / `if:` on
+`clud-bug-review`). Composite-pin v0.6.13 → v0.6.14.
+
 ## [0.6.13] — 2026-05-28
 
 ### Added — `clud-bug usage` $/LOC dashboard (Phase 0.5 / 0.0.M.1)

--- a/docs/decisions-branches/feat__0.0.W-workflow-pr-skip.md
+++ b/docs/decisions-branches/feat__0.0.W-workflow-pr-skip.md
@@ -1,0 +1,8 @@
+## 2026-05-28 18:13 - v0.6.14: workflow-PR review skip (Phase 0.5 / 0.0.W)
+
+**Reasoning:** Eliminates the structural admin-bypass merges Phase 0 hit ~6 times during propagation. New paths-check pre-flight job classifies the PR diff: if ALL changed files match either .github/workflows/clud-bug-*.yml OR .github/actions/strict-mode-gate/** patterns, outputs.is_workflow_only=true. clud-bug-review job carries needs: paths-check + if: needs.paths-check.outputs.is_workflow_only != 'true', so it skips entirely on workflow-only PRs. claude-code-action would refuse to run on such PRs anyway (self-modification guard); the LLM call doesn't happen, the strict-mode gate has nothing to fail on (skipped jobs satisfy branch protection), and the org saves the per-skipped-review cost (~$0.20-$0.30 × ~50-80 propagation PRs/year). Security guarantee: the classifier requires EVERY changed file to match the allow-list. Mixed PRs (workflow + code) still run the review normally — no path to sneak unrelated changes through. Applied across all 3 templates (workflow.yml.tmpl + workflow-ts.yml.tmpl + workflow-py.yml.tmpl); composite-pin bumped v0.6.13 → v0.6.14. +3 regression tests assert paths-check job presence, needs/if wiring on clud-bug-review, and the mixed-diff guard (any non-allow-list file flips classifier to false). 245 tests pass.
+
+**Implications:**
+- Org-wide impact validated by this PR's own review — it touches workflow files + tests + CHANGELOG + package.json, so the classifier should NOT report it as workflow-only (mixed = code change). Future workflow-only PRs (clud-bug-self-update from consuming repos) skip the review.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -51,6 +51,7 @@ clud-bug
 │   │   ├── ci__npm-publish-trusted.md
 │   │   ├── ci__unify-publish-and-promote.md
 │   │   ├── docs__skill-first-marketing-bb4.md
+│   │   ├── feat__0.0.M.1-usage-dashboard.md
 │   │   ├── feat__0.A.1-extract-prompts.md
 │   │   ├── feat__0.A.10-incremental-diff-review.md
 │   │   ├── feat__0.A.11-fix-self-update-yaml-literal.md
@@ -104,7 +105,8 @@ clud-bug
 │   ├── prompts.js
 │   ├── render.js
 │   ├── skills.js
-│   └── update.js
+│   ├── update.js
+│   └── usage.js
 ├── site
 │   ├── .vercel
 │   │   ├── project.json
@@ -148,7 +150,8 @@ clud-bug
 │   ├── release-discipline.test.js
 │   ├── render.test.js
 │   ├── skills.test.js
-│   └── update.test.js
+│   ├── update.test.js
+│   └── usage.test.js
 ├── .cursorrules
 ├── .gitattributes
 ├── .gitignore

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-28** — v0.6.14: workflow-PR review skip (Phase 0.5 / 0.0.W) *(feat/0.0.W-workflow-pr-skip)* — [decisions-branches/feat__0.0.W-workflow-pr-skip.md](decisions-branches/feat__0.0.W-workflow-pr-skip.md)
 - **2026-05-28** — PR #104 fix: extract tokens from result-event usage block only (regex was triple-counting) *(feat/0.0.M.1-usage-dashboard)* — [decisions-branches/feat__0.0.M.1-usage-dashboard.md](decisions-branches/feat__0.0.M.1-usage-dashboard.md)
 - **2026-05-28** — PR #104 review fixes: --pr filter, failure-run inclusion, unknownModel surfaced, slopePct distinguished *(feat/0.0.M.1-usage-dashboard)* — [decisions-branches/feat__0.0.M.1-usage-dashboard.md](decisions-branches/feat__0.0.M.1-usage-dashboard.md)
 - **2026-05-28** — v0.6.13: clud-bug usage $/LOC dashboard (Phase 0.5 / 0.0.M.1) *(feat/0.0.M.1-usage-dashboard)* — [decisions-branches/feat__0.0.M.1-usage-dashboard.md](decisions-branches/feat__0.0.M.1-usage-dashboard.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -6,7 +6,40 @@ on:
     types: [opened, synchronize]
 
 jobs:
+  # Pre-flight (v0.6.14 / 0.0.W) — see workflow.yml.tmpl for design notes.
+  paths-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      is_workflow_only: ${{ steps.classify.outputs.is_workflow_only }}
+    steps:
+      - name: Classify PR diff
+        id: classify
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          CHANGED=$(gh pr diff "$PR_NUMBER" -R "$REPO" --name-only)
+          if [ -z "$CHANGED" ]; then echo "is_workflow_only=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          IS_WORKFLOW_ONLY=true
+          while IFS= read -r f; do
+            case "$f" in
+              .github/workflows/clud-bug-*.yml) ;;
+              .github/actions/strict-mode-gate/*) ;;
+              *) IS_WORKFLOW_ONLY=false; break ;;
+            esac
+          done <<< "$CHANGED"
+          echo "is_workflow_only=$IS_WORKFLOW_ONLY" >> "$GITHUB_OUTPUT"
+          if [ "$IS_WORKFLOW_ONLY" = "true" ]; then
+            echo "::notice title=Clud Bug 🐛::Skipping LLM review — workflow-only PR."
+          fi
+
   clud-bug-review:
+    needs: paths-check
+    if: needs.paths-check.outputs.is_workflow_only != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -85,6 +118,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.13
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.14
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -6,7 +6,40 @@ on:
     types: [opened, synchronize]
 
 jobs:
+  # Pre-flight (v0.6.14 / 0.0.W) — see workflow.yml.tmpl for design notes.
+  paths-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      is_workflow_only: ${{ steps.classify.outputs.is_workflow_only }}
+    steps:
+      - name: Classify PR diff
+        id: classify
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          CHANGED=$(gh pr diff "$PR_NUMBER" -R "$REPO" --name-only)
+          if [ -z "$CHANGED" ]; then echo "is_workflow_only=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          IS_WORKFLOW_ONLY=true
+          while IFS= read -r f; do
+            case "$f" in
+              .github/workflows/clud-bug-*.yml) ;;
+              .github/actions/strict-mode-gate/*) ;;
+              *) IS_WORKFLOW_ONLY=false; break ;;
+            esac
+          done <<< "$CHANGED"
+          echo "is_workflow_only=$IS_WORKFLOW_ONLY" >> "$GITHUB_OUTPUT"
+          if [ "$IS_WORKFLOW_ONLY" = "true" ]; then
+            echo "::notice title=Clud Bug 🐛::Skipping LLM review — workflow-only PR."
+          fi
+
   clud-bug-review:
+    needs: paths-check
+    if: needs.paths-check.outputs.is_workflow_only != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -85,6 +118,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.13
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.14
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -6,7 +6,51 @@ on:
     types: [opened, synchronize]
 
 jobs:
+  # Pre-flight (v0.6.14 / 0.0.W): if the PR ONLY touches clud-bug workflow
+  # files or the strict-mode-gate composite action, skip the LLM review
+  # entirely. claude-code-action would refuse to run on such a PR anyway
+  # (self-modification guard — required for security), and a template
+  # re-render has no useful review surface. Skipping turns a previously
+  # required-admin-bypass merge into a normal one, AND saves the LLM
+  # call cost. Security: the classifier requires ALL changed files to
+  # match the allow-list — a mixed PR (workflow + code) still runs the
+  # review normally.
+  paths-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      is_workflow_only: ${{ steps.classify.outputs.is_workflow_only }}
+    steps:
+      - name: Classify PR diff
+        id: classify
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          CHANGED=$(gh pr diff "$PR_NUMBER" -R "$REPO" --name-only)
+          if [ -z "$CHANGED" ]; then
+            echo "is_workflow_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          IS_WORKFLOW_ONLY=true
+          while IFS= read -r f; do
+            case "$f" in
+              .github/workflows/clud-bug-*.yml) ;;
+              .github/actions/strict-mode-gate/*) ;;
+              *) IS_WORKFLOW_ONLY=false; break ;;
+            esac
+          done <<< "$CHANGED"
+          echo "is_workflow_only=$IS_WORKFLOW_ONLY" >> "$GITHUB_OUTPUT"
+          if [ "$IS_WORKFLOW_ONLY" = "true" ]; then
+            echo "::notice title=Clud Bug 🐛::Skipping LLM review — PR only touches workflow files (claude-code-action would refuse anyway due to self-modification guard)."
+          fi
+
   clud-bug-review:
+    needs: paths-check
+    if: needs.paths-check.outputs.is_workflow_only != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -145,6 +189,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.13
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.14
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/prompts.test.js
+++ b/test/prompts.test.js
@@ -336,6 +336,58 @@ test('all 3 rendered workflow templates allow git diff + git merge-base (v0.6.10
 // docs. Pin the model explicitly so we don't drift back to Opus on a future
 // claude-code-action default change.
 
+// --- 0.0.W (v0.6.14): workflow-PR review skip ---
+// When a PR only touches workflow files, the clud-bug-review job skips
+// entirely (claude-code-action would refuse anyway due to self-modification
+// guard; no useful review surface either). Eliminates the ~6 admin-bypass
+// merges per propagation cycle.
+
+test('all 3 rendered workflow templates declare a paths-check pre-flight job (v0.6.14+)', async () => {
+  for (const tmpl of ['workflow.yml.tmpl', 'workflow-ts.yml.tmpl', 'workflow-py.yml.tmpl']) {
+    const lang = tmpl.includes('-ts') ? 'ts' : tmpl.includes('-py') ? 'py' : 'generic';
+    const out = await renderFile(join(TEMPLATES, tmpl), {
+      REVIEW_PROMPT: reviewPrompt({ projectDescription: 'p', language: lang }),
+    });
+    assert.match(out, /^\s+paths-check:/m,
+      `${tmpl} missing the paths-check job (v0.6.14 / 0.0.W)`);
+    assert.match(out, /is_workflow_only:/,
+      `${tmpl} missing the is_workflow_only output (v0.6.14)`);
+  }
+});
+
+test('all 3 rendered workflow templates: clud-bug-review depends on paths-check + skips on workflow-only', async () => {
+  for (const tmpl of ['workflow.yml.tmpl', 'workflow-ts.yml.tmpl', 'workflow-py.yml.tmpl']) {
+    const lang = tmpl.includes('-ts') ? 'ts' : tmpl.includes('-py') ? 'py' : 'generic';
+    const out = await renderFile(join(TEMPLATES, tmpl), {
+      REVIEW_PROMPT: reviewPrompt({ projectDescription: 'p', language: lang }),
+    });
+    assert.match(out, /needs: paths-check/,
+      `${tmpl} clud-bug-review must depend on paths-check`);
+    assert.match(
+      out,
+      /if:\s*needs\.paths-check\.outputs\.is_workflow_only\s*!=\s*'true'/,
+      `${tmpl} clud-bug-review must skip when paths-check reports workflow-only`,
+    );
+  }
+});
+
+test('paths-check classifier: allow-list covers clud-bug-*.yml + strict-mode-gate/**', async () => {
+  // The classifier shell embedded in the workflow uses `case "$f" in ...`
+  // with two patterns. Both must be present for the security guarantee
+  // (mixed PRs must NOT match — only files matching one of these is
+  // workflow-only).
+  const out = await renderFile(join(TEMPLATES, 'workflow.yml.tmpl'), {
+    REVIEW_PROMPT: reviewPrompt({ projectDescription: 'p', language: 'generic' }),
+  });
+  assert.match(out, /\.github\/workflows\/clud-bug-\*\.yml\)/);
+  assert.match(out, /\.github\/actions\/strict-mode-gate\/\*\)/);
+  // Critical: the `*) IS_WORKFLOW_ONLY=false; break ;;` default branch
+  // ensures any unmatched file flips the classifier — a mixed PR cannot
+  // sneak through.
+  assert.match(out, /\*\)\s*IS_WORKFLOW_ONLY=false/,
+    'mixed-diff guard MUST be present — any non-allow-list file flips the classifier to false');
+});
+
 test('all 3 rendered workflow templates pin claude_args --model claude-sonnet-4-6 (v0.6.11+)', async () => {
   for (const tmpl of ['workflow.yml.tmpl', 'workflow-ts.yml.tmpl', 'workflow-py.yml.tmpl']) {
     const lang = tmpl.includes('-ts') ? 'ts' : tmpl.includes('-py') ? 'py' : 'generic';


### PR DESCRIPTION
## Summary

Eliminates the structural admin-bypass merges Phase 0 hit ~6 times during propagation. When a PR ONLY touches `clud-bug-*.yml` workflow files OR `.github/actions/strict-mode-gate/**`, the LLM review skips entirely — and the strict-mode gate skips with it.

## Why this was needed

`anthropics/claude-code-action` refuses to run on PRs that modify its own workflow file (security guard against self-neutering edits). Phase 0 hit this on every propagation cycle — the only path was admin-bypass merge. v0.6.14 makes the right thing automatic.

## How

New `paths-check` pre-flight job classifies the PR diff. If ALL changed files match the allow-list, it sets `outputs.is_workflow_only=true`. `clud-bug-review` then carries `needs: paths-check` + `if: needs.paths-check.outputs.is_workflow_only != 'true'`.

## Security guarantee

The classifier requires EVERY changed file to match the allow-list (`.github/workflows/clud-bug-*.yml` or `.github/actions/strict-mode-gate/**`). A mixed PR (workflow + code) still runs the review normally — no path to sneak unrelated changes through by bundling them with a workflow tweak. This PR itself proves it — it touches `templates/*.tmpl`, `test/`, `CHANGELOG.md`, `package.json` etc., so it's NOT workflow-only and will be reviewed normally.

## Test plan

- [x] `npm test` — 245 pass (+3 new).
- [x] New tests assert: paths-check job is present in all 3 templates; clud-bug-review carries `needs:` and `if:` correctly; the mixed-diff guard (`*) IS_WORKFLOW_ONLY=false; break;;`) is present.
- [x] Smoke: rendered workflow.yml manually inspected (523 lines, clean structure).
- [x] composite-pin v0.6.13 → v0.6.14 (release-discipline test enforces lock-step).

## Impact

| Surface | Before | After |
|---|---|---|
| Propagation PRs / year | ~50–80 admin-bypass | 0 admin-bypass |
| Per-skipped-review API cost | $0.20–$0.30 wasted (action failed mid-way) | $0 (no LLM call) |
| User friction | "merge with admin?" prompt every time | Normal merge |

🤖 Generated with [Claude Code](https://claude.com/claude-code)