### PR TITLE
feat(v0.6.15): model routing for trivial PRs — Haiku for dep bumps (Phase 0.5 / 0.0.R)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.14
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.15
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.15] — 2026-05-29
+
+### Added — model routing for trivial PRs (Phase 0.5 / 0.0.R)
+
+When a PR is a dep bump (Dependabot/Renovate author) OR a small
+manual lockfile/manifest fix, route the review to Haiku 4.5
+($0.80/MTok input) instead of Sonnet 4.6 ($3/MTok) — another **~75%
+cost reduction** on this PR class.
+
+### Classifier (in paths-check)
+
+A PR is "trivial" if EITHER:
+
+1. The author is `dependabot[bot]` or `renovate[bot]` (regardless of
+   diff size — dep-bump bots open shallow PRs even when lockfile
+   churn is large).
+2. The diff is < 2 KB AND every changed file matches the
+   dep-manifest allow-list:
+   `package.json` / `package-lock.json` / `pnpm-lock.yaml` /
+   `yarn.lock` / `requirements*.txt` / `pyproject.toml` /
+   `poetry.lock` / `uv.lock` / `Gemfile(.lock)` /
+   `go.mod` / `go.sum` / `Cargo.toml` / `Cargo.lock`.
+
+Otherwise: Sonnet (the current default).
+
+### Wiring
+
+`paths-check` job (introduced in v0.6.14) now also emits a `model`
+output. The `clud-bug-review` job's `claude_args` uses
+`--model ${{ needs.paths-check.outputs.model }}` so the SDK picks up
+the routed model dynamically.
+
+### Override
+
+To force a specific model for a specific repo, edit the rendered
+workflow to hard-code `--model claude-sonnet-4-6` (or any other valid
+ID) in place of the expression. The classifier is opt-out by
+construction — any non-trivial diff (real code change, large dep
+bump, mixed paths) defaults to Sonnet.
+
+### Net diff
+
+3 templates × ~30 lines (triviality classifier in `paths-check` +
+`--model` expansion in `claude_args`). Composite-pin v0.6.14 → v0.6.15.
+
 ## [0.6.14] — 2026-05-28
 
 ### Added — workflow-only PR review skip (Phase 0.5 / 0.0.W)

--- a/docs/decisions-branches/feat__0.0.R-model-routing-trivial.md
+++ b/docs/decisions-branches/feat__0.0.R-model-routing-trivial.md
@@ -1,0 +1,8 @@
+## 2026-05-29 01:06 - v0.6.15: model routing for trivial PRs — Haiku for dep bumps (Phase 0.5 / 0.0.R)
+
+**Reasoning:** Extends paths-check (v0.6.14) with a triviality classifier. PR is trivial if: (a) author is dependabot[bot] or renovate[bot] (regardless of diff size — lockfile churn can be huge but review surface is shallow), OR (b) diff < 2KB AND every changed file matches the dep-manifest allow-list (package.json, *-lock.*, pyproject.toml, poetry.lock, uv.lock, Gemfile(.lock), go.mod/go.sum, Cargo.toml/Cargo.lock). Trivial PRs route to claude-haiku-4-5-20251001 ($0.80/MTok input); everything else stays on Sonnet 4.6 ($3/MTok). ~75% cost reduction on dep-bump traffic. Mixed PRs (any non-allow-list file) fall back to Sonnet via the *) ALL_TRIVIAL=false; break ;; safety branch — opt-in by classifier. Wiring: paths-check emits 'model' output; claude_args uses --model ${{ needs.paths-check.outputs.model }} for dynamic interpolation. Applied across all 3 templates; composite-pin bumped v0.6.14 → v0.6.15. +4 regression tests assert: model output exposed + Sonnet default, dependabot/renovate matched, allow-list covers 5 ecosystems, mixed-diff guard present. 249 pass.
+
+**Implications:**
+- Override per-repo by editing the rendered workflow if a consumer wants Sonnet for ALL their dep bumps. Future bot authors (e.g. a new dependency-update tool) need to be added to the bot-author case. Diff size 2048 bytes covers typical manual lockfile fixes; not a hard ceiling — extreme manual edits fall through to Sonnet (safe default).
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-29** — v0.6.15: model routing for trivial PRs — Haiku for dep bumps (Phase 0.5 / 0.0.R) *(feat/0.0.R-model-routing-trivial)* — [decisions-branches/feat__0.0.R-model-routing-trivial.md](decisions-branches/feat__0.0.R-model-routing-trivial.md)
 - **2026-05-28** — v0.6.14: workflow-PR review skip (Phase 0.5 / 0.0.W) *(feat/0.0.W-workflow-pr-skip)* — [decisions-branches/feat__0.0.W-workflow-pr-skip.md](decisions-branches/feat__0.0.W-workflow-pr-skip.md)
 - **2026-05-28** — PR #104 fix: extract tokens from result-event usage block only (regex was triple-counting) *(feat/0.0.M.1-usage-dashboard)* — [decisions-branches/feat__0.0.M.1-usage-dashboard.md](decisions-branches/feat__0.0.M.1-usage-dashboard.md)
 - **2026-05-28** — PR #104 review fixes: --pr filter, failure-run inclusion, unknownModel surfaced, slopePct distinguished *(feat/0.0.M.1-usage-dashboard)* — [decisions-branches/feat__0.0.M.1-usage-dashboard.md](decisions-branches/feat__0.0.M.1-usage-dashboard.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  # Pre-flight (v0.6.14 / 0.0.W) — see workflow.yml.tmpl for design notes.
