### PR TITLE
feat(v0.6.17): golden-set regression gate for review prompt (Phase 0.5 / 0.0.E)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.16
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.17
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.17] — 2026-05-29
+
+### Added — golden-set regression gate for the review prompt (Phase 0.5 / 0.0.E)
+
+Cheap, deterministic CI gate for the rendered review prompt. **Gates
+0.0.P (prompt trim) and 0.0.O (JSON schema output) — both ship next
+under this guard.** Three categories of structural check, all
+runnable on every PR without LLM execution:
+
+1. **`must-contain`** — instruction phrases the prompt MUST include
+   (17 entries today: severity tiers, comment format, budgets,
+   incremental-diff handshake, brevity directive, FIX-PUSH FLOW, etc.).
+   Catches over-aggressive trims dropping load-bearing instructions.
+2. **`must-not-contain`** — anti-pattern filler from the May 2026
+   LLM token optimization guide § 6 ("Please make sure to…",
+   "I would like you to…", etc.). Locks in cleanups against
+   regression.
+3. **`byte-budget`** — UTF-8 byte and line caps on the rendered
+   prompt. 16 KB / 360 lines today, with documented headroom.
+   Catches the case where a trim PR cuts in one place but adds
+   bytes elsewhere.
+
+### What this gate does NOT test
+
+Live LLM behavior. That's expensive for every-PR CI; lives in a
+separate manual `clud-bug eval --live` flow (future). The structural
+check is enough to safely ship 0.0.P + 0.0.O.
+
+### Updating the golden set
+
+See `test/golden/README.md`. Add `must-contain` entries when shipping
+new load-bearing instructions; add `must-not-contain` entries when
+finding new filler to ban; bump `byte-budget` after major prompt
+structural change with a CHANGELOG note explaining why.
+
+### Net diff
+
+`test/golden/` NEW (4 fixtures + README). `test/prompts.eval.test.js`
+NEW (~120 lines, 6 tests). Composite-pin v0.6.16 → v0.6.17.
+
 ## [0.6.16] — 2026-05-29
 
 ### Added — output-token brevity directive (Phase 0.5 / 0.0.X)

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -76,6 +76,9 @@ Commands:
                         rate, 30-day rolling \$/LOC trend, per-repo/per-model
                         distributions, and outliers (> 2x org median).
                         Use --pr / --repo / --since / --limit / --json to filter.
