### PR TITLE
feat(v0.6.18): RTK-inspired tee-hint on cap fire (Phase 0.5 / 0.0.T, clud-bug side)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.17
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.18
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.18] — 2026-05-29
+
+### Added — RTK-inspired tee-hint on cap fire (Phase 0.5 / 0.0.T, clud-bug side)
+
+The review prompt now teaches the LLM to treat any `head -c "$MAX_*"`
+cap fire as an auditable event, not a silent confidence loss. Two
+required behaviours:
+
+1. **Targeted re-fetch with doubled cap** on the specific truncated
+   section. The prompt names the section that fired (diff / skill /
+   comments), the file or query affected, and the exact `head -c
+   $((MAX_* * 2))` re-fetch command.
+2. **`### Diagnostics` block** at the bottom of the summary comment
+   listing each cap that fired, the section affected, and the
+   re-fetch outcome (recovered / still truncated / deferred).
+
+This is the producer-side half of RTK's `force_tee_tail_hint`
+(`src/cmds/python/ruff_cmd.rs:214-219`): never elide without naming
+what was elided. Pattern lifted from MIT-licensed code; RTK is not a
+dependency.
+
+### Golden gate updates
+
+`test/golden/must-contain.json` adds three entries to lock in the new
+section:
+
+- `Tee-hint on cap fire`
+- `Attempt ONE targeted re-fetch with double the cap`
+- `### Diagnostics`
+
+A future 0.0.P trim that drops any of these fails the gate, exactly
+as designed in 0.0.E.
+
+### Golden-budget bump
+
+`test/golden/byte-budget.json`:
+
+- `max_prompt_bytes`: 16000 → 18500 (rendered prompt now 17080 bytes;
+  0.0.T added ~1.1 KB).
+- `max_prompt_lines`: 360 → 380 (rendered prompt now 362 lines).
+
+Both bumps are intentional and the new caps still leave headroom for
+0.0.O. Each `why` field in `byte-budget.json` is updated to point at
+this CHANGELOG entry for the bump rationale.
+
+### Composite pin
+
+v0.6.17 → v0.6.18 across `templates/workflow{,-py,-ts}.yml.tmpl` and
+`.github/actions/strict-mode-gate/action.yml` header docs.
+
 ## [0.6.17] — 2026-05-29
 
 ### Added — golden-set regression gate for the review prompt (Phase 0.5 / 0.0.E)

--- a/docs/decisions-branches/feat__0.0.T-rtk-inspired-clud-bug.md
+++ b/docs/decisions-branches/feat__0.0.T-rtk-inspired-clud-bug.md
@@ -1,0 +1,11 @@
+## 2026-05-29 09:34 - 0.0.T (clud-bug side): RTK-inspired tee-hint on cap fire — producer-side audit trail
+
+**Reasoning:** lib/prompts.js: previously the prompt reactively asked the LLM to notice and request truncated content (line 122-123 pre-change: 'If you genuinely cannot review safely without the elided content, say so plainly'). RTK's force_tee_tail_hint (src/cmds/python/ruff_cmd.rs:214-219) is producer-side: when the cap fires, the producer NAMES what was elided. The patch ports that energy to our context — on any observed cap fire, the prompt now requires (1) one targeted re-fetch with doubled cap on the specific section and (2) a ### Diagnostics block in the summary listing each cap that fired + outcome. This makes truncation auditable instead of confidence-loss-shaped. Golden gate (test/golden/must-contain.json) locks the new section against future 0.0.P trim — 3 new entries (Tee-hint on cap fire, Attempt ONE targeted re-fetch, ### Diagnostics).
+
+**Alternatives considered:** Leaving the prompt reactive (existing behavior) means the LLM might omit content silently if it doesn't notice the cut — exactly the Q6 silent-drop pattern we are eliminating elsewhere., A separate producer-side wrapper around the head -c invocation (RTK's actual force_tee_tail_hint mechanic) would have to intercept the LLM's bash command output and inject the tee-hint. Not feasible without changes to claude-code-action; instruction-level is the right surface.
+
+**Implications:**
+- Budget cap bumps required: max_prompt_bytes 16000 → 18500 (rendered 17080, +1.1 KB for new section); max_prompt_lines 360 → 380 (rendered 362, +33 lines). Both intentional with why-field rationale and CHANGELOG entry pointing here. Leaves ~1.4 KB headroom for the upcoming 0.0.O JSON schema directive.
+- Composite-pin lock-step 0.6.17 → 0.6.18 in templates/workflow{,-py,-ts}.yml.tmpl + .github/actions/strict-mode-gate/action.yml header docs.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -52,6 +52,7 @@ clud-bug
 │   │   ├── ci__npm-publish-trusted.md
 │   │   ├── ci__unify-publish-and-promote.md
 │   │   ├── docs__skill-first-marketing-bb4.md