+  # Pre-flight (v0.6.14 / 0.0.W + v0.6.15 / 0.0.R) — see workflow.yml.tmpl.
   paths-check:
     runs-on: ubuntu-latest
     permissions:
@@ -14,6 +14,7 @@ jobs:
       pull-requests: read
     outputs:
       is_workflow_only: ${{ steps.classify.outputs.is_workflow_only }}
+      model: ${{ steps.classify.outputs.model }}
     steps:
       - name: Classify PR diff
         id: classify
@@ -21,9 +22,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           CHANGED=$(gh pr diff "$PR_NUMBER" -R "$REPO" --name-only)
-          if [ -z "$CHANGED" ]; then echo "is_workflow_only=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          MODEL=claude-sonnet-4-6
+          if [ -z "$CHANGED" ]; then
+            echo "is_workflow_only=false" >> "$GITHUB_OUTPUT"
+            echo "model=$MODEL" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           IS_WORKFLOW_ONLY=true
           while IFS= read -r f; do
             case "$f" in
@@ -35,7 +42,38 @@ jobs:
           echo "is_workflow_only=$IS_WORKFLOW_ONLY" >> "$GITHUB_OUTPUT"
           if [ "$IS_WORKFLOW_ONLY" = "true" ]; then
             echo "::notice title=Clud Bug 🐛::Skipping LLM review — workflow-only PR."
+            echo "model=$MODEL" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          # Triviality (0.0.R): dep-bumping bot OR small dep-manifest diff.
+          IS_TRIVIAL=false
+          case "$PR_AUTHOR" in
+            dependabot\[bot\]|renovate\[bot\]) IS_TRIVIAL=true ;;
+          esac
+          if [ "$IS_TRIVIAL" = "false" ]; then
+            DIFF_SIZE=$(gh pr diff "$PR_NUMBER" -R "$REPO" | wc -c | tr -d ' ')
+            if [ "$DIFF_SIZE" -lt 2048 ]; then
+              ALL_TRIVIAL=true
+              while IFS= read -r f; do
+                case "$f" in
+                  package.json|*/package.json|package-lock.json|*/package-lock.json) ;;
+                  pnpm-lock.yaml|*/pnpm-lock.yaml|yarn.lock|*/yarn.lock) ;;
+                  requirements*.txt|*/requirements*.txt) ;;
+                  pyproject.toml|*/pyproject.toml|poetry.lock|*/poetry.lock|uv.lock|*/uv.lock) ;;
+                  Gemfile|*/Gemfile|Gemfile.lock|*/Gemfile.lock) ;;
+                  go.mod|*/go.mod|go.sum|*/go.sum) ;;
+                  Cargo.toml|*/Cargo.toml|Cargo.lock|*/Cargo.lock) ;;
+                  *) ALL_TRIVIAL=false; break ;;
+                esac
+              done <<< "$CHANGED"
+              [ "$ALL_TRIVIAL" = "true" ] && IS_TRIVIAL=true
+            fi
+          fi
+          if [ "$IS_TRIVIAL" = "true" ]; then
+            MODEL=claude-haiku-4-5-20251001
+            echo "::notice title=Clud Bug 🐛::Trivial PR — routing to Haiku."
+          fi
+          echo "model=$MODEL" >> "$GITHUB_OUTPUT"
 
   clud-bug-review:
     needs: paths-check
