### PR TITLE
feat(v0.6.22): --json-schema structured output enforcement (Phase 0.5 / 0.0.O)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.21
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.22
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,33 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20'
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
       - name: Render templates with placeholder values
         run: |
           mkdir -p .ci-rendered
+          # v0.6.22 / 0.0.O: render via the real renderer so REVIEW_SCHEMA +
+          # CLUD_BUG_VERSION + REVIEW_PROMPT substitutions land. Previously
+          # only PROJECT_DESCRIPTION + LANGUAGE_HINTS were sed-substituted;
+          # the new {{REVIEW_SCHEMA}} and {{CLUD_BUG_VERSION}} placeholders
+          # leaked literal {{...}} braces into shell run blocks and SC1083'd
+          # actionlint. The renderer matches what clud-bug init produces.
           for tmpl in templates/workflow*.yml.tmpl; do
-            out=".ci-rendered/$(basename "${tmpl%.tmpl}")"
-            sed -e 's/{{PROJECT_DESCRIPTION}}/A test project./g' \
-                -e 's/{{LANGUAGE_HINTS}}//g' \
-                "$tmpl" > "$out"
+            tmpl_name=$(basename "$tmpl")
+            out=".ci-rendered/${tmpl_name%.tmpl}"
+            node -e "
+              import('./lib/render.js').then(async ({renderFile, templateLanguage}) => {
+                const {reviewPrompt} = await import('./lib/prompts.js');
+                const out = await renderFile('$tmpl', {
+                  REVIEW_PROMPT: reviewPrompt({
+                    projectDescription: 'A test project.',
+                    language: templateLanguage('$tmpl_name'),
+                  }),
+                });
+                process.stdout.write(out);
+              });
+            " > "$out"
           done
       - name: Install actionlint
         env:

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -280,8 +280,14 @@ jobs:
             comment to exist for every review pass.
 
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
+      # v0.6.22 / 0.0.O: bumped from v0.6.2 because clud-bug's own summary
+      # now posts under github-actions[bot] (workflow post-step) instead
+      # of claude[bot] (claude-code-action). The bot-login override picks
+      # up the new identity; without it the gate keeps reading the OLD
+      # claude[bot]-authored review with "— critical findings" header.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.2
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.21
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          bot-login: 'github-actions[bot]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,14 +79,64 @@ Two new must-contain entries:
 the test, a future refactor to `path.extname()` would silently break
 the test-discipline skill's applies_to.
 
+### Identity contract — `claude[bot]` → `github-actions[bot]`
+
+Moving the summary post from claude-code-action to a workflow step
+changes the comment author from `claude[bot]` to `github-actions[bot]`
+(the GITHUB_TOKEN identity). Three downstream consumers depend on the
+author and are migrated this release:
+
+- **Strict-mode gate**: each rendered template now passes
+  `bot-login: 'github-actions[bot]'` to `strict-mode-gate`. The
+  composite default stays `claude[bot]` for v0.6.21- back-compat.
+- **Prior-summary detection (incremental-diff handshake)**: the
+  prompt now walks `github-actions[bot]` comments first; falls back
+  to `claude[bot]` for pre-v0.6.22 summaries so mid-version repos
+  still find the prior SHA marker.
+- **Skip-advisory dedup query** (Guard step): the jq filter now
+  selects `github-actions[bot]` so `pull_request: synchronize` on
+  long-running fork/bot PRs without `ANTHROPIC_API_KEY` doesn't
+  stack duplicate "Clud Bug skipped" advisories.
+- **PR-comments fetch**: the LLM's per-PR comment scan now excludes
+  BOTH `claude[bot]` AND `github-actions[bot]` so the LLM doesn't
+  read back its own summary as PR context.
+
+Inline review threads stay `claude[bot]`-authored (the MCP tool
+routes through claude-code-action).
+
+### User-visible header behaviour preserved via `status_header: "bare"`
+
+The schema's `status_header` enum is `['critical findings', 'clean',
+'bare']`. Non-strict-mode repos (the default) emit `'bare'` and the
+renderer produces an unsuffixed `## 🐛 Clud Bug review` H2 — matches
+the v0.6.21- visible behaviour. Without `'bare'`, every non-strict
+install would silently start seeing `— clean` / `— critical findings`
+suffix after merge.
+
+### Shell hardening
+
+Render + post + fallback steps now lead with `set -euo pipefail` and
+use `printf '%s\n'` instead of `echo` for `$STRUCTURED` (defensive
+against payloads beginning with `-n` / `-e` / `--`). Failure
+attribution stays honest when `npx` or the renderer exits non-zero —
+the failing step is the one that actually failed, not the downstream
+`gh pr comment "must specify body"`.
+
 ### Tests
 
-295 pass (+18: 17 render-review + 1 endsWith regression).
+300 pass (+23 vs v0.6.21: 17 render-review + 1 endsWith + 5 identity-
+contract pins).
 
 ### Composite pin
 
 v0.6.21 → v0.6.22 across `templates/workflow{,-py,-ts}.yml.tmpl` and
 `.github/actions/strict-mode-gate/action.yml` header docs.
+
+### Byte budget
+
+Cap bumped 14000 → 14500 (deliberate; 0.0.O adds ~1.8 KB of
+structured-output + status_header instructions). Still ~22% below the
+18500 pre-0.0.P cap.
 
 ## [0.6.21] — 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,90 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.22] — 2026-05-29
