### PR TITLE
feat(0.0.I.1): skip CLAUDE.md block install when @AGENTS.md import is present

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.18
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.19
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.19] — 2026-05-29
+
+### Changed — `clud-bug init` / `clud-bug update` skip CLAUDE.md (etc.) block install when `@AGENTS.md` import is present (Phase 0.5 / 0.0.I.1)
+
+Companion behaviour for the 0.0.I rollout. With `@AGENTS.md` eagerly
+imported at the top of consuming repos' CLAUDE.md (Q4 refinement
+landed in PR #106 + downstream rollout), the AGENTS.md clud-bug block
+becomes the canonical source and the same block in CLAUDE.md is
+eagerly-inlined duplicate content. This release:
+
+- **Skips block installation** in tool-stub files (`CLAUDE.md`,
+  `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules`,
+  `.windsurfrules`, `.clinerules`, `.continuerules`, and any
+  `.cursor/rules/*.md`) when the file already contains `@AGENTS.md`
+  at start-of-line.
+- **Removes any pre-existing block** in those files when the import
+  is present — migration path for repos installed under older
+  clud-bug versions.
+- **AGENTS.md is unaffected** — still the canonical source and always
+  receives the block.
+
+The detection is line-anchored: a prose mention like "See @AGENTS.md
+for rules" does NOT trigger the skip. Only the literal import
+directive (`@AGENTS.md` alone on its line) qualifies.
+
+### Tests
+
+`test/agents-md.test.js` adds 9 new tests covering: `hasAgentsMdImport`
+line-anchor edge cases, `removeBlock` idempotence + preserved
+surrounding content, skip-on-import for CLAUDE.md, stale-block cleanup
+on CLAUDE.md with import, back-compat install when no import,
+`.cursor/rules` walk respects the same rule. Suite: 265 pass, 0 fail.
+
+### Composite pin
+
+v0.6.18 → v0.6.19 across `templates/workflow{,-py,-ts}.yml.tmpl` and
+`.github/actions/strict-mode-gate/action.yml` header docs.
+
 ## [0.6.18] — 2026-05-29
 
 ### Added — RTK-inspired tee-hint on cap fire (Phase 0.5 / 0.0.T, clud-bug side)

--- a/docs/decisions-branches/feat__0.0.I.1-skip-block-with-import.md
+++ b/docs/decisions-branches/feat__0.0.I.1-skip-block-with-import.md
@@ -9,3 +9,11 @@
 - Test fixture: 9 new tests in test/agents-md.test.js covering hasAgentsMdImport line-anchor edge cases, removeBlock idempotence + preserving prose around the block, applyToRepo behavior for (a) skip block on CLAUDE.md with import, (b) clean up stale block on CLAUDE.md with import, (c) back-compat install on CLAUDE.md without import, (d) .cursor/rules walk respects the same rule.
 
 ---
+## 2026-05-29 09:46 - Release clud-bug v0.6.19 — 0.0.I.1 skip-block-when-import
+
+**Reasoning:** Version bump packaging commit for the 0.0.I.1 behaviour change (see earlier decision on this branch). Bumps package.json + composite-pin lock-step in templates/workflow{,-py,-ts}.yml.tmpl + .github/actions/strict-mode-gate/action.yml header docs from 0.6.18 to 0.6.19. CHANGELOG [0.6.19] entry documents the behaviour change + tests + composite pin.
+
+**Implications:**
+- After this lands + v0.6.19 is tagged + npm publishes, consumers running 'clud-bug update' will see their CLAUDE.md (etc.) tool-stub block disappear if they have @AGENTS.md at the top — which all 5 consuming repos now do post-0.0.I.
+
+---