@@ -106,7 +144,7 @@ jobs:
           track_progress: true
           show_full_output: true
           claude_args: |
-            --model claude-sonnet-4-6
+            --model ${{ needs.paths-check.outputs.model }}
             --max-turns 15
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
           prompt: |
@@ -118,6 +156,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.14
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.15
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  # Pre-flight (v0.6.14 / 0.0.W) — see workflow.yml.tmpl for design notes.
+  # Pre-flight (v0.6.14 / 0.0.W + v0.6.15 / 0.0.R) — see workflow.yml.tmpl.
   paths-check:
     runs-on: ubuntu-latest
     permissions:
@@ -14,6 +14,7 @@ jobs:
       pull-requests: read
     outputs:
       is_workflow_only: ${{ steps.classify.outputs.is_workflow_only }}
+      model: ${{ steps.classify.outputs.model }}
     steps:
       - name: Classify PR diff
         id: classify
@@ -21,9 +22,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           CHANGED=$(gh pr diff "$PR_NUMBER" -R "$REPO" --name-only)
-          if [ -z "$CHANGED" ]; then echo "is_workflow_only=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          MODEL=claude-sonnet-4-6
+          if [ -z "$CHANGED" ]; then
+            echo "is_workflow_only=false" >> "$GITHUB_OUTPUT"
+            echo "model=$MODEL" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           IS_WORKFLOW_ONLY=true
           while IFS= read -r f; do
             case "$f" in
@@ -35,7 +42,38 @@ jobs:
           echo "is_workflow_only=$IS_WORKFLOW_ONLY" >> "$GITHUB_OUTPUT"
           if [ "$IS_WORKFLOW_ONLY" = "true" ]; then
             echo "::notice title=Clud Bug 🐛::Skipping LLM review — workflow-only PR."
+            echo "model=$MODEL" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          # Triviality (0.0.R): dep-bumping bot OR small dep-manifest diff.
+          IS_TRIVIAL=false
+          case "$PR_AUTHOR" in
+            dependabot\[bot\]|renovate\[bot\]) IS_TRIVIAL=true ;;
+          esac
+          if [ "$IS_TRIVIAL" = "false" ]; then
+            DIFF_SIZE=$(gh pr diff "$PR_NUMBER" -R "$REPO" | wc -c | tr -d ' ')
+            if [ "$DIFF_SIZE" -lt 2048 ]; then
+              ALL_TRIVIAL=true
+              while IFS= read -r f; do
+                case "$f" in
+                  package.json|*/package.json|package-lock.json|*/package-lock.json) ;;
+                  pnpm-lock.yaml|*/pnpm-lock.yaml|yarn.lock|*/yarn.lock) ;;
+                  requirements*.txt|*/requirements*.txt) ;;
+                  pyproject.toml|*/pyproject.toml|poetry.lock|*/poetry.lock|uv.lock|*/uv.lock) ;;
+                  Gemfile|*/Gemfile|Gemfile.lock|*/Gemfile.lock) ;;
+                  go.mod|*/go.mod|go.sum|*/go.sum) ;;
+                  Cargo.toml|*/Cargo.toml|Cargo.lock|*/Cargo.lock) ;;
+                  *) ALL_TRIVIAL=false; break ;;
+                esac
+              done <<< "$CHANGED"
+              [ "$ALL_TRIVIAL" = "true" ] && IS_TRIVIAL=true
+            fi
+          fi
+          if [ "$IS_TRIVIAL" = "true" ]; then
+            MODEL=claude-haiku-4-5-20251001
+            echo "::notice title=Clud Bug 🐛::Trivial PR — routing to Haiku."
+          fi
+          echo "model=$MODEL" >> "$GITHUB_OUTPUT"
 
   clud-bug-review:
     needs: paths-check
@@ -106,7 +144,7 @@ jobs:
           track_progress: true
           show_full_output: true
           claude_args: |
-            --model claude-sonnet-4-6
+            --model ${{ needs.paths-check.outputs.model }}
             --max-turns 15
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
           prompt: |