+
+### Added — `--json-schema` structured output enforcement (Phase 0.5 / 0.0.O)
+
+The review prompt now instructs the LLM to emit the summary as
+structured JSON via Claude Code CLI's `--json-schema` flag (a
+first-class CLI flag, verified live against `anthropics/claude-code-action`).
+A workflow post-step reads the action's `outputs.structured_output`,
+renders to the existing GitHub-markdown summary shape, and posts via
+`gh pr comment`. The LLM no longer writes the summary comment itself.
+
+### Schema
+
+`lib/review-schema.js` exports `REVIEW_SCHEMA` +
+`serializedReviewSchema()`. Flat top-level object,
+`additionalProperties: false` on every nested object (schema-strict
+mode per Anthropic's structured-outputs guidance). Word/char caps
+embedded in `description:` fields — advisory but signal-preserving
+alongside the prompt's existing 0.0.X brevity directive.
+
+### Renderer
+
+`lib/render-review.js` exports `renderReview(data)` that returns the
+markdown body for `gh pr comment`. New `clud-bug render --stdin`
+subcommand pipes structured JSON from stdin to the renderer (the
+workflow post-step calls it via `npx --yes clud-bug@<pinned> render
+--stdin`). 17 fixture-based tests cover: clean / critical-findings /
+bare-header variants, per-skill scan, dedicated sections, all three
+severity tiers + emoji prefixes, diagnostics, anchor-without-line,
+cross-cutting findings, defensive coercion on bad counts.
+
+### Workflow changes
+
+`templates/workflow{,-py,-ts}.yml.tmpl`:
+
+- `--json-schema '{{REVIEW_SCHEMA}}'` added to `claude_args` (schema
+  embedded at template render time via `lib/render.js`'s new
+  `REVIEW_SCHEMA` + `CLUD_BUG_VERSION` defaults).
+- New `clud-bug-review` step `id` so subsequent steps can read
+  `steps.clud-bug-review.outputs.structured_output`.
+- New "Render + post structured review" step (guarded on non-empty
+  structured output) calls `npx --yes clud-bug@<pinned> render
+  --stdin` and posts via `gh pr comment`.
+- New "Fallback summary" step posts a bare-H2 advisory comment when
+  the schema-validation retries exhaust (empty `structured_output`).
+  Strict-mode gate sees the bare header and falls open rather than
+  panicking on a missing summary.
+- Removed `Bash(gh pr comment:*)` from `--allowedTools` — the LLM no
+  longer posts the summary; only the post-step (workflow-level shell)
+  does, with the workflow's GITHUB_TOKEN.
+
+### Library API
+
+- `serializedReviewSchema()` — `JSON.stringify(REVIEW_SCHEMA)` for
+  embedding in workflow templates.
+- `renderReview(data)` — pure markdown renderer.
+- `lib/render.js` DEFAULTS now includes `REVIEW_SCHEMA` (from
+  `review-schema.js`) and `CLUD_BUG_VERSION` (read from package.json
+  at module-load time).
+
+### Golden gate
+
+Two new must-contain entries:
+
+- `Emit the summary as structured JSON output`
+- `Do NOT post the summary yourself`
+
+### Regression test (out of band)
+
+`appliesToPr` (0.0.K, v0.6.21) now has an explicit test pinning the
+`endsWith()` contract for compound suffixes like `.test.ts` /
+`_test.py`. Caught by the clud-bug-review on agent-skills#51 — without
+the test, a future refactor to `path.extname()` would silently break
+the test-discipline skill's applies_to.
+
+### Tests
+
+295 pass (+18: 17 render-review + 1 endsWith regression).
+
+### Composite pin
+
+v0.6.21 → v0.6.22 across `templates/workflow{,-py,-ts}.yml.tmpl` and
+`.github/actions/strict-mode-gate/action.yml` header docs.
+
 ## [0.6.21] — 2026-05-29
 
 ### Added — Skill `applies_to:` filter (Phase 0.5 / 0.0.K)

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -31,6 +31,8 @@ function parseArgs(argv) {
     setProtection: true, quiet: false,
     // 0.0.M.1 (v0.6.13): `clud-bug usage` flags.
     repo: null, pr: null, limit: null, json: false,
+    // 0.0.O (v0.6.22): `clud-bug render` reads its payload from stdin.
+    stdin: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -49,6 +51,7 @@ function parseArgs(argv) {
     else if (a === '--pr') args.pr = Number(argv[++i]);
     else if (a === '--limit') args.limit = Number(argv[++i]);
     else if (a === '--json') args.json = true;
+    else if (a === '--stdin') args.stdin = true;
     else args._.push(a);
   }
   return args;
@@ -79,6 +82,11 @@ Commands:
   eval                  Run the golden-set regression gate against the rendered review
                         prompt (must-contain / must-not-contain / byte-budget). Same as
                         \`node --test test/prompts.eval.test.js\` but works from any cwd.
+  render --stdin        Render a structured-output JSON payload (the action's
+                        \`outputs.structured_output\`, piped via stdin) to the
+                        GitHub-markdown summary comment shape. Invoked by the
+                        workflow post-step; output is what \`gh pr comment\`
+                        receives. Empty stdin or non-object payload exits 2.
 
 Options:
   --offline             Skip skills.sh; pin only the bundled baseline specimens.
@@ -130,9 +138,50 @@ async function main() {
     case 'edit-workflow': return runEditWorkflow(args);
     case 'usage':   return runUsage(args);
     case 'eval':    return runEval();
+    case 'render':  return runRender(args);
     default:
       process.stderr.write(`Unknown command: ${cmd || '(none)'}\n\n${HELP}`);
       process.exit(2);
+  }
+}
+
+// 0.0.O (v0.6.22): render a structured-output JSON payload to the
+// GitHub-markdown summary comment shape. Called by the post-step
+// in the workflow templates: it reads the action's
+// `outputs.structured_output` (one bundled JSON string), pipes it
+// to stdin here, and we emit the rendered markdown on stdout for
+// the shell to pass to `gh pr comment --body`.
+//
+// Usage: `clud-bug render --stdin` (only input source supported).
+// Exit code: 0 on success, 2 on JSON parse error or non-object payload.
+async function runRender(args) {
+  const { renderReview } = await import('../lib/render-review.js');
+  if (!args.stdin) {
+    process.stderr.write('clud-bug render: --stdin is required (the only supported input source).\n');
+    process.exit(2);
+  }
+  let raw = '';
+  for await (const chunk of process.stdin) raw += chunk;
+  raw = raw.trim();
+  if (!raw) {
+    // Empty structured_output → post-step is supposed to skip the
+    // render. Surface the situation rather than silently producing an
+    // empty comment.
+    process.stderr.write('clud-bug render: stdin was empty — nothing to render.\n');
+    process.exit(2);
+  }
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch (e) {
+    process.stderr.write(`clud-bug render: JSON parse failed: ${e.message}\n`);
+    process.exit(2);
+  }
+  try {
+    process.stdout.write(renderReview(payload));
+  } catch (e) {
+    process.stderr.write(`clud-bug render: ${e.message}\n`);
+    process.exit(2);
   }
 }
 
@@ -220,6 +269,7 @@ async function runInit(args) {
   log('  drafting field kit...');
   const tmplName = pickTemplate(signals.languages);
   const tmplPath = join(TEMPLATES, tmplName);
+  // REVIEW_SCHEMA + CCA_VERSION + CLUD_BUG_VERSION come from render.js DEFAULTS.
   const workflow = await renderFile(tmplPath, {
     REVIEW_PROMPT: reviewPrompt({
       projectDescription: buildDescriptionLine(signals),

--- a/docs/decisions-branches/feat__0.0.O-json-schema.md
+++ b/docs/decisions-branches/feat__0.0.O-json-schema.md
@@ -9,3 +9,14 @@
 - Token economics: schema captures the entire summary as a SINGLE structured emission instead of N tool-call turns (free-form text + tool calls for each inline). Expected: lower output tokens per review, fewer tool-call round-trips. Need to measure via 'clud-bug usage' over the next sprint.
 
 ---
+## 2026-05-29 11:14 - 0.0.O follow-up: update clud-bug's own workflow strict-mode-gate pin + bot-login override to match the new identity contract
+
+**Reasoning:** Strict-mode-gate on PR #114 was failing red because clud-bug's own .github/workflows/clud-bug-review.yml pinned the gate at v0.6.2 with default bot-login: claude[bot]. After 0.0.O the summary is posted by the workflow post-step under github-actions[bot]. The gate's selectReviewHeader walks claude[bot] comments newest-first and lands on a PRE-0.0.O review comment (which contains '## 🐛 Clud Bug review — critical findings' from when 0.0.O's bot-identity-mismatch was the live finding), then fires red. Even after my fix push resolved the threads, the gate keeps reading that stale comment because no NEWER claude[bot] comment contains the H2 anchor (the summary now lives in github-actions[bot]). Bumping the pin to v0.6.21 + passing bot-login: 'github-actions[bot]' makes the gate look at the right author for the post-0.0.O world. Templates were updated already in this PR; clud-bug's own workflow needs the same migration to gate itself correctly.
+
+**Alternatives considered:** Override the gate's bot-login via a workflow-level env var instead of the with: input. Rejected: the composite reads inputs.bot-login, not env. The with: clause is the right surface., Don't migrate clud-bug's own workflow — ship 0.0.O behind admin-bypass, follow up with the migration after merge. Rejected: makes the next 24h of 0.0.O CI red-red-red and forces every retry to admin-bypass.
+
+**Implications:**
+- Once this push lands, the gate looks at github-actions[bot] comments. None of those exist YET on this PR (claude-code-action skipped because LLM wasn't allowed to post via gh pr comment AND the post-step only runs on a structured_output — which doesn't fire on a PR that hasn't been reviewed under the new schema). The gate returning verdict NONE = no comment found = passes advisory. After merge, future clud-bug self-reviews will produce github-actions[bot] comments via the new post-step and the gate will function correctly.
+- Templates already had bot-login: 'github-actions[bot]' applied (templates/workflow*.yml.tmpl); this commit migrates clud-bug's own existing rendered workflow to match. Documented in CHANGELOG [0.6.22] (the identity-contract section).
+
+---

--- a/docs/decisions-branches/feat__0.0.O-json-schema.md
+++ b/docs/decisions-branches/feat__0.0.O-json-schema.md
@@ -1,0 +1,11 @@
+## 2026-05-29 10:32 - 0.0.O: --json-schema structured output → renderer → gh pr comment post-step (replaces LLM-driven free-form summary posting)
+
+**Reasoning:** Verified --json-schema is a first-class Claude Code CLI flag (CONFIRMED, see agent research). New lib/review-schema.js defines a strict schema (additionalProperties: false everywhere, word caps in description fields). New lib/render-review.js + 'clud-bug render --stdin' subcommand renders structured payload to the existing v0.6.5 markdown shape. Templates updated: --json-schema '<schema>' in claude_args, post-step renders + posts via gh pr comment, fallback step posts a bare-H2 advisory when structured_output is empty (max-retries hit). Bash(gh pr comment:*) dropped from --allowedTools since the LLM no longer posts the summary. The cached system prompt has a new 'Emit as structured JSON' instruction at the SUMMARY section + an updated FIX-PUSH ordering that swaps step (c) from 'post summary' to 'emit structured summary output'. Regression test added in test/skills.test.js to pin appliesToPr's endsWith() semantics (the agent-skills#51 reviewer's catch). 295 pass.
+
+**Alternatives considered:** Phase A only: ship the schema + renderer + CLI, leave the workflow templates alone for a follow-up PR. Rejected: half-shipped features create stale-receiver risk where the renderer exists but doesn't get the LLM's structured output., Make the LLM post the comment AND emit structured output. Renderer would compare/dedup. Rejected: double-posting clutters the PR thread and the dedup logic would itself be a source of regressions.
+
+**Implications:**
+- v0.6.22 publish triggers an npm tag bump. Consumer repos running 'clud-bug update' will pick up the new workflow + post-step. The first review under v0.6.22 will exercise the schema; if Anthropic's schema-validation retries fail, the fallback comment shows the user what happened. Build a feedback loop via clud-bug usage --since 24h after first deployment to watch for any structured_output empties.
+- Token economics: schema captures the entire summary as a SINGLE structured emission instead of N tool-call turns (free-form text + tool calls for each inline). Expected: lower output tokens per review, fewer tool-call round-trips. Need to measure via 'clud-bug usage' over the next sprint.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -54,7 +54,9 @@ clud-bug
 │   │   ├── docs__skill-first-marketing-bb4.md
 │   │   ├── feat__0.0.E-golden-eval-harness.md
 │   │   ├── feat__0.0.I.1-skip-block-with-import.md
+│   │   ├── feat__0.0.K-skill-loading-minimization.md
 │   │   ├── feat__0.0.M.1-usage-dashboard.md
+│   │   ├── feat__0.0.P-prompt-trim.md
 │   │   ├── feat__0.0.R-model-routing-trivial.md
 │   │   ├── feat__0.0.T-rtk-inspired-clud-bug.md
 │   │   ├── feat__0.0.W-workflow-pr-skip.md

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-29** — 0.0.O follow-up: update clud-bug's own workflow strict-mode-gate pin + bot-login override to match the new identity contract *(feat/0.0.O-json-schema)* — [decisions-branches/feat__0.0.O-json-schema.md](decisions-branches/feat__0.0.O-json-schema.md)
 - **2026-05-29** — 0.0.O: --json-schema structured output → renderer → gh pr comment post-step (replaces LLM-driven free-form summary posting) *(feat/0.0.O-json-schema)* — [decisions-branches/feat__0.0.O-json-schema.md](decisions-branches/feat__0.0.O-json-schema.md)
 - **2026-05-29** — 0.0.K: applies_to frontmatter — skill-filter for non-applicable PRs *(feat/0.0.K-skill-loading-minimization)* — [decisions-branches/feat__0.0.K-skill-loading-minimization.md](decisions-branches/feat__0.0.K-skill-loading-minimization.md)
 - **2026-05-29** — 0.0.P: trim review prompt by ~29.6% bytes / ~25% lines without removing must-contain phrases *(feat/0.0.P-prompt-trim)* — [decisions-branches/feat__0.0.P-prompt-trim.md](decisions-branches/feat__0.0.P-prompt-trim.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-29** — 0.0.O: --json-schema structured output → renderer → gh pr comment post-step (replaces LLM-driven free-form summary posting) *(feat/0.0.O-json-schema)* — [decisions-branches/feat__0.0.O-json-schema.md](decisions-branches/feat__0.0.O-json-schema.md)
 - **2026-05-29** — 0.0.K: applies_to frontmatter — skill-filter for non-applicable PRs *(feat/0.0.K-skill-loading-minimization)* — [decisions-branches/feat__0.0.K-skill-loading-minimization.md](decisions-branches/feat__0.0.K-skill-loading-minimization.md)
 - **2026-05-29** — 0.0.P: trim review prompt by ~29.6% bytes / ~25% lines without removing must-contain phrases *(feat/0.0.P-prompt-trim)* — [decisions-branches/feat__0.0.P-prompt-trim.md](decisions-branches/feat__0.0.P-prompt-trim.md)
 - **2026-05-29** — Release clud-bug v0.6.19 — 0.0.I.1 skip-block-when-import *(feat/0.0.I.1-skip-block-with-import)* — [decisions-branches/feat__0.0.I.1-skip-block-with-import.md](decisions-branches/feat__0.0.I.1-skip-block-with-import.md)

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -214,11 +214,18 @@ Your review lives in TWO surfaces, in this order:
    Cross-cutting findings (no specific line) stay summary-only —
    but default to inline whenever you can name file:line.
 
-2. SUMMARY PR COMMENT — one top-level \`gh pr comment\` carrying
-   the H2 header, status line, per-skill scan, and per-skill
-   findings sections. The strict-mode gate greps the H2 for
-   "— critical findings" — keep it intact even when also using a
-   strict-mode variant.
+2. SUMMARY PR COMMENT — emitted as STRUCTURED JSON via the
+   workflow's \`--json-schema\` flag (0.0.O / v0.6.22+). Do NOT
+   post the summary yourself via \`gh pr comment\` — a post-step
+   reads your structured output and renders the comment with the
+   exact format the strict-mode gate expects. Populate every
+   schema field (\`status_header\`, \`summary_counts\`,
+   \`per_skill_scan\`, \`critical_findings\`, \`minor_findings\`,
+   \`preexisting_findings\`, \`skills_referenced\`,
+   \`last_reviewed_sha\`); \`dedicated_sections\` and
+   \`diagnostics\` are optional but emit them when applicable.
+   See workflow env for the schema; the format docs below describe
+   what each field becomes after rendering.
 
 The comment body MUST start with:
 
@@ -297,14 +304,16 @@ Shared-mode skill findings stay in the combined "Critical findings"
 (e.g. a logging-PII issue belongs in both critical-issues-only and
 pii-and-compliance at once).
 
-Post the summary:
-  gh pr comment "$PR_NUMBER" --body "<your review>"
+Emit the summary as structured JSON output (the workflow's
+--json-schema captures it; a post-step renders + posts via gh pr
+comment). Do NOT post the summary yourself.
 
-Inline findings post via mcp__github_inline_comment__create_inline_comment
+Inline findings still post via mcp__github_inline_comment__create_inline_comment
 (with \`confirmed: true\`). Pass ordering: (a) post inline findings,
 (b) resolve prior threads now fixed (FIX-PUSH FLOW below — feeds
-"resolved from prior"), (c) post summary. Step (b) MUST run before
-the summary; (a)/(b) order between themselves doesn't matter.
+"resolved_from_prior" counter in the JSON), (c) emit structured
+summary output. Step (b) MUST complete before (c) so the counter
+is accurate; (a)/(b) order between themselves doesn't matter.
 
 FIX-PUSH FLOW (when prior claude[bot] threads exist):
 List prior claude[bot] inline threads, resolve the ones whose issue

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -189,13 +189,18 @@ subsequent fix-push re-fetches only the delta since this SHA. Omit
 it and the next review falls back to full \`gh pr diff\`.
 
 Strict-mode header (opt-in): if .claude/skills/.clud-bug.json has
-\`{ "strictMode": true }\`, the H2 header MUST signal verdict:
-  - any critical issue flagged → \`## 🐛 Clud Bug review — critical findings\`
-  - otherwise → \`## 🐛 Clud Bug review — clean\`
-A post-step greps for "critical findings" and fails the check.
+\`{ "strictMode": true }\`, set the \`status_header\` schema field
+to signal verdict:
+  - any critical issue flagged → \`status_header: "critical findings"\`
+    (renderer emits \`## 🐛 Clud Bug review — critical findings\`)
+  - otherwise → \`status_header: "clean"\` (renderer emits
+    \`## 🐛 Clud Bug review — clean\`)
+The strict-mode gate post-step greps for "critical findings" and
+fails the check.
 
-If strictMode is unset or absent, keep the bare \`## 🐛 Clud Bug review\`
-header — strict mode is opt-in.
+If strictMode is unset or absent, set \`status_header: "bare"\` —
+the renderer emits the bare \`## 🐛 Clud Bug review\` (no suffix),
+matching the v0.6.21- visible behaviour for non-strict-mode repos.
 
 Tone: conversational, concise field-naturalist voice (you are Clud
 Bug examining specimens of code) — never at the cost of clarity,

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -68,20 +68,24 @@ cached system prefix is free at 10%; per-PR fetches are not.
     state lives in your PRIOR SUMMARY COMMENT as an HTML marker:
     \`<!-- last-reviewed-sha: <sha> -->\`.
 
-    Identifying the PRIOR SUMMARY: claude-code-action posts an
-    in-progress \`Claude Code is working…\` comment BEFORE this
-    prompt runs — claude[bot]-authored but NOT the summary (no
-    marker). Anchor on the H2 line \`## 🐛 Clud Bug review\` instead
-    of "latest claude[bot] comment" — same anchor strict-mode uses.
+    Identifying the PRIOR SUMMARY (v0.6.22+ identity note):
+    From v0.6.22 (0.0.O) onward the summary is posted by a workflow
+    post-step under the \`github-actions[bot]\` identity, not
+    claude[bot]. Inline review threads are still claude[bot] (the
+    MCP tool routes through claude-code-action). Beware: the
+    in-progress \`Claude Code is working…\` comment claude-code-action
+    posts BEFORE this prompt runs is claude[bot]-authored but is NOT
+    your prior summary (no marker). Anchor on the H2 line
+    \`## 🐛 Clud Bug review\` — same anchor strict-mode uses.
 
     Detection in three steps:
 
-      1. Fetch claude[bot] comments newest-first:
+      1. Fetch github-actions[bot] comments newest-first:
          \`gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$PR_NUMBER/comments?per_page=100&sort=created&direction=desc"\`
-         Walk them in order; find the FIRST whose body starts
-         (after any \`**Claude finished …**\` preamble the action
-         prepends) with \`## 🐛 Clud Bug review\`. THAT is your prior
-         summary. In its body, look for \`last-reviewed-sha: <sha>\`.
+         Walk them in order; filter to author \`github-actions[bot]\`,
+         and find the FIRST whose body starts with
+         \`## 🐛 Clud Bug review\`. THAT is your prior summary. In
+         its body, look for \`last-reviewed-sha: <sha>\`. (Pre-v0.6.22 summaries are claude[bot]-authored — if you find a recent claude[bot] comment with the H2 anchor and no newer github-actions[bot] match, treat it as the prior summary.)
 
       2. If a SHA was found, verify it's still in HEAD's ancestry:
          \`git merge-base --is-ancestor <prior_sha> $HEAD_SHA\`
@@ -105,7 +109,7 @@ cached system prefix is free at 10%; per-PR fetches are not.
     per file (default 4,000 bytes). Baseline skills fit easily;
     bloated user-added skills get truncated.
 
-  - PR comments: \`gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$PR_NUMBER/comments?per_page=20" --jq '.[] | select(.user.login != "claude[bot]")' | head -c "$MAX_COMMENT_BYTES"\`
+  - PR comments: \`gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$PR_NUMBER/comments?per_page=20" --jq '.[] | select(.user.login != "claude[bot]" and .user.login != "github-actions[bot]")' | head -c "$MAX_COMMENT_BYTES"\`
     (default 20,000 bytes, 20 most-recent). Skips your own prior
     comments — the FIX-PUSH FLOW handles those via reviewThreads
     GraphQL instead.
@@ -231,7 +235,7 @@ The comment body MUST start with:
 
   ## 🐛 Clud Bug review
 
-(claude[bot] is the bot login, but the header brands it Clud Bug.)
+(The post-step renders this H2 anchor — the strict-mode gate greps it.)
 
 On the next non-empty line, emit:
 

--- a/lib/render-review.js
+++ b/lib/render-review.js
@@ -1,0 +1,204 @@
+// Render a clud-bug review's structured-output JSON to the GitHub-markdown
+// summary comment shape the workflow has been posting since v0.6.5.
+//
+// 0.0.O (v0.6.22): introduced as the receiver for `--json-schema` output.
+// The LLM emits structured JSON (one bundled string via the action's
+// `outputs.structured_output`); a workflow post-step pipes that JSON to
+// `clud-bug render --stdin` (CLI subcommand), which calls renderReview()
+// here, then posts the result via `gh pr comment`. Failure mode: if
+// `structured_output` is empty (max retries hit), the post-step is
+// skipped and the LLM's prior free-form behaviour stands (it had already
+// been instructed to post via `gh pr comment` directly as a fallback).
+//
+// Why an outside renderer at all: with --json-schema the LLM can no
+// longer paraphrase the comment format (good for consistency, bad if the
+// rendered shape is wrong). Centralising the markdown shape here means a
+// future format tweak edits one function rather than the prompt.
+
+const SEVERITY_EMOJI = { critical: '🔴', minor: '🟡', preexisting: '🟣' };
+const SEVERITY_LABEL = {
+  critical: 'important',
+  minor: 'nit',
+  preexisting: 'pre-existing',
+};
+
+// Render the full summary comment markdown. `data` is the parsed JSON
+// matching the schema (see schema.js). Returns a string suitable for
+// `gh pr comment --body`.
+export function renderReview(data) {
+  if (!data || typeof data !== 'object') {
+    throw new TypeError('renderReview: data must be an object');
+  }
+  const out = [];
+  out.push(renderHeader(data));
+  out.push('');
+  out.push(renderStatusLine(data.summary_counts));
+  out.push('');
+  out.push(renderStatsHeader(data.summary_counts));
+  out.push('');
+  out.push(...renderPerSkillScan(data.per_skill_scan));
+  out.push('');
+  for (const section of data.dedicated_sections || []) {
+    out.push(...renderDedicatedSection(section));
+    out.push('');
+  }
+  if (nonEmpty(data.critical_findings)) {
+    out.push('### Critical findings');
+    out.push('');
+    out.push(...renderFindings(data.critical_findings, 'critical'));
+    out.push('');
+  }
+  if (nonEmpty(data.minor_findings)) {
+    out.push('### Minor findings');
+    out.push('');
+    out.push(...renderFindings(data.minor_findings, 'minor'));
+    out.push('');
+  }
+  if (nonEmpty(data.preexisting_findings)) {
+    out.push('### Pre-existing findings');
+    out.push('');
+    out.push(...renderFindings(data.preexisting_findings, 'preexisting'));
+    out.push('');
+  }
+  if (nonEmpty(data.diagnostics)) {
+    out.push('### Diagnostics');
+    out.push('');
+    for (const line of data.diagnostics) out.push(`- ${line}`);
+    out.push('');
+  }
+  out.push(renderSkillsReferenced(data.skills_referenced));
+  out.push('');
+  if (data.last_reviewed_sha) {
+    out.push(`<!-- last-reviewed-sha: ${data.last_reviewed_sha} -->`);
+  }
+  // Trim trailing blank lines but always keep a single trailing newline so
+  // the comment ends with a final newline (markdown rendering is unchanged
+  // either way, but it matches the prior LLM-driven shape).
+  return out.join('\n').replace(/\n{3,}/g, '\n\n').replace(/\s+$/, '') + '\n';
+}
+
+function renderHeader(data) {
+  const verdict = data.status_header;
+  const base = '## 🐛 Clud Bug review';
+  if (verdict === 'critical findings') return `${base} — critical findings`;
+  if (verdict === 'clean') return `${base} — clean`;
+  // Bare header — non-strict mode (or an unexpected verdict; keep the
+  // strict-mode gate's anchor intact even on weird input).
+  return base;
+}
+
+function renderStatusLine(counts) {
+  const c = sanitizeCounts(counts);
+  return `**This round:** ${c.critical} critical · ${c.minor} minor · ${c.resolved_from_prior} resolved from prior · ${c.still_open} still open`;
+}
+
+// Severity-emoji stats header. Counts pre-existing in 🟣 even though
+// it's not in summary_counts (the prompt counts pre-existing separately
+// in preexisting_findings.length).
+function renderStatsHeader(counts) {
+  const c = sanitizeCounts(counts);
+  return `Found: ${c.critical} 🔴 / ${c.minor} 🟡 / ${c.preexisting} 🟣`;
+}
+
+function renderPerSkillScan(scan) {
+  const out = ['### Per-skill scan'];
+  if (!Array.isArray(scan) || scan.length === 0) {
+    out.push('- (no skills loaded — review proceeded against the baseline.)');
+    return out;
+  }
+  for (const entry of scan) {
+    if (!entry || typeof entry !== 'object') continue;
+    const skill = String(entry.skill || '').trim();
+    const outcome = String(entry.outcome || '').trim();
+    if (!skill) continue;
+    out.push(`- [${skill}]: ${outcome || 'scanned (no outcome reported).'}`);
+  }
+  return out;
+}
+
+function renderDedicatedSection(section) {
+  if (!section || typeof section !== 'object') return [];
+  const name = String(section.section_name || '').trim();
+  const skill = String(section.skill || '').trim();
+  const header = skill && name
+    ? `### ${name} [${skill}]`
+    : `### ${name || skill || 'Dedicated section'}`;
+  const out = [header, ''];
+  if (Array.isArray(section.findings) && section.findings.length > 0) {
+    // Dedicated-section findings use the same emoji-prefix block.
+    // Default severity for dedicated sections is "critical" — they're
+    // domain-specific findings the skill considers important.
+    out.push(...renderFindings(section.findings, 'critical'));
+  } else {
+    out.push('No findings.');
+  }
+  return out;
+}
+
+function renderFindings(findings, severity) {
+  const emoji = SEVERITY_EMOJI[severity] || '🔴';
+  const out = [];
+  for (const f of findings) {
+    if (!f || typeof f !== 'object') continue;
+    const skill = String(f.skill || '').trim();
+    const summary = String(f.summary || '').trim();
+    if (!summary) continue;
+    const skillPrefix = skill ? `[${skill}]: ` : '';
+    const anchor = locationAnchor(f);
+    const claim = anchor
+      ? `${emoji} ${skillPrefix}${stripTrailingPunctuation(summary)} (${anchor}).`
+      : `${emoji} ${skillPrefix}${summary}`;
+    out.push(claim);
+    if (f.reasoning) {
+      out.push('<details><summary>Reasoning</summary>');
+      out.push('');
+      out.push(String(f.reasoning).trim());
+      out.push('');
+      out.push('</details>');
+    }
+    out.push('');
+  }
+  // Remove the trailing empty line — renderReview adds its own separators.
+  if (out[out.length - 1] === '') out.pop();
+  return out;
+}
+
+function renderSkillsReferenced(skills) {
+  if (!Array.isArray(skills) || skills.length === 0) {
+    return 'Skills referenced: [none] — no installed skill applied to this diff.';
+  }
+  return `Skills referenced: [${skills.join(', ')}]`;
+}
+
+// --- helpers ---
+
+function nonEmpty(arr) {
+  return Array.isArray(arr) && arr.length > 0;
+}
+
+function sanitizeCounts(counts) {
+  const c = counts && typeof counts === 'object' ? counts : {};
+  return {
+    critical: numOrZero(c.critical),
+    minor: numOrZero(c.minor),
+    preexisting: numOrZero(c.preexisting),
+    resolved_from_prior: numOrZero(c.resolved_from_prior),
+    still_open: numOrZero(c.still_open),
+  };
+}
+
+function numOrZero(v) {
+  const n = Number(v);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0;
+}
+
+function locationAnchor(f) {
+  const file = String(f.file || '').trim();
+  if (!file) return null;
+  const line = Number(f.line);
+  return Number.isFinite(line) && line > 0 ? `${file}:${line}` : file;
+}
+
+function stripTrailingPunctuation(s) {
+  return s.replace(/[.!?]+$/, '');
+}

--- a/lib/render-review.js
+++ b/lib/render-review.js
@@ -82,8 +82,8 @@ function renderHeader(data) {
   const base = '## 🐛 Clud Bug review';
   if (verdict === 'critical findings') return `${base} — critical findings`;
   if (verdict === 'clean') return `${base} — clean`;
-  // Bare header — non-strict mode (or an unexpected verdict; keep the
-  // strict-mode gate's anchor intact even on weird input).
+  // 'bare' (non-strict-mode default) OR an unexpected verdict — render
+  // the unsuffixed H2. Strict-mode gate's anchor stays intact either way.
   return base;
 }
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,6 +1,21 @@
 import { readFile } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { serializedReviewSchema } from './review-schema.js';
 
 const PLACEHOLDER_RE = /\{\{([A-Z_]+)\}\}/g;
+
+// CLUD_BUG_VERSION (0.0.O / v0.6.22) — read from this package's
+// package.json at module-load time. The rendered workflow uses
+// `npx --yes clud-bug@<CLUD_BUG_VERSION>` in the post-step that renders
+// structured output to markdown. Pinning to the version that ran
+// `clud-bug init` guarantees the renderer's output shape matches the
+// prompt's expectations.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_VERSION = JSON.parse(
+  readFileSync(join(__dirname, '..', 'package.json'), 'utf8'),
+).version;
 
 // Default values for substitution tokens that every template uses.
 // Callers can override per-render by passing the same key in `vars`.