+  eval                  Run the golden-set regression gate against the rendered review
+                        prompt (must-contain / must-not-contain / byte-budget). Same as
+                        \`node --test test/prompts.eval.test.js\` but works from any cwd.
 
 Options:
   --offline             Skip skills.sh; pin only the bundled baseline specimens.
@@ -126,10 +129,23 @@ async function main() {
     case 'update':  return runUpdateCmd(args);
     case 'edit-workflow': return runEditWorkflow(args);
     case 'usage':   return runUsage(args);
+    case 'eval':    return runEval(args);
     default:
       process.stderr.write(`Unknown command: ${cmd || '(none)'}\n\n${HELP}`);
       process.exit(2);
   }
+}
+
+// 0.0.E (v0.6.17): thin wrapper around the golden-set test file. Devs
+// who follow the README invoke `clud-bug eval` — this routes to the
+// same `node --test` runner CI uses, so dev and CI verdicts match.
+async function runEval(_args) {
+  const result = spawnSync(
+    'node',
+    ['--test', join(PKG_ROOT, 'test/prompts.eval.test.js')],
+    { stdio: 'inherit' },
+  );
+  process.exit(result.status ?? 1);
 }
 
 async function runInit(args) {

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -129,7 +129,7 @@ async function main() {
     case 'update':  return runUpdateCmd(args);
     case 'edit-workflow': return runEditWorkflow(args);
     case 'usage':   return runUsage(args);
-    case 'eval':    return runEval(args);
+    case 'eval':    return runEval();
     default:
       process.stderr.write(`Unknown command: ${cmd || '(none)'}\n\n${HELP}`);
       process.exit(2);
@@ -139,7 +139,12 @@ async function main() {
 // 0.0.E (v0.6.17): thin wrapper around the golden-set test file. Devs
 // who follow the README invoke `clud-bug eval` — this routes to the
 // same `node --test` runner CI uses, so dev and CI verdicts match.
-async function runEval(_args) {
+//
+// Dev-only: runs against the prompt bundled in PKG_ROOT (the cloned
+// clud-bug repo). `test/` is intentionally not in package.json `files`,
+// so invoking this from a globally installed copy will ENOENT. No args
+// supported yet — the README does not advertise any.
+async function runEval() {
   const result = spawnSync(
     'node',
     ['--test', join(PKG_ROOT, 'test/prompts.eval.test.js')],

--- a/docs/decisions-branches/feat__0.0.E-golden-eval-harness.md
+++ b/docs/decisions-branches/feat__0.0.E-golden-eval-harness.md
@@ -1,0 +1,8 @@
+## 2026-05-29 09:01 - v0.6.17: golden-set regression gate for review prompt (Phase 0.5 / 0.0.E)
+
+**Reasoning:** Gating PR for 0.0.P (prompt trim) and 0.0.O (JSON schema enforcement) — both ship next under this guard. Three categories of structural check on the rendered prompt, all CI-runnable without LLM execution: (1) must-contain — 17 instruction phrases that load-bearing CI relies on (severity tiers, comment format, MAX_*_BYTES budgets, last-reviewed-sha handshake, git merge-base ancestor check, brevity directive, FIX-PUSH FLOW, resolveReviewThread, Skills referenced footer); (2) must-not-contain — 8 anti-pattern filler phrases from LLM token optimization guide §6 ('Please make sure to', 'I would like you to', etc.); (3) byte-budget — 16 KB / 360 lines caps with documented headroom. New test/golden/ directory with 3 JSON fixtures + README explaining the format and when to update. New test/prompts.eval.test.js with 6 tests. Live LLM behavior NOT tested — too expensive for every-PR CI; lives in future 'clud-bug eval --live' flow. The structural check is enough to safely ship 0.0.P + 0.0.O. Composite-pin bumped v0.6.16 → v0.6.17. 256 tests pass.
+
+**Implications:**
+- Adding must-contain entries when shipping new load-bearing instructions; adding must-not-contain when finding new filler patterns; bumping byte-budget after major structural changes with CHANGELOG notes. 0.0.P (prompt trim) and 0.0.O (--json-schema) PRs unlock once this lands.
+
+---

--- a/docs/decisions-branches/feat__0.0.E-golden-eval-harness.md
+++ b/docs/decisions-branches/feat__0.0.E-golden-eval-harness.md
@@ -6,3 +6,8 @@
 - Adding must-contain entries when shipping new load-bearing instructions; adding must-not-contain when finding new filler patterns; bumping byte-budget after major structural changes with CHANGELOG notes. 0.0.P (prompt trim) and 0.0.O (--json-schema) PRs unlock once this lands.
 
 ---
+## 2026-05-29 09:12 - PR #109 fix: wire up clud-bug eval subcommand (was referenced in README but didn't exist)
+
+**Reasoning:** 🟡 nit from clud-bug review: test/golden/README.md mentioned 'node bin/clud-bug.js eval' and 'clud-bug eval' as runnable commands but the subcommand dispatch didn't include 'eval'. Two options offered: drop the doc references, or wire it up. Wired it up — small runEval() function shells to 'node --test test/prompts.eval.test.js' via spawnSync so dev invocations match CI exactly. PKG_ROOT-relative path means it works from any cwd. Added eval to HELP. Smoke-tested: 'node bin/clud-bug.js eval' runs all 6 golden tests. 256 pass.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-29** — v0.6.17: golden-set regression gate for review prompt (Phase 0.5 / 0.0.E) *(feat/0.0.E-golden-eval-harness)* — [decisions-branches/feat__0.0.E-golden-eval-harness.md](decisions-branches/feat__0.0.E-golden-eval-harness.md)
 - **2026-05-29** — PR #108 regen derived docs after rebase *(feat/0.0.X-output-token-directive)* — [decisions-branches/feat__0.0.X-output-token-directive.md](decisions-branches/feat__0.0.X-output-token-directive.md)
 - **2026-05-29** — v0.6.16: output-token brevity directive in cached prompt (Phase 0.5 / 0.0.X) *(feat/0.0.X-output-token-directive)* — [decisions-branches/feat__0.0.X-output-token-directive.md](decisions-branches/feat__0.0.X-output-token-directive.md)
 - **2026-05-29** — PR #106: regen derived docs after rebase *(chore/agents-md-import)* — [decisions-branches/chore__agents-md-import.md](decisions-branches/chore__agents-md-import.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-29** — PR #109 fix: wire up clud-bug eval subcommand (was referenced in README but didn't exist) *(feat/0.0.E-golden-eval-harness)* — [decisions-branches/feat__0.0.E-golden-eval-harness.md](decisions-branches/feat__0.0.E-golden-eval-harness.md)
 - **2026-05-29** — v0.6.17: golden-set regression gate for review prompt (Phase 0.5 / 0.0.E) *(feat/0.0.E-golden-eval-harness)* — [decisions-branches/feat__0.0.E-golden-eval-harness.md](decisions-branches/feat__0.0.E-golden-eval-harness.md)
 - **2026-05-29** — PR #108 regen derived docs after rebase *(feat/0.0.X-output-token-directive)* — [decisions-branches/feat__0.0.X-output-token-directive.md](decisions-branches/feat__0.0.X-output-token-directive.md)
 - **2026-05-29** — v0.6.16: output-token brevity directive in cached prompt (Phase 0.5 / 0.0.X) *(feat/0.0.X-output-token-directive)* — [decisions-branches/feat__0.0.X-output-token-directive.md](decisions-branches/feat__0.0.X-output-token-directive.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -156,6 +156,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.16
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.17
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -156,6 +156,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.16
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.17
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -247,6 +247,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.16
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.17
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/golden/README.md
+++ b/test/golden/README.md
@@ -24,15 +24,20 @@ Three categories of regression that no individual test would catch:
 ## Running
 
 ```bash