@@ -118,6 +156,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.14
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.15
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -6,15 +6,21 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  # Pre-flight (v0.6.14 / 0.0.W): if the PR ONLY touches clud-bug workflow
-  # files or the strict-mode-gate composite action, skip the LLM review
-  # entirely. claude-code-action would refuse to run on such a PR anyway
-  # (self-modification guard — required for security), and a template
-  # re-render has no useful review surface. Skipping turns a previously
-  # required-admin-bypass merge into a normal one, AND saves the LLM
-  # call cost. Security: the classifier requires ALL changed files to
-  # match the allow-list — a mixed PR (workflow + code) still runs the
-  # review normally.
+  # Pre-flight: classify the PR diff to decide (a) whether to skip the
+  # LLM review entirely, and (b) which model to route to.
+  #
+  # (a) Workflow-only PRs (v0.6.14 / 0.0.W): if every changed file
+  # matches `.github/workflows/clud-bug-*.yml` or
+  # `.github/actions/strict-mode-gate/**`, the LLM call is skipped
+  # entirely — claude-code-action would refuse anyway (self-modification
+  # guard), and template re-renders have no useful review surface.
+  # Skipping converts what were admin-bypass merges into normal ones.
+  #
+  # (b) Trivial PRs (v0.6.15 / 0.0.R): if the PR author is a dep-bumping
+  # bot (dependabot, renovate) OR the diff is small (<2KB) AND only
+  # touches dependency-manifest files, route the review to Haiku
+  # ($0.80/MTok input vs Sonnet's $3) — another ~75% cost reduction on
+  # this PR class. Sonnet remains the default for everything else.
   paths-check:
     runs-on: ubuntu-latest
     permissions:
@@ -22,6 +28,7 @@ jobs:
       pull-requests: read
     outputs:
       is_workflow_only: ${{ steps.classify.outputs.is_workflow_only }}
+      model: ${{ steps.classify.outputs.model }}
     steps:
       - name: Classify PR diff
         id: classify
@@ -29,12 +36,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           CHANGED=$(gh pr diff "$PR_NUMBER" -R "$REPO" --name-only)
+          MODEL=claude-sonnet-4-6   # default
           if [ -z "$CHANGED" ]; then
             echo "is_workflow_only=false" >> "$GITHUB_OUTPUT"
+            echo "model=$MODEL" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          # --- (a) workflow-only classifier ---
           IS_WORKFLOW_ONLY=true
           while IFS= read -r f; do
             case "$f" in
@@ -45,8 +57,50 @@ jobs:
           done <<< "$CHANGED"
           echo "is_workflow_only=$IS_WORKFLOW_ONLY" >> "$GITHUB_OUTPUT"
           if [ "$IS_WORKFLOW_ONLY" = "true" ]; then
-            echo "::notice title=Clud Bug 🐛::Skipping LLM review — PR only touches workflow files (claude-code-action would refuse anyway due to self-modification guard)."
+            echo "::notice title=Clud Bug 🐛::Skipping LLM review — PR only touches workflow files."
+            echo "model=$MODEL" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          # --- (b) triviality classifier ---
+          IS_TRIVIAL=false
+          # Bot authors that exclusively open dep-bump PRs go straight
+          # to Haiku regardless of diff size — lockfile churn can be huge
+          # but the review surface is shallow.
+          case "$PR_AUTHOR" in
+            dependabot\[bot\]|renovate\[bot\]) IS_TRIVIAL=true ;;
+          esac
+          # Otherwise: diff < 2KB AND every file matches the dep-manifest
+          # allow-list. Manual lockfile fixes / small version pins
+          # qualify; real feature work does not.
+          if [ "$IS_TRIVIAL" = "false" ]; then
+            DIFF_SIZE=$(gh pr diff "$PR_NUMBER" -R "$REPO" | wc -c | tr -d ' ')
+            if [ "$DIFF_SIZE" -lt 2048 ]; then
+              ALL_TRIVIAL=true
+              while IFS= read -r f; do
+                case "$f" in
+                  package.json|*/package.json) ;;
+                  package-lock.json|*/package-lock.json) ;;
+                  pnpm-lock.yaml|*/pnpm-lock.yaml) ;;
+                  yarn.lock|*/yarn.lock) ;;
+                  requirements*.txt|*/requirements*.txt) ;;
+                  pyproject.toml|*/pyproject.toml) ;;
+                  poetry.lock|*/poetry.lock) ;;
+                  uv.lock|*/uv.lock) ;;
+                  Gemfile|*/Gemfile|Gemfile.lock|*/Gemfile.lock) ;;
+                  go.mod|*/go.mod|go.sum|*/go.sum) ;;
+                  Cargo.toml|*/Cargo.toml|Cargo.lock|*/Cargo.lock) ;;
+                  *) ALL_TRIVIAL=false; break ;;
+                esac
+              done <<< "$CHANGED"
+              [ "$ALL_TRIVIAL" = "true" ] && IS_TRIVIAL=true
+            fi
+          fi
+          if [ "$IS_TRIVIAL" = "true" ]; then
+            MODEL=claude-haiku-4-5-20251001
+            echo "::notice title=Clud Bug 🐛::Trivial PR detected (dep bump / bot author) — routing to Haiku for ~75% cost reduction."
+          fi
+          echo "model=$MODEL" >> "$GITHUB_OUTPUT"
 
   clud-bug-review:
     needs: paths-check
