### PR TITLE
chore: @AGENTS.md import in CLAUDE.md (Q4 refinement / 0.0.I)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+@AGENTS.md
+
 <!-- logmind-stub: AI agent instructions for this project live in AGENTS.md -->
 See [AGENTS.md](AGENTS.md) for project-specific AI agent instructions, including
 the decision-logging requirement (logmind) and required reading.

--- a/docs/decisions-branches/chore__agents-md-import.md
+++ b/docs/decisions-branches/chore__agents-md-import.md
@@ -3,3 +3,8 @@
 **Reasoning:** Same pattern as agent-skills #48. 1-line addition: @AGENTS.md as first line of CLAUDE.md. Eliminates the silent failure mode where Claude doesn't follow the stub redirect. Token cost unchanged; single source of truth preserved.
 
 ---
+## 2026-05-29 01:19 - PR #106: regen derived docs after rebase
+
+**Reasoning:** Post-rebase regen of docs/file-structure.md + docs/timeline.md. No source code change.
+
+---

--- a/docs/decisions-branches/chore__agents-md-import.md
+++ b/docs/decisions-branches/chore__agents-md-import.md
@@ -1,0 +1,5 @@
+## 2026-05-29 01:00 - chore: @AGENTS.md import in CLAUDE.md (Q4 refinement / 0.0.I)
+
+**Reasoning:** Same pattern as agent-skills #48. 1-line addition: @AGENTS.md as first line of CLAUDE.md. Eliminates the silent failure mode where Claude doesn't follow the stub redirect. Token cost unchanged; single source of truth preserved.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -40,6 +40,7 @@ clud-bug
 │   │   ├── ceremony__self-mod-bump-to-v0.5.15.md
 │   │   ├── ceremony__self-mod-v0.6.0.md
 │   │   ├── ceremony__self-mod-v0.6.1.md
+│   │   ├── chore__agents-md-import.md
 │   │   ├── chore__bump-logmind-pin-0.3.3.md
 │   │   ├── chore__empty-strictskills-v2.md
 │   │   ├── chore__logmind-v0.2.10-propagation.md
@@ -52,6 +53,7 @@ clud-bug
 │   │   ├── ci__unify-publish-and-promote.md
 │   │   ├── docs__skill-first-marketing-bb4.md
 │   │   ├── feat__0.0.M.1-usage-dashboard.md
+│   │   ├── feat__0.0.R-model-routing-trivial.md
 │   │   ├── feat__0.0.W-workflow-pr-skip.md
 │   │   ├── feat__0.A.1-extract-prompts.md
 │   │   ├── feat__0.A.10-incremental-diff-review.md

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -52,6 +52,7 @@ clud-bug
 │   │   ├── ci__unify-publish-and-promote.md
 │   │   ├── docs__skill-first-marketing-bb4.md
 │   │   ├── feat__0.0.M.1-usage-dashboard.md
+│   │   ├── feat__0.0.W-workflow-pr-skip.md
 │   │   ├── feat__0.A.1-extract-prompts.md
 │   │   ├── feat__0.A.10-incremental-diff-review.md
 │   │   ├── feat__0.A.11-fix-self-update-yaml-literal.md

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,7 +15,9 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-29** — PR #106: regen derived docs after rebase *(chore/agents-md-import)* — [decisions-branches/chore__agents-md-import.md](decisions-branches/chore__agents-md-import.md)
 - **2026-05-29** — v0.6.15: model routing for trivial PRs — Haiku for dep bumps (Phase 0.5 / 0.0.R) *(feat/0.0.R-model-routing-trivial)* — [decisions-branches/feat__0.0.R-model-routing-trivial.md](decisions-branches/feat__0.0.R-model-routing-trivial.md)
+- **2026-05-29** — chore: @AGENTS.md import in CLAUDE.md (Q4 refinement / 0.0.I) *(chore/agents-md-import)* — [decisions-branches/chore__agents-md-import.md](decisions-branches/chore__agents-md-import.md)
 - **2026-05-28** — v0.6.14: workflow-PR review skip (Phase 0.5 / 0.0.W) *(feat/0.0.W-workflow-pr-skip)* — [decisions-branches/feat__0.0.W-workflow-pr-skip.md](decisions-branches/feat__0.0.W-workflow-pr-skip.md)
 - **2026-05-28** — PR #104 fix: extract tokens from result-event usage block only (regex was triple-counting) *(feat/0.0.M.1-usage-dashboard)* — [decisions-branches/feat__0.0.M.1-usage-dashboard.md](decisions-branches/feat__0.0.M.1-usage-dashboard.md)
 - **2026-05-28** — PR #104 review fixes: --pr filter, failure-run inclusion, unknownModel surfaced, slopePct distinguished *(feat/0.0.M.1-usage-dashboard)* — [decisions-branches/feat__0.0.M.1-usage-dashboard.md](decisions-branches/feat__0.0.M.1-usage-dashboard.md)


### PR DESCRIPTION
Part of Phase 0.5 / 0.0.I. Companion to agent-skills #48. Trivial 1-line addition: @AGENTS.md import at top of CLAUDE.md so Claude Code auto-loads canonical content instead of relying on the stub redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)