@@ -13,6 +28,8 @@ const PLACEHOLDER_RE = /\{\{([A-Z_]+)\}\}/g;
 // version in their own forked workflow.
 export const DEFAULTS = {
   CCA_VERSION: 'v1.0.133',
+  CLUD_BUG_VERSION: PKG_VERSION,
+  REVIEW_SCHEMA: serializedReviewSchema(),
 };
 
 // Multi-line value substitution preserves YAML/Markdown indentation by

--- a/lib/review-schema.js
+++ b/lib/review-schema.js
@@ -74,8 +74,8 @@ export const REVIEW_SCHEMA = {
   properties: {
     status_header: {
       type: 'string',
-      enum: ['critical findings', 'clean'],
-      description: '`critical findings` when ANY 🔴 finding exists. `clean` when all three tiers are 0. Drives the strict-mode gate header.',
+      enum: ['critical findings', 'clean', 'bare'],
+      description: 'Strict-mode opt-in repos: `critical findings` when ANY 🔴 finding exists, otherwise `clean`. Non-strict-mode repos (the default): emit `bare` — the renderer produces a `## 🐛 Clud Bug review` H2 with no suffix, matching the v0.6.21- behaviour. Check .claude/skills/.clud-bug.json for `strictMode: true` to pick critical/clean vs bare.',
     },
     summary_counts: {
       type: 'object',

--- a/lib/review-schema.js
+++ b/lib/review-schema.js
@@ -1,0 +1,159 @@
+// JSON Schema for clud-bug review structured output (0.0.O / v0.6.22).
+//
+// Passed to claude-code-action via `claude_args: --json-schema '<JSON>'`.
+// The Agent SDK validates the LLM's emitted JSON against this schema and
+// re-prompts on mismatch (internal retry; not a clud-bug-level loop).
+//
+// Schema design choices:
+//   - Flat top-level — composite-action outputs are a single string, so we
+//     fromJSON() once and pluck fields. No deep nesting that would force
+//     extra path traversal in the post-step shell.
+//   - Word/char caps in `description:` — the SDK doc names these as the
+//     primary lever for keeping output cheap. They're advisory (the SDK
+//     does not enforce numeric caps; the LLM treats them as instruction).
+//     0.0.X already lives in the prompt, so the schema description here is
+//     a complementary belt-and-suspenders signal.
+//   - Required minimum — only the fields a renderer absolutely needs to
+//     produce a valid summary comment. Counts are always required (the
+//     stats header + status block depend on them); finding arrays are
+//     required but may be empty (a clean review has 0 findings, not
+//     missing arrays).
+//   - `additionalProperties: false` on every object — schema-strict mode.
+//     Anthropic's structured-outputs doc explicitly recommends this to
+//     keep the model from inventing fields.
+//
+// Bumped via deliberate edit; not derived from a TypeScript type. The
+// rendering side (lib/render-review.js) treats unknown fields permissively
+// — schema and renderer can drift up to one minor version safely.
+
+const FINDING_ITEM = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    skill: {
+      type: 'string',
+      description: 'The skill name in brackets, e.g. "critical-issues-only". Must match a loaded skill or "(none)".',
+    },
+    file: {
+      type: 'string',
+      description: 'Path of the affected file relative to repo root. Optional when the finding is cross-cutting.',
+    },
+    line: {
+      type: 'integer',
+      minimum: 1,
+      description: 'Line number in the affected file. Required when `file` is set.',
+    },
+    summary: {
+      type: 'string',
+      description: 'One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one).',
+    },
+    reasoning: {
+      type: 'string',
+      description: 'Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings.',
+    },
+  },
+  required: ['skill', 'summary'],
+};
+
+const PER_SKILL_SCAN_ITEM = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    skill: { type: 'string' },
+    outcome: {
+      type: 'string',
+      description: 'One sentence describing what the skill found. Max ~15 words. Examples: "scanned all paths. 2 critical findings below.", "0 findings.", "not applicable to this diff."',
+    },
+  },
+  required: ['skill', 'outcome'],
+};
+
+export const REVIEW_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    status_header: {
+      type: 'string',
+      enum: ['critical findings', 'clean'],
+      description: '`critical findings` when ANY 🔴 finding exists. `clean` when all three tiers are 0. Drives the strict-mode gate header.',
+    },
+    summary_counts: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        critical: { type: 'integer', minimum: 0 },
+        minor: { type: 'integer', minimum: 0 },
+        preexisting: { type: 'integer', minimum: 0 },
+        resolved_from_prior: { type: 'integer', minimum: 0 },
+        still_open: { type: 'integer', minimum: 0 },
+      },
+      required: ['critical', 'minor', 'preexisting', 'resolved_from_prior', 'still_open'],
+    },
+    per_skill_scan: {
+      type: 'array',
+      description: 'One entry per LOADED skill — even silent ones. Empty when no skills are installed.',
+      items: PER_SKILL_SCAN_ITEM,
+    },
+    critical_findings: {
+      type: 'array',
+      description: 'NEW 🔴 findings (bugs, security, perf, missing test coverage). May be empty.',
+      items: FINDING_ITEM,
+    },
+    minor_findings: {
+      type: 'array',
+      description: 'NEW 🟡 findings (nits, style, observations). May be empty.',
+      items: FINDING_ITEM,
+    },
+    preexisting_findings: {
+      type: 'array',
+      description: 'NEW 🟣 findings (issues that pre-date this PR). May be empty.',
+      items: FINDING_ITEM,
+    },
+    dedicated_sections: {
+      type: 'array',
+      description: 'Per-dedicated-mode-skill section blocks. Each item carries the section header text and its findings.',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          section_name: { type: 'string', description: 'Human-readable section title, e.g. "Brand voice".' },
+          skill: { type: 'string', description: 'The dedicated skill name.' },
+          findings: { type: 'array', items: FINDING_ITEM },
+        },
+        required: ['section_name', 'skill', 'findings'],
+      },
+    },
+    diagnostics: {
+      type: 'array',
+      description: '0.0.T tee-hint diagnostics. One line per `head -c` cap that fired during fetch. Empty when no truncation occurred.',
+      items: { type: 'string' },
+    },
+    skills_referenced: {
+      type: 'array',
+      description: 'Names of every skill cited in any finding. Empty list (or ["(none)"]) when no skill applied.',
+      items: { type: 'string' },
+    },
+    last_reviewed_sha: {
+      type: 'string',
+      description: 'The HEAD SHA at review time, used by the incremental-diff handshake. Set to the literal value of the workflow env var $HEAD_SHA.',
+    },
+  },
+  required: [
+    'status_header',
+    'summary_counts',
+    'per_skill_scan',
+    'critical_findings',
+    'minor_findings',
+    'preexisting_findings',
+    'skills_referenced',
+    'last_reviewed_sha',
+  ],
+};
+
+// Serialize the schema for inclusion in workflow templates as the
+// `--json-schema '<JSON>'` argument. Single-line (the workflow YAML uses
+// the pipe block; single-quoted JSON inside that needs to stay flat to
+// avoid YAML parser surprises with embedded newlines).
+export function serializedReviewSchema() {
+  return JSON.stringify(REVIEW_SCHEMA);
+}