@@ -164,8 +218,12 @@ jobs:
           # cache_creation_input_tokens in the run's result JSON so we can
           # measure caching effectiveness post-rollout (per v0.6.3 plan).
           show_full_output: true
+          # v0.6.15 / 0.0.R: --model is dynamic. paths-check classifies
+          # the PR as trivial (Haiku) or default (Sonnet). Override
+          # per-repo by editing the rendered workflow if you want a
+          # specific model for a specific repo.
           claude_args: |
-            --model claude-sonnet-4-6
+            --model ${{ needs.paths-check.outputs.model }}
             --max-turns 15
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
           prompt: |
@@ -189,6 +247,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.14
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.15
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/prompts.test.js
+++ b/test/prompts.test.js
@@ -388,7 +388,11 @@ test('paths-check classifier: allow-list covers clud-bug-*.yml + strict-mode-gat
     'mixed-diff guard MUST be present — any non-allow-list file flips the classifier to false');
 });
 
-test('all 3 rendered workflow templates pin claude_args --model claude-sonnet-4-6 (v0.6.11+)', async () => {
+test('all 3 rendered workflow templates use --model ${{ needs.paths-check.outputs.model }} (v0.6.15+)', async () => {
+  // v0.6.11 hard-coded --model claude-sonnet-4-6. v0.6.15 (0.0.R)
+  // makes the model dynamic: paths-check emits `model` output, which
+  // claude_args interpolates. Trivial PRs route to Haiku; default
+  // remains Sonnet (set in the classifier).
   for (const tmpl of ['workflow.yml.tmpl', 'workflow-ts.yml.tmpl', 'workflow-py.yml.tmpl']) {
     const lang = tmpl.includes('-ts') ? 'ts' : tmpl.includes('-py') ? 'py' : 'generic';
     const out = await renderFile(join(TEMPLATES, tmpl), {
@@ -396,10 +400,83 @@ test('all 3 rendered workflow templates pin claude_args --model claude-sonnet-4-
     });
     assert.match(
       out,
-      /--model claude-sonnet-4-6/,
-      `${tmpl} missing --model claude-sonnet-4-6 in claude_args (v0.6.11 — Phase 0.A.8 model pin)`,
+      /--model \$\{\{ needs\.paths-check\.outputs\.model \}\}/,
+      `${tmpl} must use dynamic --model from paths-check (v0.6.15 / 0.0.R)`,
+    );
+    // The hard-coded Sonnet pin from v0.6.11 should no longer appear
+    // as a literal `--model claude-sonnet-4-6` in claude_args.
+    assert.doesNotMatch(
+      out,
+      /--model claude-sonnet-4-6\b/,
+      `${tmpl} should not hard-code --model claude-sonnet-4-6; use the paths-check output instead`,
     );
   }
+});
+
+// --- 0.0.R (v0.6.15): model routing for trivial PRs ---
+
+test('paths-check exposes model output AND defaults to Sonnet', async () => {
+  for (const tmpl of ['workflow.yml.tmpl', 'workflow-ts.yml.tmpl', 'workflow-py.yml.tmpl']) {
+    const lang = tmpl.includes('-ts') ? 'ts' : tmpl.includes('-py') ? 'py' : 'generic';
+    const out = await renderFile(join(TEMPLATES, tmpl), {
+      REVIEW_PROMPT: reviewPrompt({ projectDescription: 'p', language: lang }),
+    });
+    // paths-check must emit `model` in its outputs block.
+    assert.match(out, /model:\s*\$\{\{\s*steps\.classify\.outputs\.model\s*\}\}/,
+      `${tmpl} paths-check must expose model output (v0.6.15)`);
+    // The default MODEL inside the classifier is Sonnet — anything
+    // un-classified must NOT silently route to a cheaper model.
+    assert.match(out, /MODEL=claude-sonnet-4-6/,
+      `${tmpl} default MODEL must be Sonnet (safety: trivial routing is opt-in by classifier)`);
+  }
+});
+
+test('triviality classifier: dependabot/renovate bot authors route to Haiku', async () => {
+  // The classifier hard-codes the two bot login names that exclusively
+  // open dep-bump PRs. Adding new dep-bot authors would extend this case.
+  const out = await renderFile(join(TEMPLATES, 'workflow.yml.tmpl'), {
+    REVIEW_PROMPT: reviewPrompt({ projectDescription: 'p', language: 'generic' }),
+  });
+  assert.match(out, /dependabot\\\[bot\\\]\|renovate\\\[bot\\\]/,
+    'classifier must match dependabot[bot] AND renovate[bot] (escaped for case glob)');
+  assert.match(out, /MODEL=claude-haiku-4-5-20251001/,
+    'classifier must assign Haiku 4.5 to trivial PRs');
+});
+
+test('triviality classifier: dep-manifest allow-list covers npm/pip/cargo/go/ruby', async () => {
+  const out = await renderFile(join(TEMPLATES, 'workflow.yml.tmpl'), {
+    REVIEW_PROMPT: reviewPrompt({ projectDescription: 'p', language: 'generic' }),
+  });
+  // Spot-check one pattern per ecosystem so regressions in the
+  // allow-list are caught.
+  for (const pat of [
+    /package\.json/,
+    /package-lock\.json/,
+    /pyproject\.toml/,
+    /poetry\.lock/,
+    /uv\.lock/,
+    /\bGemfile\b/,
+    /go\.mod\b/,
+    /go\.sum\b/,
+    /Cargo\.toml/,
+    /Cargo\.lock/,
+  ]) {
+    assert.match(out, pat, `triviality allow-list must include ${pat}`);
+  }
+});
+
+test('triviality classifier: any non-allow-list file flips MODEL back to Sonnet (safety)', async () => {
+  // The classifier's bail-out branch — `*) ALL_TRIVIAL=false; break ;;`
+  // — must be present. Without it, a single feature-code file in the
+  // diff would still route to Haiku, defeating the purpose.
+  const out = await renderFile(join(TEMPLATES, 'workflow.yml.tmpl'), {
+    REVIEW_PROMPT: reviewPrompt({ projectDescription: 'p', language: 'generic' }),
+  });
+  assert.match(
+    out,
+    /\*\)\s*ALL_TRIVIAL=false/,
+    'mixed-diff guard must flip ALL_TRIVIAL=false when any non-manifest file appears',
+  );
 });
 
 test('templateLanguage maps template filename to reviewPrompt language', () => {


### PR DESCRIPTION
## Summary

Extends the `paths-check` job (v0.6.14) with a triviality classifier. Trivial PRs route to **Haiku 4.5** ($0.80/MTok input) instead of Sonnet ($3/MTok) — **~75% additional cost reduction** on this PR class. Sonnet remains the default for everything else.

## Classifier

A PR is "trivial" if EITHER:

1. **Author** is `dependabot[bot]` or `renovate[bot]` (regardless of diff size — lockfile churn can be huge but the review surface is shallow).
2. **Diff < 2 KB** AND every changed file matches the dep-manifest allow-list (npm/yarn/pnpm lockfiles, pip requirements, pyproject + poetry/uv, Gemfile + lock, go.mod/sum, Cargo).

Otherwise: Sonnet (the current default).

## Safety

The mixed-diff guard (`*) ALL_TRIVIAL=false; break ;;`) flips back to Sonnet on any non-allow-list file. **The classifier is opt-in by construction** — any non-trivial diff (real code change, large dep bump, mixed paths) defaults to Sonnet.

## Wiring

`paths-check` now also emits a `model` output; `clud-bug-review`'s `claude_args` uses `--model \${{ needs.paths-check.outputs.model }}` — dynamic interpolation.

## Test plan

- [x] `npm test` — 249 pass (+4 new).
- [x] New tests assert: model output exposed + Sonnet default, dependabot/renovate matched, allow-list covers 5 ecosystems, mixed-diff guard present.
- [x] Existing `release-discipline.test.js` enforces composite-pin lock-step v0.6.14 → v0.6.15.

## Validation

This PR itself touches templates + tests + CHANGELOG + package.json (mixed PR, non-trivial) — so the classifier MUST keep it on Sonnet. If clud-bug review fires on Sonnet, that's behavioral proof of the safety guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)