--- a/docs/decisions-branches/feat__0.0.I.1-skip-block-with-import.md
+++ b/docs/decisions-branches/feat__0.0.I.1-skip-block-with-import.md
@@ -1,0 +1,11 @@
+## 2026-05-29 09:40 - 0.0.I.1 (clud-bug code change): skip installing CLAUDE.md block when @AGENTS.md import is present
+
+**Reasoning:** Q4 refinement (0.0.I) added @AGENTS.md eager-import at the top of each consuming repo's CLAUDE.md. That makes the AGENTS.md clud-bug block authoritative and the same block in CLAUDE.md duplicate content (eagerly inlined twice on every session). lib/agents-md.js applyToRepo now branches in the TOUCH_IF_PRESENT loop AND in the .cursor/rules walk: if the file already contains @AGENTS.md at start-of-line, SKIP installing the block AND remove any pre-existing block (migration path). AGENTS.md itself is unaffected — it's the source of truth and ALWAYS gets the block. Two new exported helpers: hasAgentsMdImport(content) for the detection (line-anchored to avoid matching prose mentions); removeBlock(content) for the cleanup (also eats the preceding blank line to avoid leaving a visible dent).
+
+**Alternatives considered:** Detect via filename heuristic (file === 'CLAUDE.md' → skip). Rejected: doesn't compose with cursor/windsurf/copilot — those don't always use @AGENTS.md, only Claude Code's CLAUDE.md syntax does today. The content check is the right signal., Always skip non-AGENTS.md files. Rejected: breaks back-compat for repos that don't use @-import.
+
+**Implications:**
+- After this lands, agent-skills/reporulez/rezgen/tokenomics/logmind/clud-bug repos' CLAUDE.md files will lose their clud-bug block on the next clud-bug init/update run. AGENTS.md block stays. Net per-session bytes drop because the same content is no longer present in two files.
+- Test fixture: 9 new tests in test/agents-md.test.js covering hasAgentsMdImport line-anchor edge cases, removeBlock idempotence + preserving prose around the block, applyToRepo behavior for (a) skip block on CLAUDE.md with import, (b) clean up stale block on CLAUDE.md with import, (c) back-compat install on CLAUDE.md without import, (d) .cursor/rules walk respects the same rule.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,8 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-29** — Release clud-bug v0.6.19 — 0.0.I.1 skip-block-when-import *(feat/0.0.I.1-skip-block-with-import)* — [decisions-branches/feat__0.0.I.1-skip-block-with-import.md](decisions-branches/feat__0.0.I.1-skip-block-with-import.md)
+- **2026-05-29** — 0.0.I.1 (clud-bug code change): skip installing CLAUDE.md block when @AGENTS.md import is present *(feat/0.0.I.1-skip-block-with-import)* — [decisions-branches/feat__0.0.I.1-skip-block-with-import.md](decisions-branches/feat__0.0.I.1-skip-block-with-import.md)
 - **2026-05-29** — 0.0.T (clud-bug side): RTK-inspired tee-hint on cap fire — producer-side audit trail *(feat/0.0.T-rtk-inspired-clud-bug)* — [decisions-branches/feat__0.0.T-rtk-inspired-clud-bug.md](decisions-branches/feat__0.0.T-rtk-inspired-clud-bug.md)
 - **2026-05-29** — PR #109 fix: wire up clud-bug eval subcommand (was referenced in README but didn't exist) *(feat/0.0.E-golden-eval-harness)* — [decisions-branches/feat__0.0.E-golden-eval-harness.md](decisions-branches/feat__0.0.E-golden-eval-harness.md)
 - **2026-05-29** — v0.6.17: golden-set regression gate for review prompt (Phase 0.5 / 0.0.E) *(feat/0.0.E-golden-eval-harness)* — [decisions-branches/feat__0.0.E-golden-eval-harness.md](decisions-branches/feat__0.0.E-golden-eval-harness.md)

--- a/lib/agents-md.js
+++ b/lib/agents-md.js
@@ -86,6 +86,35 @@ export function upsertBlock(content, block) {
   return `${content}${sep}${block}\n`;
 }
 
