### PR TITLE
feat(v0.6.16): output-token brevity directive in cached prompt (Phase 0.5 / 0.0.X)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.15
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.16
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.16] — 2026-05-29
+
+### Added — output-token brevity directive (Phase 0.5 / 0.0.X)
+
+Tiny prompt addition. Per the May 2026 LLM token optimization guide
+(section 6), `max_tokens` should be capped per call type — but the
+Claude Code CLI doesn't expose it (the SDK is agent-shaped, not
+single-call). Workaround: an explicit brevity instruction inside the
+cached system-prompt appendix.
+
+The new directive tells Claude:
+
+- Keep total output under ~600 tokens
+- Per finding: one-sentence claim + `<details>` reasoning ≤ 80 words
+- No code quotes > 2 lines
+- Omit reasoning details that don't change the verdict
+
+Discipline, not a hard cap. Verbose review output costs the consuming
+repo on every review; brevity compounds across the org.
+
+### Net diff
+
+`lib/prompts.js`: +8 lines. Composite-pin v0.6.15 → v0.6.16.
+
 ## [0.6.15] — 2026-05-29
 
 ### Added — model routing for trivial PRs (Phase 0.5 / 0.0.R)

--- a/docs/decisions-branches/feat__0.0.X-output-token-directive.md
+++ b/docs/decisions-branches/feat__0.0.X-output-token-directive.md
@@ -1,0 +1,5 @@
+## 2026-05-29 01:21 - v0.6.16: output-token brevity directive in cached prompt (Phase 0.5 / 0.0.X)
+
+**Reasoning:** Per LLM token optimization guide section 6: max_tokens should be capped per call type, but Claude Code CLI doesn't expose it (SDK is agent-shaped, not single-call). Workaround: explicit brevity instruction inside cached system-prompt appendix. New directive in lib/prompts.js (~8 lines): cap total output ~600 tokens; per finding 1-sentence claim + Reasoning ≤80 words + no code quotes >2 lines; omit reasoning that doesn't change verdict. Discipline, not hard cap — verbose review output costs the consuming repo on every review; brevity compounds across the org. +1 test asserts directive present. Composite-pin v0.6.15 → v0.6.16. 250 tests pass.
+
+---

--- a/docs/decisions-branches/feat__0.0.X-output-token-directive.md
+++ b/docs/decisions-branches/feat__0.0.X-output-token-directive.md
@@ -3,3 +3,8 @@
 **Reasoning:** Per LLM token optimization guide section 6: max_tokens should be capped per call type, but Claude Code CLI doesn't expose it (SDK is agent-shaped, not single-call). Workaround: explicit brevity instruction inside cached system-prompt appendix. New directive in lib/prompts.js (~8 lines): cap total output ~600 tokens; per finding 1-sentence claim + Reasoning ≤80 words + no code quotes >2 lines; omit reasoning that doesn't change verdict. Discipline, not hard cap — verbose review output costs the consuming repo on every review; brevity compounds across the org. +1 test asserts directive present. Composite-pin v0.6.15 → v0.6.16. 250 tests pass.
 
 ---
+## 2026-05-29 08:56 - PR #108 regen derived docs after rebase
+
+**Reasoning:** Post-rebase regen.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -55,6 +55,7 @@ clud-bug
 │   │   ├── feat__0.0.M.1-usage-dashboard.md
 │   │   ├── feat__0.0.R-model-routing-trivial.md
 │   │   ├── feat__0.0.W-workflow-pr-skip.md
+│   │   ├── feat__0.0.X-output-token-directive.md
 │   │   ├── feat__0.A.1-extract-prompts.md
 │   │   ├── feat__0.A.10-incremental-diff-review.md
 │   │   ├── feat__0.A.11-fix-self-update-yaml-literal.md
@@ -143,12 +144,18 @@ clud-bug
 │   ├── workflow-ts.yml.tmpl
 │   └── workflow.yml.tmpl
 ├── test
+│   ├── golden
+│   │   ├── byte-budget.json
+│   │   ├── must-contain.json
+│   │   ├── must-not-contain.json
+│   │   └── README.md
 │   ├── agents-md.test.js
 │   ├── audit.test.js
 │   ├── branch-protection.test.js
 │   ├── cli.test.js
 │   ├── detect.test.js
 │   ├── edit-workflow.test.js