-# Single-shot from the repo root (also runs in CI via `npm test`):
+# From the clud-bug repo root (also runs in CI via `npm test`):
 node --test test/prompts.eval.test.js
 
-# Or via the new subcommand for richer output:
+# Via the subcommand — same runner, works from anywhere inside the
+# clud-bug repo:
 node bin/clud-bug.js eval
-
-# Or against an arbitrary repo:
-clud-bug eval --repo path/to/clud-bug
 ```
+
+`clud-bug eval` is a **dev-only** command. It runs the gate against
+the review prompt bundled in this repo. `test/` is not in the npm
+`files` array, so an end-user invoking `clud-bug eval` from a globally
+installed copy would hit `ENOENT` — intentional. If you maintain your
+own prompts and want similar regression protection, fork this fixture
+structure into your own repo.
 
 ## When to update the golden set
 

--- a/test/golden/README.md
+++ b/test/golden/README.md
@@ -1,0 +1,61 @@
+# Golden set — review-prompt regression gate
+
+> 0.0.E (v0.6.17). Gates 0.0.P (prompt trim) and 0.0.O (JSON schema
+> output). Cheap, deterministic, runs in CI on every PR.
+
+## What it tests
+
+Three categories of regression that no individual test would catch:
+
+1. **`must-contain.json`** — instruction phrases the review prompt
+   MUST include. If 0.0.P over-aggressively trims and drops one of
+   these, CI fails. Each entry has a `pattern` (regex), a `why`
+   (rationale for keeping), and a `category` (rough grouping).
+
+2. **`must-not-contain.json`** — anti-pattern phrases (filler from
+   the LLM token optimization guide § 6) that should NEVER be
+   re-added. Catches accidental regression where polite-but-bloated
+   prose creeps back into the prompt.
+
+3. **`byte-budget.json`** — size caps. The whole prompt + per-section
+   targets. Catches the case where 0.0.P "trims" but actually adds
+   bytes elsewhere.
+
+## Running
+
+```bash
+# Single-shot from the repo root (also runs in CI via `npm test`):
+node --test test/prompts.eval.test.js
+
+# Or via the new subcommand for richer output:
+node bin/clud-bug.js eval
+
+# Or against an arbitrary repo:
+clud-bug eval --repo path/to/clud-bug
+```
+
+## When to update the golden set
+
+- **Adding a must-contain** when you ship a new prompt instruction
+  that's load-bearing (e.g., when 0.0.O lands and the prompt needs a
+  new schema-output instruction).
+- **Adding a must-not-contain** when you find a filler pattern that
+  bloated the prompt before — locks in the cleanup.
+- **Updating byte-budget** when a major prompt structural change ships
+  (with a CHANGELOG note explaining the change).
+
+## What this gate does NOT test
+
+- It does NOT run the LLM. That's too expensive for every-PR CI.
+  Quality testing against real model outputs lives in a separate
+  layer (manual `clud-bug eval --live` invocation, future).
+- It does NOT test the renderer/post-processor. That ships with
+  0.0.O and gets its own tests.
+- It does NOT replace clud-bug-review itself. The gate is a
+  structural check; clud-bug-review is the behavioral check on
+  each PR.
+
+## Fixture format
+
+See `must-contain.json`, `must-not-contain.json`, `byte-budget.json`
+for the JSON schema in use.

--- a/test/golden/byte-budget.json
+++ b/test/golden/byte-budget.json
@@ -1,0 +1,11 @@
+{
+  "$schema-comment": "Size caps for the rendered prompt. UTF-8 byte counts. The CI gate fails if the actual size exceeds the cap. Caps are intentionally close to current size so 0.0.P trim work has headroom without inviting regression.",
+  "max_prompt_bytes": {
+    "value": 16000,
+    "why": "Current rendered prompt is ~11–12 KB (the appendix from reviewPrompt()). Cap at 16 KB leaves ~30% headroom for new instructions (e.g., 0.0.O schema directive). If exceeded, audit before bumping the cap."
+  },
+  "max_prompt_lines": {
+    "value": 360,
+    "why": "Current is ~329 lines (post-v0.6.16 brevity directive). Cap leaves ~30 lines headroom for new instructions (e.g., 0.0.O schema directive). Bump after major prompt structural change with a CHANGELOG note."
+  }
+}

--- a/test/golden/must-contain.json
+++ b/test/golden/must-contain.json
@@ -1,0 +1,90 @@
+{
+  "$schema-comment": "Regex patterns the rendered review prompt MUST contain. Each entry: { pattern: string, why: string, category: string }. The pattern is a JS regex source (no /.../ delimiters; flags are 'u' by default for emoji literals).",
+  "entries": [
+    {
+      "pattern": "critical-issues-only",
+      "why": "Without the critical-issues-only routing, the prompt invites style-nit churn and dilutes the strict-mode signal.",
+      "category": "discipline"
+    },
+    {
+      "pattern": "evidence-based-review",
+      "why": "Every finding must cite file:line evidence; this skill name is what the prompt references in the example.",
+      "category": "discipline"
+    },
+    {
+      "pattern": "## 🐛 Clud Bug review",
+      "why": "The strict-mode gate greps this exact H2 header. Without it, the gate can't classify and falls open.",
+      "category": "strict-mode-contract"
+    },
+    {
+      "pattern": "Found: N 🔴 / N 🟡 / N 🟣",
+      "why": "Stats-header shape (v0.6.5). Drives the fast-triage UX and the comment compression for re-reviews.",
+      "category": "comment-format"
+    },
+    {
+      "pattern": "<details><summary>Reasoning</summary>",
+      "why": "Per-finding reasoning lives inside collapsibles (v0.6.5). Re-reviews skip the body; humans expand.",
+      "category": "comment-format"
+    },
+    {
+      "pattern": "🔴 important",
+      "why": "Severity tier (v0.6.5). Removing this would orphan the stats-header grading.",
+      "category": "comment-format"
+    },
+    {
+      "pattern": "🟡 nit",
+      "why": "Severity tier (v0.6.5).",
+      "category": "comment-format"
+    },
+    {
+      "pattern": "🟣 pre-existing",
+      "why": "Severity tier (v0.6.5). Critical for keeping pre-existing issues from re-firing on every review.",
+      "category": "comment-format"
+    },
+    {
+      "pattern": "MAX_DIFF_BYTES",
+      "why": "Per-section budget (v0.6.4). The prompt teaches Claude to cap with head -c.",
+      "category": "budgets"
+    },
+    {
+      "pattern": "MAX_COMMENT_BYTES",
+      "why": "Per-section budget (v0.6.4).",
+      "category": "budgets"
+    },
+    {
+      "pattern": "MAX_SKILL_BYTES",
+      "why": "Per-section budget (v0.6.4).",
+      "category": "budgets"
+    },
+    {
+      "pattern": "last-reviewed-sha",
+      "why": "Incremental-diff handshake (v0.6.10). Without the marker emission instruction, every re-review reverts to full gh pr diff.",
+      "category": "incremental-diff"
+    },
+    {
+      "pattern": "git merge-base --is-ancestor",
+      "why": "The ancestor-check fallback for force-push/rebase (v0.6.10).",
+      "category": "incremental-diff"
+    },
+    {
+      "pattern": "Keep total output under ~600 tokens",
+      "why": "Brevity directive (v0.6.16 / 0.0.X). The output-side cap that compensates for max_tokens being unavailable in Claude Code CLI.",
+      "category": "brevity"
+    },
+    {
+      "pattern": "FIX-PUSH FLOW",
+      "why": "Section that teaches Claude to resolve prior threads. Without it, the resolved-from-prior counter is always 0 and the loop never closes.",
+      "category": "discipline"
+    },
+    {
+      "pattern": "resolveReviewThread",
+      "why": "The actual GraphQL mutation Claude must call to close prior threads.",
+      "category": "discipline"
+    },
+    {
+      "pattern": "Skills referenced:",
+      "why": "Per-review footer (v0.6.5). Anti-dilution layer — every loaded skill must be acknowledged.",
+      "category": "comment-format"
+    }
+  ]
+}

--- a/test/golden/must-not-contain.json
+++ b/test/golden/must-not-contain.json
@@ -1,0 +1,45 @@
+{
+  "$schema-comment": "Anti-pattern phrases (LLM token optimization guide § 6) that should NEVER appear in the rendered prompt. Catches regression where polite filler creeps back in. The 'i' flag lets the patterns be case-insensitive — filler doesn't care about capitalization.",
+  "entries": [
+    {
+      "pattern": "Please make sure to",
+      "why": "Pure filler per the guide. The imperative form ('Make sure to' or just direct statement) is shorter and equally clear.",
+      "category": "filler"
+    },
+    {
+      "pattern": "Please ensure that",
+      "why": "Filler — use imperative.",
+      "category": "filler"
+    },
+    {
+      "pattern": "I would like you to",
+      "why": "Filler — the instruction itself is the request.",
+      "category": "filler"
+    },
+    {
+      "pattern": "It is important that you",
+      "why": "Filler — just state the rule directly.",
+      "category": "filler"
+    },
+    {
+      "pattern": "As an AI language model",
+      "why": "Never appears in instructions and should not be re-added.",
+      "category": "filler"
+    },
+    {
+      "pattern": "Certainly! I'd be happy to",
+      "why": "Output-side conversational wrapping that doesn't belong in instructions.",
+      "category": "filler"
+    },
+    {
+      "pattern": "Please be aware that",
+      "why": "Filler — direct statement instead.",
+      "category": "filler"
+    },
+    {
+      "pattern": "I think it would be a good idea to",
+      "why": "Filler — the instruction itself is the request; never wrap in opinion.",
+      "category": "filler"
+    }
+  ]
+}

--- a/test/prompts.eval.test.js
+++ b/test/prompts.eval.test.js
@@ -1,0 +1,102 @@
+// 0.0.E (v0.6.17): golden-set regression gate for the review prompt.
+//
+// Runs three categories of structural checks against the rendered prompt:
+//
+//   1. must-contain  — instruction phrases that load-bearing CI relies on
+//   2. must-not-contain — anti-pattern filler that the LLM token guide § 6 flags
+//   3. byte-budget  — size caps so future trims have headroom, not slop
+//
+// Gates 0.0.P (prompt trim) and 0.0.O (schema enforcement). Cheap,
+// deterministic, runs on every PR. See test/golden/README.md for the
+// fixture format + when to update.
+
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { reviewPrompt } from '../lib/prompts.js';
+
+const GOLDEN = join(import.meta.dirname, 'golden');
+
+async function loadFixture(name) {
+  const raw = await readFile(join(GOLDEN, name), 'utf8');
+  return JSON.parse(raw);
+}
+
+const PROMPT_ARGS = { projectDescription: 'p' };
+
+test('golden: must-contain — every required instruction phrase is in the prompt', async () => {
+  const fixture = await loadFixture('must-contain.json');
+  const prompt = reviewPrompt(PROMPT_ARGS);
+  const missing = [];
+  for (const entry of fixture.entries) {
+    const re = new RegExp(entry.pattern, 'u');
+    if (!re.test(prompt)) {
+      missing.push(`  • ${entry.pattern} (${entry.category}) — ${entry.why}`);
+    }
+  }
+  assert.equal(
+    missing.length, 0,
+    `\n${missing.length} required instruction(s) missing from the rendered prompt:\n${missing.join('\n')}\n\nAdd them back to lib/prompts.js OR remove the entry from test/golden/must-contain.json if intentionally dropped (with a CHANGELOG note).`,
+  );
+});
+
+test('golden: must-not-contain — no filler anti-patterns are in the prompt', async () => {
+  const fixture = await loadFixture('must-not-contain.json');
+  const prompt = reviewPrompt(PROMPT_ARGS);
+  const present = [];
+  for (const entry of fixture.entries) {
+    const re = new RegExp(entry.pattern, 'i');
+    if (re.test(prompt)) {
+      present.push(`  • ${entry.pattern} (${entry.category}) — ${entry.why}`);
+    }
+  }
+  assert.equal(
+    present.length, 0,
+    `\n${present.length} anti-pattern phrase(s) leaked into the rendered prompt:\n${present.join('\n')}\n\nRemove from lib/prompts.js. These are filler per the LLM token optimization guide § 6.`,
+  );
+});
+
+test('golden: byte-budget — rendered prompt is under the size cap', async () => {
+  const fixture = await loadFixture('byte-budget.json');
+  const prompt = reviewPrompt(PROMPT_ARGS);
+  const actualBytes = Buffer.byteLength(prompt, 'utf8');
+  const capBytes = fixture.max_prompt_bytes.value;
+  assert.ok(
+    actualBytes <= capBytes,
+    `Rendered prompt is ${actualBytes} bytes, exceeds cap of ${capBytes} bytes. ` +
+    `${fixture.max_prompt_bytes.why} If the growth is intentional, bump the cap with a CHANGELOG entry explaining why.`,
+  );
+});
+
+test('golden: byte-budget — rendered prompt is under the line cap', async () => {
+  const fixture = await loadFixture('byte-budget.json');
+  const prompt = reviewPrompt(PROMPT_ARGS);
+  const actualLines = prompt.split('\n').length;
+  const capLines = fixture.max_prompt_lines.value;
+  assert.ok(
+    actualLines <= capLines,
+    `Rendered prompt is ${actualLines} lines, exceeds cap of ${capLines} lines. ` +
+    `${fixture.max_prompt_lines.why}`,
+  );
+});
+
+test('golden: fixture sanity — each must-contain entry has why + category', async () => {
+  // Catches malformed fixtures.
+  const fixture = await loadFixture('must-contain.json');
+  for (const entry of fixture.entries) {
+    assert.equal(typeof entry.pattern, 'string', 'pattern must be a string');
+    assert.equal(typeof entry.why, 'string', `${entry.pattern}: why must be a string`);
+    assert.equal(typeof entry.category, 'string', `${entry.pattern}: category must be a string`);
+    assert.ok(entry.why.length >= 10, `${entry.pattern}: why must be substantive (>=10 chars)`);
+  }
+});
+
+test('golden: fixture sanity — each must-not-contain entry has why + category', async () => {
+  const fixture = await loadFixture('must-not-contain.json');
+  for (const entry of fixture.entries) {
+    assert.equal(typeof entry.pattern, 'string');
+    assert.ok(entry.why.length >= 10);
+    assert.equal(typeof entry.category, 'string');
+  }
+});


### PR DESCRIPTION
## Summary

Cheap, deterministic CI gate for the rendered review prompt. **Gates 0.0.P (prompt trim) and 0.0.O (JSON schema output)** — both ship next under this guard.

Three categories of structural check, all runnable on every PR without LLM execution:

| Category | What it catches |
|---|---|
| **must-contain** (17 entries) | Over-aggressive trims dropping load-bearing instructions (severity tiers, MAX_*_BYTES, FIX-PUSH FLOW, brevity directive, etc.) |
| **must-not-contain** (8 entries) | Filler regression from the LLM token guide § 6 ("Please make sure to…", "I would like you to…", etc.) |
| **byte-budget** (16 KB / 360 lines) | "Trim" PRs that cut in one place but add bytes elsewhere |

## What this gate does NOT test

Live LLM behavior. That's expensive for every-PR CI; lives in a separate manual `clud-bug eval --live` flow (future). The structural check is enough to safely ship 0.0.P + 0.0.O.

## Updating the golden set

See `test/golden/README.md`. Add `must-contain` when shipping new load-bearing instructions; add `must-not-contain` when finding new filler patterns; bump `byte-budget` after major structural changes with a CHANGELOG note.

## Test plan

- [x] `npm test` — 256 pass (+6 new golden tests).
- [x] Composite-pin v0.6.16 → v0.6.17 (release-discipline test enforces lock-step).
- [x] Smoke-tested: hand-removed a `must-contain` phrase, harness caught it with actionable message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)