### PR TITLE
feat(v0.6.21): skill applies_to filter for non-applicable PRs (Phase 0.5 / 0.0.K)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.20
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.21
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,75 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.21] — 2026-05-29
+
+### Added — Skill `applies_to:` filter (Phase 0.5 / 0.0.K)
+
+Skills can declare an optional `applies_to:` block in their SKILL.md
+frontmatter listing paths/extensions the skill cares about. The review
+prompt now instructs the LLM to scan frontmatter first; if the skill
+declares applies_to AND the PR's changed files match NONE of the
+declared paths/extensions, the body is skipped entirely.
+
+```yaml
+---
+name: brand-voice-review
+review_mode: dedicated
+applies_to:
+  paths:
+    - "src/ui/**"
+    - "lib/components/**"
+  extensions: [".tsx", ".jsx", ".css"]
+---
+```
+
+**Match semantics**: paths OR extensions — any single hit wins. Path
+globs use the minimal set (`*` non-slash, `**` cross-slash, `?` single
+char). Skills without applies_to load unconditionally (back-compat).
+
+**Savings**: for a repo with N installed skills where only K care
+about a given PR's paths, the review skips ~(N-K) × MAX_SKILL_BYTES
+of skill-body fetch. A UI-only PR no longer pays for the
+`pii-and-compliance` body; a backend-only PR no longer pays for
+`brand-voice-review`.
+
+### Library API
+
+Two new helpers exported from `lib/skills.js`:
+
+- `readAppliesTo(skillContent)` — parses the frontmatter block.
+  Returns `{paths: string[], extensions: string[]}` or `null` if
+  absent (or if both lists are empty — the degenerate "no rule" case).
+  Hand-rolled YAML parser scoped to the exact shape; no new deps.
+- `appliesToPr(skillContent, prPaths)` — boolean. Skills without
+  applies_to ALWAYS apply (back-compat).
+
+The CLI doesn't use these helpers itself (the filter runs in the
+LLM's prompt). They're exported for: (1) test coverage, (2) the v0.6
+GitHub App's planned pre-filter step that will compute the applicable
+subset BEFORE the API call so the prompt can list only matching skills.
+
+### Golden gate
+
+Two new must-contain entries lock the prompt section against future
+0.0.P-style trim regression:
+
+- `Skill applies_to`
+- `SKIP that skill's body`
+
+### Tests
+
+277 pass (+12 new in `test/skills.test.js`). Cover: missing
+frontmatter, missing applies_to, block-list + inline-array forms,
+paths-only / extensions-only, prose mention does NOT fire, degenerate
+empty-lists rule returns null, back-compat without applies_to, glob
+single-star vs double-star semantics, paths OR extensions.
+
+### Composite pin
+
+v0.6.20 → v0.6.21 across `templates/workflow{,-py,-ts}.yml.tmpl` and
+`.github/actions/strict-mode-gate/action.yml` header docs.
+
 ## [0.6.20] — 2026-05-29
 
 ### Changed — Review prompt trim (Phase 0.5 / 0.0.P)