+// 0.0.I.1 (v0.6.X): true if `content` has Claude Code's `@AGENTS.md`
+// @-import — the canonical AGENTS.md content gets eager-loaded.
+//
+// Matches at start-of-line (a literal `@AGENTS.md` mentioned in prose
+// won't fire; only the import directive does). Allows trailing space
+// (some editors trim it; some don't) and optional newline terminator.
+export function hasAgentsMdImport(content) {
+  if (typeof content !== 'string') return false;
+  return /^@AGENTS\.md\s*$/m.test(content);
+}
+
+// 0.0.I.1: strip a clud-bug block (markers + body) AND the blank line
+// that precedes it, if any. Used when an @AGENTS.md import is detected
+// — the AGENTS.md content covers the block, so keeping it in CLAUDE.md
+// (or any tool stub) is duplication.
+//
+// Returns the cleaned content. If no block exists, returns content
+// unchanged. Idempotent.
+export function removeBlock(content) {
+  if (typeof content !== 'string') return content;
+  // Strip the block. Match \n+ before the marker so we also eat the
+  // preceding blank line — otherwise we'd leave a "stub line + blank
+  // + block" structure as "stub line + blank line".
+  const re = new RegExp(
+    `\\n*${escapeRe(START_MARKER)}[\\s\\S]*?${escapeRe(END_MARKER)}\\n?`,
+  );
+  return content.replace(re, '');
+}
+
 function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -116,7 +145,7 @@ export async function applyToRepo(cwd, blockOpts = {}) {
     const full = join(cwd, path);
     if (!(await fileExists(full))) continue;
     const prior = await readFile(full, 'utf8');
-    const next = upsertBlock(prior, block);
+    const next = nextContentFor(prior, block);
     if (next !== prior) {
       await writeFile(full, next);
       touched.push(path);
@@ -132,7 +161,7 @@ export async function applyToRepo(cwd, blockOpts = {}) {
       if (!name.endsWith('.md')) continue;
       const full = join(cursorRulesDir, name);
       const prior = await readFile(full, 'utf8');
-      const next = upsertBlock(prior, block);
+      const next = nextContentFor(prior, block);
       if (next !== prior) {
         await writeFile(full, next);
         touched.push(`.cursor/rules/${name}`);
@@ -141,6 +170,18 @@ export async function applyToRepo(cwd, blockOpts = {}) {
   }
 
   return { touched, created };
+}
+
+// 0.0.I.1: decide what content a TOUCH_IF_PRESENT file should have.
+// If it already imports AGENTS.md via Claude Code's @-syntax, skip the
+// block entirely (and clean up any pre-existing block — the content is
+// duplicated via @-import, so the AGENTS.md block is the only authority).
+// Otherwise, upsert as before.
+//
+// AGENTS.md itself is NOT routed through here — it always gets the
+// block (it's the canonical source).
+function nextContentFor(prior, block) {
+  return hasAgentsMdImport(prior) ? removeBlock(prior) : upsertBlock(prior, block);
 }
 
 function seedFile(name) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -156,6 +156,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.18
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.19
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -156,6 +156,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.18
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.19
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -247,6 +247,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.18
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.19
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/agents-md.test.js
+++ b/test/agents-md.test.js
@@ -3,7 +3,7 @@ import { strict as assert } from 'node:assert';
 import { mkdtemp, writeFile, mkdir, readFile, rm, stat } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
-import { applyToRepo, renderBlock, upsertBlock } from '../lib/agents-md.js';
+import { applyToRepo, hasAgentsMdImport, removeBlock, renderBlock, upsertBlock } from '../lib/agents-md.js';
 
 async function makeRepo(files = {}) {
   const dir = await mkdtemp(join(tmpdir(), 'clud-bug-agents-md-'));
@@ -225,5 +225,130 @@ test('applyToRepo: does not create CLAUDE.md or other tool files when absent', a
     assert.equal(await exists(join(dir, 'GEMINI.md')), false);
     assert.equal(await exists(join(dir, '.cursorrules')), false);
     assert.equal(await exists(join(dir, '.windsurfrules')), false);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+// --- 0.0.I.1 (v0.6.X): @AGENTS.md import detection + block-skip ---
+
+test('hasAgentsMdImport: matches `@AGENTS.md` at start of line', () => {
+  assert.equal(hasAgentsMdImport('@AGENTS.md\n\n# rest\n'), true);
+  assert.equal(hasAgentsMdImport('# heading\n\n@AGENTS.md\n\nfooter\n'), true);
+  // Trailing whitespace tolerated (some editors trim, some don't).
+  assert.equal(hasAgentsMdImport('@AGENTS.md   \n'), true);
+});
+
+test('hasAgentsMdImport: does NOT match prose mentions or partial matches', () => {
+  // Prose mention — has surrounding text on the same line.
+  assert.equal(hasAgentsMdImport('See @AGENTS.md for rules\n'), false);
+  // Wrong file name.
+  assert.equal(hasAgentsMdImport('@CLAUDE.md\n'), false);
+  // Empty / non-string inputs.
+  assert.equal(hasAgentsMdImport(''), false);
+  assert.equal(hasAgentsMdImport(null), false);
+  assert.equal(hasAgentsMdImport(undefined), false);
+});
+
+test('removeBlock: strips the block AND a preceding blank line', () => {
+  const before = '# CLAUDE.md\n\nSee AGENTS.md.\n\n<!-- clud-bug-start -->\nbody\n<!-- clud-bug-end -->\n';
+  const after = removeBlock(before);
+  assert.doesNotMatch(after, /clud-bug-start/);
+  assert.doesNotMatch(after, /clud-bug-end/);
+  // Preserves the surrounding content.
+  assert.match(after, /# CLAUDE\.md/);
+  assert.match(after, /See AGENTS\.md\./);
+  // Does NOT leave a double-blank-line dent where the block used to be.
+  assert.doesNotMatch(after, /\n\n\n/);
+});
+
+test('removeBlock: idempotent — running twice produces the same result', () => {
+  const before = '@AGENTS.md\n\n# stuff\n\n<!-- clud-bug-start -->\nx\n<!-- clud-bug-end -->\n';
+  const once = removeBlock(before);
+  const twice = removeBlock(once);
+  assert.equal(once, twice);
+  // No block present → unchanged.
+  assert.doesNotMatch(once, /clud-bug-/);
+});
+
+test('removeBlock: no-op when no block is present', () => {
+  const before = '@AGENTS.md\n\n# clean\n';
+  assert.equal(removeBlock(before), before);
+});
+
+test('applyToRepo: SKIPS clud-bug block in CLAUDE.md when @AGENTS.md import is present', async () => {
+  // The 0.0.I.1 contract: if CLAUDE.md already imports AGENTS.md, the
+  // AGENTS.md block is the canonical source — don't duplicate into CLAUDE.md.
+  const dir = await makeRepo({
+    'AGENTS.md': '# AGENTS.md\n',
+    'CLAUDE.md': '@AGENTS.md\n\n# CLAUDE.md stub\n',
+  });
+  try {
+    const r = await applyToRepo(dir, { version: '0.6.18', strictMode: true });
+    // AGENTS.md still gets the block — it's the source of truth.
+    const agents = await readFile(join(dir, 'AGENTS.md'), 'utf8');
+    assert.match(agents, /<!-- clud-bug-start -->/);
+    // CLAUDE.md does NOT get a block.
+    const claude = await readFile(join(dir, 'CLAUDE.md'), 'utf8');
+    assert.doesNotMatch(claude, /<!-- clud-bug-start -->/);
+    // CLAUDE.md prior content preserved.
+    assert.match(claude, /@AGENTS\.md/);
+    assert.match(claude, /# CLAUDE\.md stub/);
+    // Touched array does NOT mention CLAUDE.md (no write happened).
+    assert.equal(r.touched.includes('CLAUDE.md'), false);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('applyToRepo: REMOVES stale clud-bug block from CLAUDE.md when @AGENTS.md import is present', async () => {
+  // Migration path: an older clud-bug version installed the block into
+  // CLAUDE.md. The user has since added @AGENTS.md at the top. Now the
+  // block is duplicated content. clud-bug init/update should clean it up.
+  const dir = await makeRepo({
+    'AGENTS.md': '# AGENTS.md\n',
+    'CLAUDE.md': '@AGENTS.md\n\n# stub\n\n<!-- clud-bug-start -->\nOLD STALE BLOCK\n<!-- clud-bug-end -->\n',
+  });
+  try {
+    const r = await applyToRepo(dir, { version: '0.6.18', strictMode: true });
+    const claude = await readFile(join(dir, 'CLAUDE.md'), 'utf8');
+    assert.doesNotMatch(claude, /<!-- clud-bug-start -->/);
+    assert.doesNotMatch(claude, /OLD STALE BLOCK/);
+    assert.match(claude, /@AGENTS\.md/);
+    assert.match(claude, /# stub/);
+    // Touched because we modified the file (block removed).
+    assert.ok(r.touched.includes('CLAUDE.md'));
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('applyToRepo: STILL installs block into CLAUDE.md when @AGENTS.md import is absent', async () => {
+  // Back-compat: repos that don't use Claude Code's @-import still get the
+  // block in their tool stub files. The skip behavior is opt-in via import.
+  const dir = await makeRepo({
+    'AGENTS.md': '# AGENTS.md\n',
+    'CLAUDE.md': '# CLAUDE.md\n\nstuff\n',
+  });
+  try {
+    await applyToRepo(dir, { version: '0.6.18', strictMode: true });
+    const claude = await readFile(join(dir, 'CLAUDE.md'), 'utf8');
+    assert.match(claude, /<!-- clud-bug-start -->/);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('applyToRepo: SKIPS .cursor/rules/*.md that import @AGENTS.md', async () => {
+  // Cursor rules can also use @-import. Same behaviour: skip the block
+  // when the import is present.
+  const dir = await makeRepo({
+    'AGENTS.md': '# AGENTS.md\n',
+    '.cursor/rules/general.md': '@AGENTS.md\n\n# general\n',
+    '.cursor/rules/no-import.md': '# no import\n',
+  });
+  try {
+    const r = await applyToRepo(dir, { strictMode: true });
+    const general = await readFile(join(dir, '.cursor/rules/general.md'), 'utf8');
+    const noImport = await readFile(join(dir, '.cursor/rules/no-import.md'), 'utf8');
+    // The @AGENTS.md one gets NO block.
+    assert.doesNotMatch(general, /<!-- clud-bug-start -->/);
+    // The other one DOES get the block (back-compat).
+    assert.match(noImport, /<!-- clud-bug-start -->/);
+    // Touched array reflects only the one we wrote to.
+    assert.ok(r.touched.includes('.cursor/rules/no-import.md'));
+    assert.equal(r.touched.includes('.cursor/rules/general.md'), false);
   } finally { await rm(dir, { recursive: true, force: true }); }
 });


### PR DESCRIPTION
## Summary

Companion to 0.0.I (which added `@AGENTS.md` to each consuming repo's CLAUDE.md). With @-import in place, the AGENTS.md clud-bug block becomes the authoritative source and the same block in CLAUDE.md becomes eagerly-inlined duplicate content. This PR makes `clud-bug init` / `clud-bug update` skip block installation in tool-stub files (CLAUDE.md, GEMINI.md, .cursor/rules/*.md, etc.) when they already contain the @-import, AND removes any stale block left from older clud-bug versions.

## What changed

| Function | Behaviour |
|---|---|
| `hasAgentsMdImport(content)` (new) | Line-anchored regex match for `@AGENTS.md` (prose mentions don't fire) |
| `removeBlock(content)` (new) | Strips the marker block AND its leading blank line; idempotent |
| `applyToRepo` | In TOUCH_IF_PRESENT + .cursor/rules walks: branches on `hasAgentsMdImport` — if true, removes block; else upserts as before |
| AGENTS.md handling | Unchanged — AGENTS.md is the canonical source and always gets the block |

## Test plan

- [x] `node --test test/agents-md.test.js` — 26/26 pass (existing 17 + 9 new).
- [x] Tests cover: line-anchor edge cases on `hasAgentsMdImport`, idempotence of `removeBlock`, skip-on-import for CLAUDE.md, clean-up of stale block on CLAUDE.md with import, back-compat install when no import, .cursor/rules walks respecting the same rule.
- [ ] CI green.

## Sequencing

This PR is open BEFORE the v0.6.18 (0.0.T) PR #110 is merged. To avoid a version-pin merge conflict, no version bump in this PR — after #110 lands and bumps to v0.6.18, this PR will rebase onto the new main and bump to v0.6.19 with the composite-pin lock-step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)