+│   ├── prompts.eval.test.js
 │   ├── prompts.test.js
 │   ├── release-discipline.test.js
 │   ├── render.test.js

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,8 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-29** — PR #108 regen derived docs after rebase *(feat/0.0.X-output-token-directive)* — [decisions-branches/feat__0.0.X-output-token-directive.md](decisions-branches/feat__0.0.X-output-token-directive.md)
+- **2026-05-29** — v0.6.16: output-token brevity directive in cached prompt (Phase 0.5 / 0.0.X) *(feat/0.0.X-output-token-directive)* — [decisions-branches/feat__0.0.X-output-token-directive.md](decisions-branches/feat__0.0.X-output-token-directive.md)
 - **2026-05-29** — PR #106: regen derived docs after rebase *(chore/agents-md-import)* — [decisions-branches/chore__agents-md-import.md](decisions-branches/chore__agents-md-import.md)
 - **2026-05-29** — v0.6.15: model routing for trivial PRs — Haiku for dep bumps (Phase 0.5 / 0.0.R) *(feat/0.0.R-model-routing-trivial)* — [decisions-branches/feat__0.0.R-model-routing-trivial.md](decisions-branches/feat__0.0.R-model-routing-trivial.md)
 - **2026-05-29** — chore: @AGENTS.md import in CLAUDE.md (Q4 refinement / 0.0.I) *(chore/agents-md-import)* — [decisions-branches/chore__agents-md-import.md](decisions-branches/chore__agents-md-import.md)

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -151,6 +151,16 @@ At the end of every review, append a single-line footer:
 If you genuinely cited none, list "[none]" and explain why no
 installed skill applied to this diff.
 
+Output-token budget (v0.6.16 / 0.0.X):
+Keep total output under ~600 tokens. Per finding:
+  - One-sentence claim
+  - <details>Reasoning</details> ≤ 80 words
+  - No code quotes > 2 lines
+  - Omit reasoning details that don't change the verdict
+This isn't a hard cap — the SDK doesn't expose max_tokens — but a
+discipline. Verbose output costs the consuming repo on every review;
+brevity compounds across the org.
+
 Incremental-diff handshake (v0.6.10+) — emit the SHA marker:
 At the very end of the summary comment (after the Skills-referenced
 footer, on its own line), append the HTML marker that the next

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -156,6 +156,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.15
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.16
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -156,6 +156,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.15
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.16
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -247,6 +247,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.15
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.16
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/prompts.test.js
+++ b/test/prompts.test.js
@@ -413,6 +413,21 @@ test('all 3 rendered workflow templates use --model ${{ needs.paths-check.output
   }
 });
 
+// --- 0.0.X (v0.6.16): output-token brevity directive ---
+// The Claude Code CLI doesn't expose max_tokens (the SDK is agent-shaped,
+// not single-call). Workaround: an explicit brevity instruction in the
+// cached system prompt appendix. The directive lives in lib/prompts.js
+// (the canonical source for the appendix) so caching covers it.
+
+test('reviewPrompt: includes output-token brevity directive (v0.6.16 / 0.0.X)', () => {
+  const out = reviewPrompt({ projectDescription: 'p' });
+  // Core directive: ~600 token cap.
+  assert.match(out, /Keep total output under ~600 tokens/);
+  // Per-finding caps that drive the budget.
+  assert.match(out, /Reasoning.*≤ 80 words/);
+  assert.match(out, /No code quotes > 2 lines/);
+});
+
 // --- 0.0.R (v0.6.15): model routing for trivial PRs ---
 
 test('paths-check exposes model output AND defaults to Sonnet', async () => {


### PR DESCRIPTION
## Summary

Tiny prompt addition. Per the May 2026 LLM token optimization guide (§ 6), `max_tokens` should be capped per call type — but the Claude Code CLI doesn't expose it (SDK is agent-shaped, not single-call). Workaround: an explicit brevity instruction inside the **cached** system-prompt appendix (so the budget covers it).

## What changed

`lib/prompts.js` — new directive tells Claude:

- Keep total output under ~600 tokens
- Per finding: one-sentence claim + `<details>` reasoning ≤ 80 words
- No code quotes > 2 lines
- Omit reasoning details that don't change the verdict

Discipline, not a hard cap. Verbose review output costs the consuming repo on every review; brevity compounds across the org.

## Test plan

- [x] `npm test` — 250 pass (+1 new).
- [x] composite-pin v0.6.15 → v0.6.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)