+│   │   ├── feat__0.0.E-golden-eval-harness.md
 │   │   ├── feat__0.0.M.1-usage-dashboard.md
 │   │   ├── feat__0.0.R-model-routing-trivial.md
 │   │   ├── feat__0.0.W-workflow-pr-skip.md

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-29** — 0.0.T (clud-bug side): RTK-inspired tee-hint on cap fire — producer-side audit trail *(feat/0.0.T-rtk-inspired-clud-bug)* — [decisions-branches/feat__0.0.T-rtk-inspired-clud-bug.md](decisions-branches/feat__0.0.T-rtk-inspired-clud-bug.md)
 - **2026-05-29** — PR #109 fix: wire up clud-bug eval subcommand (was referenced in README but didn't exist) *(feat/0.0.E-golden-eval-harness)* — [decisions-branches/feat__0.0.E-golden-eval-harness.md](decisions-branches/feat__0.0.E-golden-eval-harness.md)
 - **2026-05-29** — v0.6.17: golden-set regression gate for review prompt (Phase 0.5 / 0.0.E) *(feat/0.0.E-golden-eval-harness)* — [decisions-branches/feat__0.0.E-golden-eval-harness.md](decisions-branches/feat__0.0.E-golden-eval-harness.md)
 - **2026-05-29** — PR #108 regen derived docs after rebase *(feat/0.0.X-output-token-directive)* — [decisions-branches/feat__0.0.X-output-token-directive.md](decisions-branches/feat__0.0.X-output-token-directive.md)

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -129,12 +129,16 @@ two things, in order:
      head -c $((MAX_DIFF_BYTES * 2))\`. For skills: re-fetch the
      specific \`.claude/skills/<name>/SKILL.md\` that hit the cap with
      \`head -c $((MAX_SKILL_BYTES * 2))\` — name the file. For
-     comments: re-fetch with \`per_page=40\` instead of 20.
+     comments: re-fetch with \`per_page=40\` AND \`head -c
+     $((MAX_COMMENT_BYTES * 2))\` — doubling per_page alone is wasted
+     work when the original truncation was byte-bound.
 
-  2. Add a \`### Diagnostics\` block at the bottom of the summary
-     comment naming each cap that fired, the section affected, and the
-     outcome of the re-fetch (e.g. "still truncated", "recovered with
-     2x cap", "finding deferred — content beyond 2x").
+  2. Add a \`### Diagnostics\` block above the Skills-referenced
+     footer (the \`<!-- last-reviewed-sha: ... -->\` marker still goes
+     last on its own line — Diagnostics is not the last thing in the
+     comment). Each line names a cap that fired, the section affected,
+     and the outcome of the re-fetch (e.g. "still truncated",
+     "recovered with 2x cap", "finding deferred — content beyond 2x").
 
 This makes truncation an auditable event in the review trail instead
 of a silent confidence reduction. The pattern is the producer-side

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -119,8 +119,31 @@ size discipline on those fetches pays back directly.
     comments — the FIX-PUSH FLOW handles those via reviewThreads
     GraphQL instead.
 
-If you genuinely cannot review safely without the elided content,
-say so plainly in the summary comment instead of speculating.
+Tee-hint on cap fire (v0.6.18, RTK-inspired):
+When ANY \`head -c "$MAX_*"\` cap fires (last line cut mid-token, or
+\`wc -c\` on the captured output equals the cap exactly), you MUST do
+two things, in order:
+
+  1. Attempt ONE targeted re-fetch with double the cap on the specific
+     truncated section. Example for diff: \`gh pr diff "$PR_NUMBER" |
+     head -c $((MAX_DIFF_BYTES * 2))\`. For skills: re-fetch the
+     specific \`.claude/skills/<name>/SKILL.md\` that hit the cap with
+     \`head -c $((MAX_SKILL_BYTES * 2))\` — name the file. For
+     comments: re-fetch with \`per_page=40\` instead of 20.
+
+  2. Add a \`### Diagnostics\` block at the bottom of the summary
+     comment naming each cap that fired, the section affected, and the
+     outcome of the re-fetch (e.g. "still truncated", "recovered with
+     2x cap", "finding deferred — content beyond 2x").
+
+This makes truncation an auditable event in the review trail instead
+of a silent confidence reduction. The pattern is the producer-side
+half of RTK's \`force_tee_tail_hint\`: never elide without naming what
+was elided.
+
+If after the re-fetch you genuinely cannot review safely without the
+still-elided content, say so plainly in the summary comment instead
+of speculating.
 
 Skills are not background context — they are review rules with
 authority. Before flagging any finding, scan the loaded skills in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -156,6 +156,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.17
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.18
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -156,6 +156,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.17
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.18
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -247,6 +247,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.17
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.18
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/golden/byte-budget.json
+++ b/test/golden/byte-budget.json
@@ -1,11 +1,11 @@
 {
   "$schema-comment": "Size caps for the rendered prompt. UTF-8 byte counts. The CI gate fails if the actual size exceeds the cap. Caps are intentionally close to current size so 0.0.P trim work has headroom without inviting regression.",
   "max_prompt_bytes": {
-    "value": 16000,
-    "why": "Current rendered prompt is ~11–12 KB (the appendix from reviewPrompt()). Cap at 16 KB leaves ~30% headroom for new instructions (e.g., 0.0.O schema directive). If exceeded, audit before bumping the cap."
+    "value": 18500,
+    "why": "Current rendered prompt is ~17 KB post-0.0.T (the tee-hint + Diagnostics block added ~1.1 KB). Cap leaves ~1.4 KB headroom for 0.0.O schema directive (typically 200-400 bytes) plus margin. Bump from 16000 (pre-0.0.T) documented in CHANGELOG [0.6.18]. Audit before bumping again."
   },
   "max_prompt_lines": {
-    "value": 360,
-    "why": "Current is ~329 lines (post-v0.6.16 brevity directive). Cap leaves ~30 lines headroom for new instructions (e.g., 0.0.O schema directive). Bump after major prompt structural change with a CHANGELOG note."
+    "value": 380,
+    "why": "Current is ~362 lines post-0.0.T (tee-hint section added 33 lines). Cap leaves ~18 lines headroom for 0.0.O. Bump from 360 (pre-0.0.T) documented in CHANGELOG [0.6.18]."
   }
 }

--- a/test/golden/must-contain.json
+++ b/test/golden/must-contain.json
@@ -85,6 +85,21 @@
       "pattern": "Skills referenced:",
       "why": "Per-review footer (v0.6.5). Anti-dilution layer — every loaded skill must be acknowledged.",
       "category": "comment-format"
+    },
+    {
+      "pattern": "Tee-hint on cap fire",
+      "why": "0.0.T (v0.6.18). The RTK-inspired truncation-audit pattern. Without this section, the LLM falls back to silent confidence loss when caps fire.",
+      "category": "fail-safe"
+    },
+    {
+      "pattern": "Attempt ONE targeted re-fetch with double the cap",
+      "why": "0.0.T (v0.6.18). The actionable producer-side half — naming what was elided AND attempting recovery. Removing it would leave the diagnostic but no recovery path.",
+      "category": "fail-safe"
+    },
+    {
+      "pattern": "### Diagnostics",
+      "why": "0.0.T (v0.6.18). Surfaces cap-fire events as an auditable block in the summary comment. Removing it would let truncation become invisible again.",
+      "category": "fail-safe"
     }
   ]
 }


### PR DESCRIPTION
## Summary

clud-bug side of 0.0.T. Producer-side tee-hint pattern lifted from RTK's MIT-licensed `force_tee_tail_hint` — never elide without naming what was elided.

The logmind side of 0.0.T shipped as logmind#76 (parser warn-not-silent + atomic_io orphan cleanup).

## What changed

| File | Change |
|---|---|
| `lib/prompts.js` | New "Tee-hint on cap fire" section: on any `head -c` cap fire, attempt one re-fetch with doubled cap, then emit a `### Diagnostics` block in the summary naming the section + outcome |
| `test/golden/must-contain.json` | +3 entries locking the new patterns against 0.0.P trim regression |
| `test/golden/byte-budget.json` | Caps bumped (16000→18500 bytes, 360→380 lines) with `why` field updated. Each bump documented in CHANGELOG `[0.6.18]` |
| `package.json` + 3 templates + action.yml header | Composite-pin 0.6.17 → 0.6.18 |
| `docs/file-structure.md` | Derived-docs regen from #109's merge |

## Test plan

- [x] `npm test` — 256/256 pass.
- [ ] CI green.
- [ ] After merge: tag `v0.6.18` so consumers can pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)