--- a/lib/update.js
+++ b/lib/update.js
@@ -45,6 +45,7 @@ export async function runUpdate({
   // 1. Re-render review workflow with the latest template.
   const signals = await detect(cwd);
   const tmplName = pickTemplate(signals.languages);
+  // REVIEW_SCHEMA + CCA_VERSION + CLUD_BUG_VERSION come from render.js DEFAULTS.
   const newReview = await renderFile(join(templatesDir, tmplName), {
     REVIEW_PROMPT: reviewPrompt({
       projectDescription: buildDescriptionLine(signals),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -108,7 +108,7 @@ jobs:
           if $IS_FORK || $IS_BOT; then
             REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
             EXISTING=$(gh api "repos/${BASE_REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
-              --jq '[.[] | select(.user.login == "claude[bot]" and (.body | startswith("## 🐛 Clud Bug skipped")))] | length')
+              --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("## 🐛 Clud Bug skipped")))] | length')
             if [ "${EXISTING:-0}" = "0" ]; then
               BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
               gh pr comment "$PR_NUMBER" --body "$BODY" || true
@@ -165,7 +165,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
         run: |
-          BODY=$(echo "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} render --stdin)
+          set -euo pipefail
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} render --stdin)
           gh pr comment "$PR_NUMBER" --body "$BODY"
 
       # Fallback when structured_output is empty (max-retries hit).
@@ -175,6 +176,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -euo pipefail
           gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug review
 
           **This round:** 0 critical · 0 minor · 0 resolved from prior · 0 still open

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -143,19 +143,51 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           show_full_output: true
+          # v0.6.22 / 0.0.O: --json-schema captures the summary as
+          # structured output; post-step renders + posts. See workflow.yml.tmpl for design notes.
           claude_args: |
             --model ${{ needs.paths-check.outputs.model }}
             --max-turns 15
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
+            --json-schema '{{REVIEW_SCHEMA}}'
           prompt: |
             Review this pull request following the discipline in your
             system prompt — every rule about skill routing, comment
             format, the strict-mode header, the two-surface review
             shape, and the FIX-PUSH FLOW applies.
+        id: clud-bug-review
+
+      # v0.6.22 / 0.0.O: render structured output → post via gh pr comment.
+      - name: Render + post structured review
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          BODY=$(echo "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} render --stdin)
+          gh pr comment "$PR_NUMBER" --body "$BODY"
+
+      # Fallback when structured_output is empty (max-retries hit).
+      - name: Fallback summary (structured_output empty)
+        if: success() && steps.clud-bug-review.outputs.structured_output == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug review
+
+          **This round:** 0 critical · 0 minor · 0 resolved from prior · 0 still open
+
+          Found: 0 🔴 / 0 🟡 / 0 🟣
+
+          ⚠️ Structured output (\`--json-schema\`) returned empty — likely max-retries hit on schema validation. Investigate the action logs.
+
+          Skills referenced: [none]"
 
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.21
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -191,3 +191,6 @@ jobs:
         uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].
+          # See workflow.yml.tmpl for design notes.
+          bot-login: 'github-actions[bot]'

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -108,7 +108,7 @@ jobs:
           if $IS_FORK || $IS_BOT; then
             REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
             EXISTING=$(gh api "repos/${BASE_REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
-              --jq '[.[] | select(.user.login == "claude[bot]" and (.body | startswith("## 🐛 Clud Bug skipped")))] | length')
+              --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("## 🐛 Clud Bug skipped")))] | length')
             if [ "${EXISTING:-0}" = "0" ]; then
               BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
               gh pr comment "$PR_NUMBER" --body "$BODY" || true
@@ -165,7 +165,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
         run: |
-          BODY=$(echo "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} render --stdin)
+          set -euo pipefail
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} render --stdin)
           gh pr comment "$PR_NUMBER" --body "$BODY"
 
       # Fallback when structured_output is empty (max-retries hit).
@@ -175,6 +176,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -euo pipefail
           gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug review
 
           **This round:** 0 critical · 0 minor · 0 resolved from prior · 0 still open

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -143,19 +143,51 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           show_full_output: true
+          # v0.6.22 / 0.0.O: --json-schema captures the summary as
+          # structured output; post-step renders + posts. See workflow.yml.tmpl for design notes.
           claude_args: |
             --model ${{ needs.paths-check.outputs.model }}
             --max-turns 15
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
+            --json-schema '{{REVIEW_SCHEMA}}'
           prompt: |
             Review this pull request following the discipline in your
             system prompt — every rule about skill routing, comment
             format, the strict-mode header, the two-surface review
             shape, and the FIX-PUSH FLOW applies.
+        id: clud-bug-review
+
+      # v0.6.22 / 0.0.O: render structured output → post via gh pr comment.
+      - name: Render + post structured review
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          BODY=$(echo "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} render --stdin)
+          gh pr comment "$PR_NUMBER" --body "$BODY"
+
+      # Fallback when structured_output is empty (max-retries hit).
+      - name: Fallback summary (structured_output empty)
+        if: success() && steps.clud-bug-review.outputs.structured_output == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug review
+
+          **This round:** 0 critical · 0 minor · 0 resolved from prior · 0 still open
+
+          Found: 0 🔴 / 0 🟡 / 0 🟣
+
+          ⚠️ Structured output (\`--json-schema\`) returned empty — likely max-retries hit on schema validation. Investigate the action logs.
+
+          Skills referenced: [none]"
 
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.21
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -191,3 +191,6 @@ jobs:
         uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].
+          # See workflow.yml.tmpl for design notes.
+          bot-login: 'github-actions[bot]'

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -222,15 +222,56 @@ jobs:
           # the PR as trivial (Haiku) or default (Sonnet). Override
           # per-repo by editing the rendered workflow if you want a
           # specific model for a specific repo.
+          # v0.6.22 / 0.0.O: --json-schema captures the summary as
+          # structured output (action exposes outputs.structured_output).
+          # The model emits findings as schema fields; a post-step
+          # renders to markdown and posts. The schema is rendered into
+          # this template at `clud-bug init` time via {{REVIEW_SCHEMA}}.
           claude_args: |
             --model ${{ needs.paths-check.outputs.model }}
             --max-turns 15
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
+            --json-schema '{{REVIEW_SCHEMA}}'
           prompt: |
             Review this pull request following the discipline in your
             system prompt — every rule about skill routing, comment
             format, the strict-mode header, the two-surface review
             shape, and the FIX-PUSH FLOW applies.
+        id: clud-bug-review
+
+      # v0.6.22 / 0.0.O: render the structured output to the summary
+      # comment shape, post via gh pr comment. Guarded so we only run
+      # when the action returned a non-empty structured payload
+      # (max-retries hit → empty → fall through to the next step).
+      - name: Render + post structured review
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          BODY=$(echo "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} render --stdin)
+          gh pr comment "$PR_NUMBER" --body "$BODY"
+
+      # Fallback comment when the model couldn't produce schema-valid
+      # output after max retries (structured_output is empty). Keeps a
+      # bare H2 header so the strict-mode gate sees a comment and falls
+      # open (advisory) rather than panicking on a missing summary.
+      - name: Fallback summary (structured_output empty)
+        if: success() && steps.clud-bug-review.outputs.structured_output == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug review
+
+          **This round:** 0 critical · 0 minor · 0 resolved from prior · 0 still open
+
+          Found: 0 🔴 / 0 🟡 / 0 🟣
+
+          ⚠️ Structured output (\`--json-schema\`) returned empty — likely max-retries hit on schema validation. Investigate the action logs.
+
+          Skills referenced: [none]"
 
       # Strict-mode gate. Fails the check when the BASE ref's manifest
       # has { "strictMode": true } AND the latest clud-bug review's first
@@ -247,6 +288,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.21
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -158,7 +158,7 @@ jobs:
             # pull_request: synchronize on a long-running Dependabot PR would
             # otherwise stack one identical comment per rebase.
             EXISTING=$(gh api "repos/${BASE_REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
-              --jq '[.[] | select(.user.login == "claude[bot]" and (.body | startswith("## 🐛 Clud Bug skipped")))] | length')
+              --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("## 🐛 Clud Bug skipped")))] | length')
             if [ "${EXISTING:-0}" = "0" ]; then
               BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
               gh pr comment "$PR_NUMBER" --body "$BODY" || true
@@ -250,7 +250,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
         run: |
-          BODY=$(echo "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} render --stdin)
+          set -euo pipefail
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} render --stdin)
           gh pr comment "$PR_NUMBER" --body "$BODY"
 
       # Fallback comment when the model couldn't produce schema-valid
@@ -263,6 +264,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -euo pipefail
           gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug review
 
           **This round:** 0 critical · 0 minor · 0 resolved from prior · 0 still open

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -291,3 +291,10 @@ jobs:
         uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # v0.6.22 / 0.0.O: the summary is now posted by the workflow
+          # post-step under the github-actions[bot] identity (was
+          # claude[bot] when claude-code-action did the posting).
+          # Without this override the gate's default (claude[bot])
+          # never matches the new summary author → strict mode falls
+          # open advisory for every install that opted in.
+          bot-login: 'github-actions[bot]'

--- a/test/golden/byte-budget.json
+++ b/test/golden/byte-budget.json
@@ -1,11 +1,11 @@
 {
   "$schema-comment": "Size caps for the rendered prompt. UTF-8 byte counts. The CI gate fails if the actual size exceeds the cap. Caps are intentionally close to current size so 0.0.P trim work has headroom without inviting regression.",
   "max_prompt_bytes": {
-    "value": 14000,
-    "why": "Current rendered prompt is ~12.2 KB post-0.0.P trim (down from ~17 KB pre-trim — 29.6% reduction). Cap LOWERED from 18500 to lock in the win while leaving ~1.8 KB headroom for 0.0.O schema directive. Each future addition pays a meaningful tax; deliberate. See CHANGELOG [0.6.20]."
+    "value": 14500,
+    "why": "Current rendered prompt is ~14.0 KB post-0.0.O (was 12.2 KB post-0.0.P; 0.0.O added ~1.8 KB of structured-output + status_header instructions). Cap bumped 14000 → 14500 with this PR; still ~33% below the 18500 pre-0.0.P cap. See CHANGELOG [0.6.22]."
   },
   "max_prompt_lines": {
     "value": 310,
-    "why": "Current is ~272 lines post-0.0.P (down from ~362 — 25% reduction). Cap LOWERED from 380 to lock in the win while leaving ~38 lines headroom for 0.0.O. See CHANGELOG [0.6.20]."
+    "why": "Current is ~295 lines post-0.0.O. Cap holds at 310 — the prompt grew by ~23 lines for 0.0.O but stayed under the line cap. See CHANGELOG [0.6.22]."
   }
 }

--- a/test/golden/must-contain.json
+++ b/test/golden/must-contain.json
@@ -110,6 +110,16 @@
       "pattern": "SKIP that skill's body",
       "why": "0.0.K (v0.6.21). The actionable rule — the wording the LLM follows to decide which skill bodies to fetch. Trimming around this phrase would gut the filter's behavior.",
       "category": "skill-filter"
+    },
+    {
+      "pattern": "Emit the summary as structured JSON output",
+      "why": "0.0.O (v0.6.22). Without this directive, the LLM falls back to free-form `gh pr comment` posting and the post-step renders an empty comment.",
+      "category": "structured-output"
+    },
+    {
+      "pattern": "Do NOT post the summary yourself",
+      "why": "0.0.O (v0.6.22). Prevents the LLM from double-posting (one free-form via gh pr comment AND the rendered post-step) which would clutter the PR thread.",
+      "category": "structured-output"
     }
   ]
 }

--- a/test/prompts.test.js
+++ b/test/prompts.test.js
@@ -550,6 +550,45 @@ test('rendered workflow-py.yml.tmpl contains Python bullets (no generic test-cov
   assert.doesNotMatch(out, /\n            - Broken or missing test coverage/);
 });
 
+// --- 0.0.O (v0.6.22): post-step identity contract ---
+// REGRESSION GUARD: clud-bug-review on PR #114 caught that moving the
+// summary post to a workflow step with `GH_TOKEN: secrets.GITHUB_TOKEN`
+// attributes the comment to github-actions[bot], NOT claude[bot]. The
+// strict-mode gate, per-skill check-runs, and incremental-diff handshake
+// all filter on bot author — without these tests, a future template
+// refactor could silently re-introduce the identity mismatch.
+
+test('all 3 rendered workflow templates pass bot-login: github-actions[bot] to strict-mode-gate', async () => {
+  for (const tmpl of ['workflow.yml.tmpl', 'workflow-ts.yml.tmpl', 'workflow-py.yml.tmpl']) {
+    const out = await renderFile(join(TEMPLATES, tmpl), {
+      REVIEW_PROMPT: reviewPrompt({ projectDescription: 'p', language: templateLanguage(tmpl) }),
+    });
+    assert.match(
+      out,
+      /strict-mode-gate@[^\n]+\n\s+with:\n\s+github-token: [^\n]+\n[\s\S]*?bot-login: 'github-actions\[bot\]'/,
+      `${tmpl}: strict-mode-gate must receive bot-login: 'github-actions[bot]' since the summary is posted by the workflow post-step under that identity`,
+    );
+  }
+});
+
+test('reviewPrompt: prior-summary detection block names github-actions[bot] (post-0.0.O identity)', () => {
+  const out = reviewPrompt({ projectDescription: 'p' });
+  // The LLM walks comments to find the prior summary for the incremental-
+  // diff handshake. The summary is now posted by github-actions[bot].
+  assert.match(out, /github-actions\[bot\] comments newest-first/);
+  // Pre-v0.6.22 back-compat note: the prompt should mention that older
+  // summaries are claude[bot]-authored so the LLM can still find them on
+  // mid-version repos.
+  assert.match(out, /Pre-v0\.6\.22 summaries are claude\[bot\]-authored/);
+});
+
+test('reviewPrompt: PR-comments fetch excludes BOTH claude[bot] and github-actions[bot]', () => {
+  const out = reviewPrompt({ projectDescription: 'p' });
+  // Otherwise the LLM reads back its own prior summary in the comments fetch,
+  // wasting bytes and double-counting the review state.
+  assert.match(out, /\.user\.login != "claude\[bot\]" and \.user\.login != "github-actions\[bot\]"/);
+});
+
 test('APPEND_SYSTEM_PROMPT content is byte-stable across reviews of different PRs (cache prerequisite)', async () => {
   // Caching only works if the cached prefix is BYTE-IDENTICAL across runs.
   // Two synthetic reviews of the same repo (same projectDescription, same

--- a/test/prompts.test.js
+++ b/test/prompts.test.js
@@ -571,6 +571,26 @@ test('all 3 rendered workflow templates pass bot-login: github-actions[bot] to s
   }
 });
 
+test('all 3 rendered workflow templates: skip-advisory dedup query filters github-actions[bot]', async () => {
+  // REGRESSION GUARD: clud-bug-review on PR #114 caught that the
+  // Guard step's skip-dedup query filtered claude[bot] but the
+  // accompanying gh pr comment posts under github-actions[bot]
+  // (workflow GITHUB_TOKEN identity). The dedup returned 0 every
+  // run, stacking duplicate "Clud Bug skipped" advisories on every
+  // pull_request: synchronize on a long-running fork/bot PR.
+  // Mirror of the strict-mode-gate identity contract — pin it.
+  for (const tmpl of ['workflow.yml.tmpl', 'workflow-ts.yml.tmpl', 'workflow-py.yml.tmpl']) {
+    const out = await renderFile(join(TEMPLATES, tmpl), {
+      REVIEW_PROMPT: reviewPrompt({ projectDescription: 'p', language: templateLanguage(tmpl) }),
+    });
+    assert.match(
+      out,
+      /select\(\.user\.login == "github-actions\[bot\]" and \(\.body \| startswith\("## 🐛 Clud Bug skipped"\)\)\)/,
+      `${tmpl}: skip-advisory dedup query must filter github-actions[bot] (the GITHUB_TOKEN identity), not claude[bot]`,
+    );
+  }
+});
+
 test('reviewPrompt: prior-summary detection block names github-actions[bot] (post-0.0.O identity)', () => {
   const out = reviewPrompt({ projectDescription: 'p' });
   // The LLM walks comments to find the prior summary for the incremental-

--- a/test/render-review.test.js
+++ b/test/render-review.test.js
@@ -43,6 +43,18 @@ test('renderReview: bare H2 header when status_header is unknown (defensive)', (
   assert.match(out, /^## 🐛 Clud Bug review\n/);
 });
 
+test('renderReview: status_header "bare" produces unsuffixed H2 (non-strict-mode default)', () => {
+  // 0.0.O (v0.6.22): the schema explicitly accepts 'bare' as a
+  // status_header value so non-strict-mode repos can keep the v0.6.21-
+  // visible behaviour (no "— clean" / "— critical findings" suffix on
+  // the H2). Without this, every non-strict install would silently
+  // start seeing a suffix in the summary header after merge.
+  const out = renderReview({ ...MIN, status_header: 'bare' });
+  assert.match(out, /^## 🐛 Clud Bug review\n/);
+  assert.doesNotMatch(out, /— clean/);
+  assert.doesNotMatch(out, /— critical findings/);
+});
+
 test('renderReview: per-skill scan emits one line per entry with [skill]: outcome shape', () => {
   const out = renderReview({
     ...MIN,

--- a/test/render-review.test.js
+++ b/test/render-review.test.js
@@ -1,0 +1,213 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { renderReview } from '../lib/render-review.js';
+
+// Minimum-shape input that matches the schema's required fields. Tests
+// build off this via {...MIN, override} to keep each test focused.
+const MIN = {
+  status_header: 'clean',
+  summary_counts: { critical: 0, minor: 0, preexisting: 0, resolved_from_prior: 0, still_open: 0 },
+  per_skill_scan: [],
+  critical_findings: [],
+  minor_findings: [],
+  preexisting_findings: [],
+  skills_referenced: [],
+  last_reviewed_sha: 'abc1234',
+};
+
+test('renderReview: clean review with no skills produces minimal valid summary', () => {
+  const out = renderReview(MIN);
+  assert.match(out, /^## 🐛 Clud Bug review — clean/);
+  assert.match(out, /\*\*This round:\*\* 0 critical · 0 minor · 0 resolved from prior · 0 still open/);
+  assert.match(out, /Found: 0 🔴 \/ 0 🟡 \/ 0 🟣/);
+  assert.match(out, /### Per-skill scan/);
+  assert.match(out, /<!-- last-reviewed-sha: abc1234 -->/);
+  // No findings sections rendered when arrays empty.
+  assert.doesNotMatch(out, /### Critical findings/);
+  assert.doesNotMatch(out, /### Minor findings/);
+  assert.doesNotMatch(out, /### Pre-existing findings/);
+  assert.doesNotMatch(out, /### Diagnostics/);
+});
+
+test('renderReview: critical-findings header → strict-mode-gate-anchored verdict line', () => {
+  const out = renderReview({ ...MIN, status_header: 'critical findings' });
+  // The strict-mode gate greps EXACTLY this anchor. Don't change without
+  // updating the action.yml grep predicate.
+  assert.match(out, /^## 🐛 Clud Bug review — critical findings/);
+});
+
+test('renderReview: bare H2 header when status_header is unknown (defensive)', () => {
+  const out = renderReview({ ...MIN, status_header: 'something-else' });
+  // Bare anchor — strict-mode gate sees no critical-findings verdict so
+  // it falls through as non-critical. Better than throwing.
+  assert.match(out, /^## 🐛 Clud Bug review\n/);
+});
+
+test('renderReview: per-skill scan emits one line per entry with [skill]: outcome shape', () => {
+  const out = renderReview({
+    ...MIN,
+    per_skill_scan: [
+      { skill: 'critical-issues-only', outcome: 'scanned all paths. 0 findings.' },
+      { skill: 'evidence-based-review', outcome: 'applied to 0 findings.' },
+    ],
+  });
+  assert.match(out, /- \[critical-issues-only\]: scanned all paths\. 0 findings\./);
+  assert.match(out, /- \[evidence-based-review\]: applied to 0 findings\./);
+});
+
+test('renderReview: per-skill scan with empty array notes baseline-only review', () => {
+  const out = renderReview(MIN);
+  assert.match(out, /### Per-skill scan/);
+  assert.match(out, /no skills loaded — review proceeded against the baseline/);
+});
+
+test('renderReview: critical finding renders with 🔴 prefix + file:line anchor + reasoning block', () => {
+  const out = renderReview({
+    ...MIN,
+    status_header: 'critical findings',
+    summary_counts: { critical: 1, minor: 0, preexisting: 0, resolved_from_prior: 0, still_open: 0 },
+    critical_findings: [{
+      skill: 'critical-issues-only',
+      file: 'src/auth.ts',
+      line: 42,
+      summary: 'session token logged in cleartext',
+      reasoning: 'The token is written to debug.log on line 42, which ships to the central log aggregator. Replace with a redacted prefix (`token.slice(0, 4) + "***"`).',
+    }],
+  });
+  assert.match(out, /🔴 \[critical-issues-only\]: session token logged in cleartext \(src\/auth\.ts:42\)\./);
+  assert.match(out, /<details><summary>Reasoning<\/summary>/);
+  assert.match(out, /redacted prefix/);
+  assert.match(out, /<\/details>/);
+  assert.match(out, /Found: 1 🔴 \/ 0 🟡 \/ 0 🟣/);
+});
+
+test('renderReview: anchor without line renders file only', () => {
+  const out = renderReview({
+    ...MIN,
+    critical_findings: [{
+      skill: 'evidence-based-review',
+      file: 'src/auth.ts',
+      summary: 'cross-cutting nullability gap',
+    }],
+  });
+  assert.match(out, /🔴 \[evidence-based-review\]: cross-cutting nullability gap \(src\/auth\.ts\)\./);
+});
+
+test('renderReview: anchor without file renders without parens (cross-cutting)', () => {
+  const out = renderReview({
+    ...MIN,
+    critical_findings: [{
+      skill: 'critical-issues-only',
+      summary: 'missing test coverage for new endpoint',
+    }],
+  });
+  assert.match(out, /🔴 \[critical-issues-only\]: missing test coverage for new endpoint/);
+  // No parens added when there's no file.
+  assert.doesNotMatch(out, /missing test coverage for new endpoint \(\)/);
+});
+
+test('renderReview: minor + preexisting findings use 🟡 / 🟣 emoji and their own sections', () => {
+  const out = renderReview({
+    ...MIN,
+    summary_counts: { critical: 0, minor: 1, preexisting: 1, resolved_from_prior: 0, still_open: 0 },
+    minor_findings: [{ skill: 'critical-issues-only', summary: 'nit: rename helper to be self-documenting' }],
+    preexisting_findings: [{ skill: 'critical-issues-only', summary: 'pre-existing nullability gap in unrelated module' }],
+  });
+  assert.match(out, /### Minor findings/);
+  assert.match(out, /🟡 \[critical-issues-only\]: nit: rename helper to be self-documenting/);
+  assert.match(out, /### Pre-existing findings/);
+  assert.match(out, /🟣 \[critical-issues-only\]: pre-existing nullability gap/);
+  assert.match(out, /Found: 0 🔴 \/ 1 🟡 \/ 1 🟣/);
+});
+
+test('renderReview: diagnostics block renders when array is non-empty', () => {
+  const out = renderReview({
+    ...MIN,
+    diagnostics: [
+      'diff: hit MAX_DIFF_BYTES; re-fetched at 2x — recovered.',
+      'comments: still truncated at 2x cap; finding deferred.',
+    ],
+  });
+  assert.match(out, /### Diagnostics/);
+  assert.match(out, /- diff: hit MAX_DIFF_BYTES; re-fetched at 2x — recovered\./);
+  assert.match(out, /- comments: still truncated at 2x cap; finding deferred\./);
+});
+
+test('renderReview: dedicated_sections emit a H3 per section in order, before standard buckets', () => {
+  const out = renderReview({
+    ...MIN,
+    status_header: 'critical findings',
+    summary_counts: { critical: 2, minor: 0, preexisting: 0, resolved_from_prior: 0, still_open: 0 },
+    dedicated_sections: [
+      {
+        section_name: 'Brand voice',
+        skill: 'brand-voice-review',
+        findings: [{ skill: 'brand-voice-review', file: 'src/ui/Button.tsx', line: 12, summary: 'label "Click here!" violates verb-noun rule' }],
+      },
+    ],
+    critical_findings: [
+      { skill: 'critical-issues-only', file: 'src/auth.ts', line: 99, summary: 'token logged' },
+    ],
+  });
+  // Section header includes both display name and skill in brackets.
+  assert.match(out, /### Brand voice \[brand-voice-review\]/);
+  assert.match(out, /label "Click here!" violates verb-noun rule/);
+  // Standard critical bucket renders too.
+  assert.match(out, /### Critical findings/);
+  assert.match(out, /token logged/);
+  // Order: Brand voice section appears BEFORE the standard Critical findings bucket.
+  const brand = out.indexOf('### Brand voice');
+  const crit = out.indexOf('### Critical findings');
+  assert.ok(brand >= 0 && crit > brand, 'dedicated section must precede the standard critical bucket');
+});
+
+test('renderReview: skills_referenced footer single-line when present', () => {
+  const out = renderReview({
+    ...MIN,
+    skills_referenced: ['critical-issues-only', 'evidence-based-review'],
+  });
+  assert.match(out, /Skills referenced: \[critical-issues-only, evidence-based-review\]/);
+});
+
+test('renderReview: skills_referenced empty array emits [none] + reason', () => {
+  const out = renderReview(MIN);
+  assert.match(out, /Skills referenced: \[none\] — no installed skill applied to this diff/);
+});
+
+test('renderReview: last-reviewed-sha marker always emits when present', () => {
+  const out = renderReview({ ...MIN, last_reviewed_sha: 'deadbeef' });
+  // Marker on its own line at the very end (after a trailing newline).
+  assert.match(out, /<!-- last-reviewed-sha: deadbeef -->\n$/);
+});
+
+test('renderReview: throws TypeError on non-object input (programmer error)', () => {
+  assert.throws(() => renderReview(null), /must be an object/);
+  assert.throws(() => renderReview('string'), /must be an object/);
+});
+
+test('renderReview: defensively coerces negative / non-numeric counts to 0', () => {
+  // Belt-and-suspenders: the schema sets minimum: 0, but the renderer should
+  // not blow up if a malformed JSON somehow slipped through (e.g. someone
+  // hand-tests with --json-schema absent).
+  const out = renderReview({
+    ...MIN,
+    summary_counts: { critical: -3, minor: 'two', preexisting: NaN, resolved_from_prior: 0, still_open: 0 },
+  });
+  assert.match(out, /\*\*This round:\*\* 0 critical · 0 minor · 0 resolved from prior · 0 still open/);
+  assert.match(out, /Found: 0 🔴 \/ 0 🟡 \/ 0 🟣/);
+});
+
+test('renderReview: strips trailing period from summary before adding (anchor) period', () => {
+  // The renderer adds its own period after the (file:line) anchor. A summary
+  // ending in a period would render as "claim. (file:line)." — read clean.
+  const out = renderReview({
+    ...MIN,
+    critical_findings: [{
+      skill: 'evidence-based-review',
+      file: 'src/foo.ts',
+      line: 1,
+      summary: 'unsupported type assertion.',
+    }],
+  });
+  assert.match(out, /🔴 \[evidence-based-review\]: unsupported type assertion \(src\/foo\.ts:1\)\./);
+});

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -626,6 +626,26 @@ applies_to:
   assert.equal(appliesToPr(double, ['src/ui/nested/Foo.tsx']), true);
 });
 
+test('appliesToPr: compound suffixes like ".test.ts" match via endsWith (not path.extname)', () => {
+  // REGRESSION GUARD: clud-bug-review on agent-skills#51 flagged that if
+  // appliesToPr used path.extname() the compound-suffix entries (.test.ts,
+  // _test.py, etc.) in test-discipline's applies_to would silently never
+  // fire. The implementation uses endsWith — pin that here so a future
+  // "let's normalize to extname" refactor doesn't break the contract.
+  const fm = `---
+applies_to:
+  extensions: [".test.ts", "_test.py"]
+---
+`;
+  assert.equal(appliesToPr(fm, ['src/auth.test.ts']), true,
+    'compound suffix .test.ts must match src/auth.test.ts');
+  assert.equal(appliesToPr(fm, ['db/seeder_test.py']), true,
+    'compound suffix _test.py must match db/seeder_test.py');
+  // Negative — bare .ts should NOT match if only .test.ts is in the list.
+  assert.equal(appliesToPr(fm, ['src/auth.ts']), false,
+    '.ts alone should NOT match when only .test.ts is declared');
+});
+
 test('appliesToPr: paths OR extensions — any single hit applies', () => {
   const fm = `---
 applies_to:


### PR DESCRIPTION
## Summary

The review prompt now instructs the LLM to emit the summary as **structured JSON** via Claude Code CLI's `--json-schema` flag (verified live — see [research notes inline](#) below). A workflow post-step reads `steps.clud-bug-review.outputs.structured_output`, renders to the existing v0.6.5 markdown shape via `clud-bug render --stdin`, and posts via `gh pr comment`. The LLM no longer writes the summary comment itself.

Inline review threads (the OTHER surface) are unchanged — those still post via the MCP tool.

## Files

| File | Change |
|---|---|
| `lib/review-schema.js` (NEW) | `REVIEW_SCHEMA` + `serializedReviewSchema()`. Flat top-level, `additionalProperties: false` on every nested object (schema-strict mode). Word caps in `description:` fields. |
| `lib/render-review.js` (NEW) | `renderReview(data)` — pure markdown renderer. Centralises the v0.6.5 format. |
| `bin/clud-bug.js` | New `render --stdin` subcommand (and `--stdin` flag parsed). Help text updated. |
| `lib/prompts.js` | Top-of-SUMMARY-section directive: "Emit the summary as structured JSON output. Do NOT post the summary yourself." Drops the `Post the summary: gh pr comment ...` block. |
| `templates/workflow{,-py,-ts}.yml.tmpl` | `--json-schema '{{REVIEW_SCHEMA}}'` in claude_args, new render-and-post step (guarded on non-empty structured_output), fallback bare-H2 step (empty case). `Bash(gh pr comment:*)` removed from allowedTools. |
| `lib/render.js` | DEFAULTS now includes `REVIEW_SCHEMA` (from review-schema.js) + `CLUD_BUG_VERSION` (from package.json). |
| `lib/update.js` + `bin/clud-bug.js` | Callers simplified — both rely on render.js DEFAULTS for REVIEW_SCHEMA / CLUD_BUG_VERSION. |
| `test/render-review.test.js` (NEW) | 17 fixture-based tests covering clean / critical-findings / bare-H2 variants, per-skill scan, dedicated sections, all three severity tiers, diagnostics, defensive coercion. |
| `test/skills.test.js` | +1 regression test pinning `appliesToPr`'s endsWith contract (caught by clud-bug-review on agent-skills#51). |
| `test/golden/must-contain.json` | +2 entries (`Emit the summary as structured JSON output`, `Do NOT post the summary yourself`). |
| `package.json` + 3 templates + action.yml | Composite pin 0.6.21 → 0.6.22. |

## Failure modes

- **`outputs.structured_output` non-empty** → render-and-post step runs, posts the rendered markdown.
- **`outputs.structured_output` empty** (max-retries hit on schema validation) → fallback step posts a bare-H2 advisory. Strict-mode gate sees the H2 anchor and falls open rather than panicking.
- **JSON parse failure inside renderer** (defensive — schema should prevent) → `clud-bug render --stdin` exits 2, post-step exits non-zero, workflow check fails red.

## Research

Schema-enforced output verified production-ready end-to-end (see `https://code.claude.com/docs/en/cli-reference` for `--json-schema`, `https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md` for `claude_args` wiring, `outputs.structured_output` field). Failure subtype `error_max_structured_output_retries` is named in the SDK docs. Schema sits in tool/response spec, not the system prompt — caching of the cached prefix is unaffected (will measure post-deploy).

## Test plan

- [x] `npm test` — 295/295 pass.
- [x] `node bin/clud-bug.js render --stdin` smoke-tested locally with a sample JSON.
- [ ] CI green.
- [ ] After merge: tag v0.6.22 → npm publish → first review under the new schema → watch `clud-bug usage --since 24h` for `structured_output` empties and total cost trend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)