--- a/docs/decisions-branches/feat__0.0.K-skill-loading-minimization.md
+++ b/docs/decisions-branches/feat__0.0.K-skill-loading-minimization.md
@@ -1,0 +1,11 @@
+## 2026-05-29 10:13 - 0.0.K: applies_to frontmatter — skill-filter for non-applicable PRs
+
+**Reasoning:** Skills now carry an optional applies_to: { paths: [glob...], extensions: [ext...] } frontmatter block. lib/skills.js exports readAppliesTo + appliesToPr (12 new tests covering missing frontmatter, both list forms, OR semantics, single/double star, prose-mention-doesn't-fire, degenerate empty rule). lib/prompts.js gets a 10-line Skill applies_to section in the routing block instructing the LLM to scan frontmatter cheap, skip body when match is empty. Back-compat: skills without applies_to apply universally.
+
+**Alternatives considered:** Pre-compute the applicable subset in the workflow and inject only matching skills into the prompt. Rejected: would break caching — the system prompt is the cached prefix, and varying it per-PR defeats the 10% cost cap. Instruction-level filter keeps the cached prefix stable; the LLM does the cheap frontmatter scan., Make applies_to mandatory for dedicated skills. Rejected: agent-skills' existing dedicated skills don't have it yet; making it required would break every installed dedicated skill until propagation.
+
+**Implications:**
+- Companion follow-up PR in agent-skills: add applies_to to brand-voice-review (UI paths/extensions), pii-and-compliance (logging/analytics/db paths), api-contract-enforcement (API paths), test-discipline (test files). Generic skills (critical-issues-only, evidence-based-review, respect-existing-conventions) stay un-scoped — universal review baselines.
+- Prompt growth: +554 bytes / +10 lines for the applies_to section. Total prompt now 12765 / 282 — still well under the 14000 / 310 cap left after 0.0.P. Net Phase 0.5 trim still ~26.5% bytes vs pre-0.0.T.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-29** — 0.0.K: applies_to frontmatter — skill-filter for non-applicable PRs *(feat/0.0.K-skill-loading-minimization)* — [decisions-branches/feat__0.0.K-skill-loading-minimization.md](decisions-branches/feat__0.0.K-skill-loading-minimization.md)
 - **2026-05-29** — 0.0.P: trim review prompt by ~29.6% bytes / ~25% lines without removing must-contain phrases *(feat/0.0.P-prompt-trim)* — [decisions-branches/feat__0.0.P-prompt-trim.md](decisions-branches/feat__0.0.P-prompt-trim.md)
 - **2026-05-29** — Release clud-bug v0.6.19 — 0.0.I.1 skip-block-when-import *(feat/0.0.I.1-skip-block-with-import)* — [decisions-branches/feat__0.0.I.1-skip-block-with-import.md](decisions-branches/feat__0.0.I.1-skip-block-with-import.md)
 - **2026-05-29** — 0.0.I.1 (clud-bug code change): skip installing CLAUDE.md block when @AGENTS.md import is present *(feat/0.0.I.1-skip-block-with-import)* — [decisions-branches/feat__0.0.I.1-skip-block-with-import.md](decisions-branches/feat__0.0.I.1-skip-block-with-import.md)

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -148,7 +148,17 @@ Each SKILL.md frontmatter (first \`---\`-delimited block) has a
     API-contract, test-discipline). Each gets its own H3 section.
   - Missing → treat as \`shared\`.
 
-Read each capped: \`head -c "$MAX_SKILL_BYTES" .claude/skills/*/SKILL.md\`
+Skill applies_to (v0.6.21 / 0.0.K):
+Frontmatter may also have \`applies_to:\` with \`paths:\` (glob list)
+and/or \`extensions:\` (extension list). Scan each skill's frontmatter
+first (cheap — just the \`---\` block). If applies_to is present and
+the PR's changed files (from \`gh pr diff --name-only\`) match NONE
+of the declared paths or extensions, SKIP that skill's body — don't
+read it, don't reference it. Skills without applies_to load
+unconditionally (back-compat). Net effect: a UI-scoped skill stays
+unread on a backend-only PR.
+
+Read each applicable body capped: \`head -c "$MAX_SKILL_BYTES" .claude/skills/<name>/SKILL.md\`
 
 At review end, append a single-line footer:
   Skills referenced: [skill-name-1, skill-name-2, ...]

--- a/lib/skills.js
+++ b/lib/skills.js
@@ -383,6 +383,113 @@ export function readReviewMode(skillContent) {
   return value === 'dedicated' ? 'dedicated' : 'shared';
 }
 
+// 0.0.K (v0.6.21): parse the optional `applies_to:` frontmatter block.
+//
+// Schema:
+//   applies_to:
+//     paths:
+//       - "src/ui/**"
+//       - "lib/components/**"
+//     extensions: [".tsx", ".jsx"]
+//
+// Returns `{paths: string[], extensions: string[]}` if the field is
+// present (either sub-list optional, both default to empty array), or
+// `null` if absent. Skills without applies_to are scope-universal —
+// the caller should treat null as "load unconditionally."
+//
+// Hand-rolled YAML parser scoped to this exact shape. The frontmatter
+// is otherwise opaque (review_mode is parsed elsewhere with a similar
+// single-key regex), so pulling in a YAML dep would be overkill.
+export function readAppliesTo(skillContent) {
+  if (typeof skillContent !== 'string') return null;
+  const fm = skillContent.match(/^---\n([\s\S]*?)\n---/);
+  if (!fm) return null;
+  const block = fm[1];
+  // Anchor on `applies_to:` at start of line (the body of a SKILL.md
+  // could mention the term in prose; only the frontmatter key fires).
+  const head = block.match(/^applies_to:\s*$/m);
+  if (!head) return null;
+  // Slice from after the `applies_to:` line; the block ends at the
+  // next top-level key (a line starting with a word character + `:`)
+  // OR end-of-block.
+  const startIdx = head.index + head[0].length;
+  const rest = block.slice(startIdx);
+  const stop = rest.search(/^\w[\w-]*:/m);
+  const scoped = stop === -1 ? rest : rest.slice(0, stop);
+  const paths = parseYamlList(scoped, 'paths');
+  const extensions = parseYamlList(scoped, 'extensions');
+  if (paths.length === 0 && extensions.length === 0) return null;
+  return { paths, extensions };
+}
+
+// Parse a YAML list under `<key>:`, handling both the inline-array
+// form (`extensions: [".tsx", ".jsx"]`) and the block form
+// (`paths:` followed by `  - "src/ui/**"` lines).
+function parseYamlList(block, key) {
+  const inline = block.match(new RegExp(`^\\s{2}${key}:\\s*\\[(.*?)\\]\\s*$`, 'm'));
+  if (inline) {
+    return inline[1]
+      .split(',')
+      .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+      .filter(Boolean);
+  }
+  const headerRe = new RegExp(`^\\s{2}${key}:\\s*$`, 'm');
+  const head = block.match(headerRe);
+  if (!head) return [];
+  const after = block.slice(head.index + head[0].length);
+  const items = [];
+  for (const line of after.split('\n')) {
+    const item = line.match(/^\s{4,}-\s*(.+?)\s*$/);
+    if (item) {
+      items.push(item[1].replace(/^["']|["']$/g, ''));
+      continue;
+    }
+    // Anything that isn't a list item (or blank) ends the list.
+    if (line.trim() !== '' && !item) break;
+  }
+  return items;
+}
+
+// 0.0.K: does `prPaths` contain at least one file matching the skill's
+// applies_to? Skills without applies_to ALWAYS apply (back-compat).
+//
+// `prPaths` is the list of changed files in the PR (e.g. from
+// `gh pr diff --name-only`). Match semantics:
+//   - paths: any glob in `paths` matches any of `prPaths`
+//   - extensions: any extension in `extensions` matches any of `prPaths`
+//   - paths OR extensions (NOT AND) — a single hit is enough
+//
+// Skill `paths` use the minimal glob set logmind already uses
+// (`*` matches non-slash, `**` matches across slashes, `?` single
+// char). Anything fancier would need a real glob lib.
+export function appliesToPr(skillContent, prPaths) {
+  const rule = readAppliesTo(skillContent);
+  if (rule === null) return true;  // back-compat: no rule → applies
+  if (!Array.isArray(prPaths)) return true;  // be permissive on bad input
+  for (const path of prPaths) {
+    if (typeof path !== 'string') continue;
+    for (const ext of rule.extensions) {
+      if (path.endsWith(ext)) return true;
+    }
+    for (const glob of rule.paths) {
+      if (globMatch(glob, path)) return true;
+    }
+  }
+  return false;
+}
+
+// Minimal glob → regex: `**` → `.*`, `*` → `[^/]*`, `?` → `.`,
+// everything else escaped. Anchored full-string match.
+function globMatch(glob, path) {
+  const escaped = glob
+    .replace(/([.+^${}()|[\]\\])/g, '\\$1')
+    .replace(/\*\*/g, '__DOUBLESTAR__')
+    .replace(/\*/g, '[^/]*')
+    .replace(/__DOUBLESTAR__/g, '.*')
+    .replace(/\?/g, '.');
+  return new RegExp(`^${escaped}$`).test(path);
+}
+
 // Partition a set of loaded skills into {shared, dedicated} buckets per
 // each skill's review_mode frontmatter. Expects skills with a `content`
 // field (SKILL.md text). Skills without content default to `shared`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -156,6 +156,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.20
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.21
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -156,6 +156,6 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.20
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.21
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -247,6 +247,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.20
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.21
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/golden/must-contain.json
+++ b/test/golden/must-contain.json
@@ -100,6 +100,16 @@
       "pattern": "### Diagnostics",
       "why": "0.0.T (v0.6.18). Surfaces cap-fire events as an auditable block in the summary comment. Removing it would let truncation become invisible again.",
       "category": "fail-safe"
+    },
+    {
+      "pattern": "Skill applies_to",
+      "why": "0.0.K (v0.6.21). The skill-filter instruction. Without it, the LLM falls back to reading every installed SKILL.md unconditionally — the (N-K) * skill_bytes savings disappear.",
+      "category": "skill-filter"
+    },
+    {
+      "pattern": "SKIP that skill's body",
+      "why": "0.0.K (v0.6.21). The actionable rule — the wording the LLM follows to decide which skill bodies to fetch. Trimming around this phrase would gut the filter's behavior.",
+      "category": "skill-filter"
     }
   ]
 }

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -7,7 +7,7 @@ import {
   SkillsClient, rankAndCap, writeSkills, loadBaseline,
   readManifest, writeManifest, mergeManifest,
   removeSkill, listInstalled, diffManifest,
-  readReviewMode, partitionByReviewMode,
+  readReviewMode, partitionByReviewMode, readAppliesTo, appliesToPr,
   extractPerSkillLine, classifyPerSkillOutcome,
   selectReviewHeader, extractFirstReviewHeaderLine, isCriticalReviewHeader,
   selectReviewBody,
@@ -488,6 +488,158 @@ test('partitionByReviewMode: handles skills with no content (defaults to shared)
   const { shared, dedicated } = partitionByReviewMode(skills);
   assert.deepEqual(shared.map((s) => s.name), ['a', 'b']);
   assert.deepEqual(dedicated.map((s) => s.name), ['c']);
+});
+
+// --- 0.0.K (v0.6.21): applies_to frontmatter — skill-filter helper ---
+
+test('readAppliesTo: returns null when frontmatter is absent', () => {
+  assert.equal(readAppliesTo('# bare body, no frontmatter\n'), null);
+});
+
+test('readAppliesTo: returns null when applies_to key is absent', () => {
+  const fm = `---
+name: foo
+review_mode: shared
+---
+
+body`;
+  assert.equal(readAppliesTo(fm), null);
+});
+
+test('readAppliesTo: parses block-list paths + inline-array extensions', () => {
+  const fm = `---
+name: brand-voice
+review_mode: dedicated
+applies_to:
+  paths:
+    - "src/ui/**"
+    - "lib/components/**"
+  extensions: [".tsx", ".jsx", ".css"]
+---
+
+body`;
+  const r = readAppliesTo(fm);
+  assert.deepEqual(r.paths, ['src/ui/**', 'lib/components/**']);
+  assert.deepEqual(r.extensions, ['.tsx', '.jsx', '.css']);
+});
+
+test('readAppliesTo: handles paths-only (extensions absent)', () => {
+  const fm = `---
+applies_to:
+  paths:
+    - "api/**"
+---
+
+body`;
+  const r = readAppliesTo(fm);
+  assert.deepEqual(r.paths, ['api/**']);
+  assert.deepEqual(r.extensions, []);
+});
+
+test('readAppliesTo: handles extensions-only (paths absent)', () => {
+  const fm = `---
+applies_to:
+  extensions: [".sql"]
+---
+
+body`;
+  const r = readAppliesTo(fm);
+  assert.deepEqual(r.paths, []);
+  assert.deepEqual(r.extensions, ['.sql']);
+});
+
+test('readAppliesTo: prose mention of `applies_to` in body does NOT fire', () => {
+  // Match must be in frontmatter only; body mentions are documentation.
+  const fm = `---
+name: foo
+---
+
+This skill applies_to nothing in particular.
+`;
+  assert.equal(readAppliesTo(fm), null);
+});
+
+test('readAppliesTo: empty paths AND empty extensions → null (degenerate rule)', () => {
+  const fm = `---
+applies_to:
+  paths: []
+  extensions: []
+---
+`;
+  // An applies_to with both lists empty is the same as no rule —
+  // returning null lets the back-compat "always apply" branch fire.
+  assert.equal(readAppliesTo(fm), null);
+});
+
+test('appliesToPr: skill WITHOUT applies_to always applies (back-compat)', () => {
+  const fm = `---
+name: critical-issues-only
+---
+
+body`;
+  assert.equal(appliesToPr(fm, ['anything.go']), true);
+  assert.equal(appliesToPr(fm, []), true);
+  assert.equal(appliesToPr(fm, null), true);
+});
+
+test('appliesToPr: extension match fires', () => {
+  const fm = `---
+applies_to:
+  extensions: [".tsx"]
+---
+`;
+  assert.equal(appliesToPr(fm, ['src/App.tsx', 'lib/util.go']), true);
+  assert.equal(appliesToPr(fm, ['lib/util.go']), false);
+});
+
+test('appliesToPr: glob path match fires', () => {
+  const fm = `---
+applies_to:
+  paths:
+    - "src/ui/**"
+---
+`;
+  assert.equal(appliesToPr(fm, ['src/ui/Button.tsx']), true);
+  assert.equal(appliesToPr(fm, ['src/ui/nested/deeply/Foo.tsx']), true);
+  assert.equal(appliesToPr(fm, ['lib/backend/api.go']), false);
+});
+
+test('appliesToPr: single-star does NOT cross slashes; double-star does', () => {
+  const single = `---
+applies_to:
+  paths:
+    - "src/*"
+---
+`;
+  // Single star matches direct children only.
+  assert.equal(appliesToPr(single, ['src/Foo.tsx']), true);
+  assert.equal(appliesToPr(single, ['src/ui/Foo.tsx']), false);
+
+  const double = `---
+applies_to:
+  paths:
+    - "src/**"
+---
+`;
+  // Double star crosses slashes.
+  assert.equal(appliesToPr(double, ['src/Foo.tsx']), true);
+  assert.equal(appliesToPr(double, ['src/ui/nested/Foo.tsx']), true);
+});
+
+test('appliesToPr: paths OR extensions — any single hit applies', () => {
+  const fm = `---
+applies_to:
+  paths:
+    - "src/ui/**"
+  extensions: [".sql"]
+---
+`;
+  // path-only match
+  assert.equal(appliesToPr(fm, ['src/ui/Foo.tsx']), true);
+  // extension-only match
+  assert.equal(appliesToPr(fm, ['db/migrations/0001.sql']), true);
+  // both miss
+  assert.equal(appliesToPr(fm, ['lib/api.go']), false);
 });
 
 // --- BB.3: per-skill check-run classifier (v0.5.10) ---


### PR DESCRIPTION
## Summary

Skills can declare an optional `applies_to:` block listing paths/extensions they care about. The review prompt instructs the LLM to scan frontmatter first and SKIP body fetch for skills whose declared paths/extensions don't match any of the PR's changed files. Skills without `applies_to` load unconditionally (back-compat).

## Frontmatter schema

```yaml
---
name: brand-voice-review
review_mode: dedicated
applies_to:
  paths:
    - "src/ui/**"
    - "lib/components/**"
  extensions: [".tsx", ".jsx", ".css"]
---
```

Match semantics: `paths` OR `extensions` — any single hit wins. Path globs use the minimal set (`*` non-slash, `**` cross-slash, `?` single char).

## Savings

For a repo with N installed skills where only K care about a given PR's paths, the review skips ~(N-K) × `MAX_SKILL_BYTES` of skill-body fetch. UI-only PR → no `pii-and-compliance` body fetched. Backend-only PR → no `brand-voice-review` fetched. Compounds with caching.

## Files

| File | Change |
|---|---|
| `lib/skills.js` | New exports: `readAppliesTo`, `appliesToPr`. Hand-rolled YAML parser scoped to the exact shape; no new deps. The CLI doesn't use these directly (filter runs in prompt); they're for tests + the planned v0.6 GitHub App pre-filter. |
| `lib/prompts.js` | `Skill applies_to` section (10 lines) in the routing block. The cached system prefix still varies only on prompt version, not per-PR — caching intact. |
| `test/skills.test.js` | +12 tests covering: missing frontmatter, missing applies_to, block-list + inline-array forms, paths-only / extensions-only, prose mention does NOT fire, degenerate empty-lists → null, back-compat universal-apply, glob `*` vs `**`, paths OR extensions. |
| `test/golden/must-contain.json` | +2 entries (`Skill applies_to`, `SKIP that skill's body`) lock the new prompt section against future trim regression. |
| `package.json` + 3 templates + action.yml | Composite pin 0.6.20 → 0.6.21 |

## Test plan

- [x] `npm test` — 277/277 pass (golden gate green; prompt at 12765 bytes / 282 lines, under 14000 / 310 cap).
- [ ] CI green.
- [ ] After merge: tag `v0.6.21` + companion PR in agent-skills to add `applies_to:` to scoped skills (brand-voice-review, pii-and-compliance, api-contract-enforcement, test-discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)