### PR TITLE
v0.6.29: Component 4 — workflow integration auto-populates skill usage

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.28
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.29
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.29] — 2026-05-31
+
+### Added — Component 4 of the pragmatic SkDD pivot (workflow integration)
+
+Closes the loop on v0.6.28's data layer + CLI. The `update-skill-usage`
+subcommand + workflow post-step now auto-populate the skill-usage
+block from every review's structured output, so `clud-bug usage
+--health` has live data to surface instead of waiting on consumers
+to run anything manually.
+
+#### `clud-bug update-skill-usage --stdin` (new subcommand)
+
+Reads structured-output JSON from stdin, computes the per-skill
+delta via `computeSkillUsageDelta`, merges into
+`.claude/skills/.clud-bug.json` via `mergeSkillUsage`, and writes
+atomically (temp file + rename). Returns exit 0 on no-op cases
+(empty stdin, no skills in payload, missing .clud-bug.json) so the
+workflow post-step never fails the review on usage-tracking issues.
+Exits 2 only on hard input errors (`--stdin` missing, malformed JSON).
+
+#### Workflow post-step (all 3 templates)
+
+`workflow.yml.tmpl`, `workflow-ts.yml.tmpl`, `workflow-py.yml.tmpl`
+gain two new post-steps after the existing render step:
+
+1. **Update skill-usage tracking** — pipes `STRUCTURED` through
+   `npx clud-bug@<pin> update-skill-usage --stdin`. Bootstraps an
+   empty `{"version": 1}` shell if the workspace lacks one (so a
+   fresh consumer repo doesn't no-op forever). `continue-on-error:
+   true` — usage-tracking flakes never fail a review.
+2. **Upload skill-usage artifact** — uploads the workspace
+   `.clud-bug.json` as a 90-day-retained workflow artifact named
+   `clud-bug-skill-usage-pr-<N>`. v0.6.30 will add cross-review
+   aggregation logic so `clud-bug usage --health` reads the artifact
+   stream and accumulates real org-level data over time.
+
+**Why artifact instead of committing back to main**: committing
+would require `contents: write` permission expansion (v0.6.23
+regression risk on private-repo triggers) + race-handling logic.
+Artifacts are GitHub-native persistence with zero permission
+expansion + zero commit noise.
+
+#### Tests
+
+`test/update-skill-usage.test.js` — 7 CLI-level tests covering
+required `--stdin` flag, empty stdin, malformed JSON, payload with
+no skills, first-write, idempotent accumulation, missing-file
+skip-with-warning. All green alongside existing 333 tests (340
+total).
+
 ## [0.6.28] — 2026-05-30
 
 ### Added — Components 1+2 of the pragmatic SkDD pivot

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -84,12 +84,18 @@ Commands:
                         \`.claude/skills/.clud-bug.json\` usage block + renders
                         archive-candidate / stale / new / healthy status per skill.
                         Read-only — no automation acts on the output. Humans
-                        decide which skills to prune. Workflow integration ships
-                        in v0.6.29; today this command surfaces whatever data
-                        has been written manually or by future runs.
+                        decide which skills to prune. v0.6.29 wires the workflow
+                        post-step that auto-writes per-review deltas; v0.6.30
+                        will aggregate across runs into the dashboard read path.
   eval                  Run the golden-set regression gate against the rendered review
                         prompt (must-contain / must-not-contain / byte-budget). Same as
                         \`node --test test/prompts.eval.test.js\` but works from any cwd.
+  update-skill-usage    Update the .claude/skills/.clud-bug.json usage block from
+                        a structured-output JSON payload (the action's
+                        \`outputs.structured_output\`). Called as a workflow
+                        post-step alongside \`render\` (v0.6.29 / Component 4).
+                        Pipe the JSON to stdin. Idempotent + atomic write.
+                        Silent no-op on empty stdin (parity with \`render\`).
   render --stdin        Render a structured-output JSON payload (the action's
                         \`outputs.structured_output\`, piped via stdin) to the
                         GitHub-markdown summary comment shape. Invoked by the
@@ -147,6 +153,7 @@ async function main() {
     case 'usage':   return runUsage(args);
     case 'eval':    return runEval();
     case 'render':  return runRender(args);
+    case 'update-skill-usage': return runUpdateSkillUsage(args);
     default:
       process.stderr.write(`Unknown command: ${cmd || '(none)'}\n\n${HELP}`);
       process.exit(2);
@@ -192,6 +199,104 @@ async function runRender(args) {
     process.exit(2);
   }
 }
+
+// v0.6.29 — Component 4. Pipe the action's structured_output through
+// the skill-usage data layer (v0.6.28) + write the merged result back
+// to .claude/skills/.clud-bug.json atomically.
+//
+// Workflow integration (post-step in workflow.yml.tmpl):
+//
+//     echo "${{ steps.review.outputs.structured_output }}" \
+//       | npx clud-bug@latest update-skill-usage --stdin
+//
+// Runs AFTER the render post-step. Silent no-op on empty stdin
+// (same contract as `render` — preserves the workflow's existing
+// "skip both if empty" branch). Idempotent: running on the same JSON
+// twice produces the same result.
+async function runUpdateSkillUsage(args) {
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  const {
+    computeSkillUsageDelta,
+    mergeSkillUsage,
+  } = await import('../lib/skill-usage.js');
+
+  if (!args.stdin) {
+    process.stderr.write('clud-bug update-skill-usage: --stdin is required.\n');
+    process.exit(2);
+  }
+
+  let raw = '';
+  for await (const chunk of process.stdin) raw += chunk;
+  raw = raw.trim();
+  if (!raw) {
+    // Empty structured_output → render is also skipped → nothing to
+    // update. Match the render contract: exit 0 with a stderr note.
+    process.stderr.write('clud-bug update-skill-usage: stdin empty — no usage update.\n');
+    return;
+  }
+
+  let reviewJson;
+  try {
+    reviewJson = JSON.parse(raw);
+  } catch (e) {
+    process.stderr.write(`clud-bug update-skill-usage: invalid JSON: ${e.message}\n`);
+    process.exit(2);
+  }
+  if (!reviewJson || typeof reviewJson !== 'object') {
+    process.stderr.write('clud-bug update-skill-usage: payload must be a JSON object.\n');
+    process.exit(2);
+  }
+
+  // Compute per-review delta. Empty delta is fine — just means no
+  // skills loaded or cited (workflow-only PRs, e.g.).
+  const delta = computeSkillUsageDelta(reviewJson);
+  if (Object.keys(delta).length === 0) {
+    process.stderr.write('clud-bug update-skill-usage: no skills in payload — nothing to record.\n');
+    return;
+  }
+
+  // Read existing .clud-bug.json. The path is canonical:
+  // .claude/skills/.clud-bug.json relative to cwd (the workflow runs
+  // from the repo root).
+  const jsonPath = path.resolve(process.cwd(), '.claude', 'skills', '.clud-bug.json');
+  let parsed;
+  try {
+    const existingRaw = await fs.readFile(jsonPath, 'utf-8');
+    parsed = JSON.parse(existingRaw);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      process.stderr.write(
+        `clud-bug update-skill-usage: no .clud-bug.json at ${jsonPath} — skipping. ` +
+        `Run \`npx clud-bug init\` first.\n`
+      );
+      return;
+    }
+    process.stderr.write(`clud-bug update-skill-usage: parse failed: ${err.message}\n`);
+    process.exit(2);
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    process.stderr.write('clud-bug update-skill-usage: .clud-bug.json malformed.\n');
+    process.exit(2);
+  }
+
+  const existingUsage = parsed.usage || {};
+  const timestamp = new Date().toISOString();
+  const mergedUsage = mergeSkillUsage(existingUsage, delta, timestamp);
+  parsed.usage = mergedUsage;
+
+  // Write back ATOMICALLY: temp file + rename. Guards against a
+  // crashed write leaving the JSON half-written + unparseable on next
+  // read (which would brick the entire skill catalog).
+  const tmpPath = jsonPath + '.tmp';
+  const serialized = JSON.stringify(parsed, null, 2) + '\n';
+  await fs.writeFile(tmpPath, serialized, 'utf-8');
+  await fs.rename(tmpPath, jsonPath);
+
+  const skillCount = Object.keys(delta).length;
+  ok(`update-skill-usage: merged ${skillCount} skill${skillCount === 1 ? '' : 's'} from review`);
+}
+
 
 // 0.0.E (v0.6.17): thin wrapper around the golden-set test file. Devs
 // who follow the README invoke `clud-bug eval` — this routes to the

--- a/docs/decisions-branches/feat__v0.6.29-skill-usage-workflow-integration.md
+++ b/docs/decisions-branches/feat__v0.6.29-skill-usage-workflow-integration.md
@@ -1,0 +1,12 @@
+## 2026-05-31 13:52 - clud-bug v0.6.29: workflow post-step + update-skill-usage CLI (Component 4)
+
+**Reasoning:** v0.6.28 shipped the dashboard + data layer with no data feeding it. v0.6.29 closes the loop by wiring the workflow to write per-review usage deltas + upload as artifacts (90d retention). Atomic write, idempotent, continue-on-error so usage-tracking flakes never fail a review.
+
+**Alternatives considered:** Commit-back to main via gh api PUT (rejected: requires contents:write expansion → v0.6.23-style trigger-firing risk on private repos + race-handling complexity), Skip Component 4 entirely + ship v0.6.29 as CLI-only (rejected: false-promise dashboard message in v0.6.28 needs a fix; small CLI-only release wastes the version slot)
+
+**Implications:**
+- Workspace .clud-bug.json edits are ephemeral — only the artifact persists. v0.6.30 must add cross-review aggregation in clud-bug usage --health to actually read artifact stream + merge
+- continue-on-error: true on both new steps — usage-tracking is non-critical telemetry; reviews must never fail because of it
+- Artifact name uses PR# — re-uploads on PR sync overwrite prior artifact for that PR. Final usage delta wins per PR, which matches semantics (we want the post-review state, not intermediate)
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -70,6 +70,7 @@ clud-bug
 │   ├── render.test.js
 │   ├── skill-usage.test.js
 │   ├── skills.test.js
+│   ├── update-skill-usage.test.js
 │   ├── update.test.js
 │   └── usage.test.js
 ├── .cursorrules

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (104 decisions)
+## 2026-05 (105 decisions)
 
-- **2026-05-30** — site: align SDD framing with Zak Elfassi's SkDD prior art *(site/smart-budget-and-drop-in-propagation)* — [decisions-branches/site__smart-budget-and-drop-in-propagation.md](decisions-branches/site__smart-budget-and-drop-in-propagation.md)
-- *... 102 more decisions ...*
+- **2026-05-31** — clud-bug v0.6.29: workflow post-step + update-skill-usage CLI (Component 4) *(feat/v0.6.29-skill-usage-workflow-integration)* — [decisions-branches/feat__v0.6.29-skill-usage-workflow-integration.md](decisions-branches/feat__v0.6.29-skill-usage-workflow-integration.md)
+- *... 103 more decisions ...*
 - **2026-05-15** — Initialize logmind decision tracking *(feat/logmind-redo)* — [decisions-branches/feat__logmind-redo.md](decisions-branches/feat__logmind-redo.md)

--- a/lib/skill-usage.js
+++ b/lib/skill-usage.js
@@ -225,8 +225,9 @@ export function formatHealthDashboard(rows) {
     return (
       'Skill health: no usage data yet.\n\n' +
       'Usage data accumulates after clud-bug reviews land in your repo.\n' +
-      'Workflow integration ships in v0.6.29 — until then this command is\n' +
-      'a structural placeholder.'
+      'v0.6.29 wires up per-review delta writes via the workflow post-step\n' +
+      'and uploads them as 90-day artifacts. v0.6.30 will add cross-review\n' +
+      'aggregation so this dashboard reads the full artifact stream.'
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -283,6 +283,30 @@ jobs:
 
           $CALIBRATION"
 
+      # v0.6.29 / Component 4 — see workflow.yml.tmpl for design notes.
+      - name: Update skill-usage tracking
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          mkdir -p .claude/skills
+          if [ ! -f .claude/skills/.clud-bug.json ]; then
+            echo '{"version": 1}' > .claude/skills/.clud-bug.json
+          fi
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} update-skill-usage --stdin
+          echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
+
+      - name: Upload skill-usage artifact
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}
+          path: .claude/skills/.clud-bug.json
+          retention-days: 90
+
       # v0.6.26 / §5.5 Layer 6 fallback render-from-inlines — see workflow.yml.tmpl for design notes.
       - name: Fallback summary (structured_output empty)
         if: success() && steps.clud-bug-review.outputs.structured_output == ''
@@ -339,7 +363,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.28
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.29
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -283,6 +283,30 @@ jobs:
 
           $CALIBRATION"
 
+      # v0.6.29 / Component 4 — see workflow.yml.tmpl for design notes.
+      - name: Update skill-usage tracking
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          mkdir -p .claude/skills
+          if [ ! -f .claude/skills/.clud-bug.json ]; then
+            echo '{"version": 1}' > .claude/skills/.clud-bug.json
+          fi
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} update-skill-usage --stdin
+          echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
+
+      - name: Upload skill-usage artifact
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}
+          path: .claude/skills/.clud-bug.json
+          retention-days: 90
+
       # v0.6.26 / §5.5 Layer 6 fallback render-from-inlines — see workflow.yml.tmpl for design notes.
       - name: Fallback summary (structured_output empty)
         if: success() && steps.clud-bug-review.outputs.structured_output == ''
@@ -339,7 +363,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.28
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.29
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -494,6 +494,44 @@ jobs:
 
           $CALIBRATION"
 
+      # v0.6.29 / Component 4: pipe structured_output through
+      # `clud-bug update-skill-usage` to compute the per-skill loads +
+      # citations delta from this one review. Writes to the ephemeral
+      # workspace .clud-bug.json AND uploads as a workflow artifact
+      # (90-day retention). v0.6.30 will add aggregation logic so
+      # `clud-bug usage --health` reads + merges artifacts across runs.
+      #
+      # Why artifact instead of committing back to main: committing
+      # would require `contents: write` permission (private-repo
+      # trigger-firing regression risk per v0.6.23 hotfix) + race
+      # handling. Artifacts are GitHub-native persistence with zero
+      # permission expansion + zero commit noise.
+      - name: Update skill-usage tracking
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true  # don't fail the whole review if usage update flakes
+        env:
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          mkdir -p .claude/skills
+          # If a .clud-bug.json already exists in the workspace (PR's
+          # snapshot), keep it. Otherwise initialize an empty shell so
+          # update-skill-usage has something to merge into.
+          if [ ! -f .claude/skills/.clud-bug.json ]; then
+            echo '{"version": 1}' > .claude/skills/.clud-bug.json
+          fi
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} update-skill-usage --stdin
+          echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
+
+      - name: Upload skill-usage artifact
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}
+          path: .claude/skills/.clud-bug.json
+          retention-days: 90
+
       # Fallback comment when the model couldn't produce schema-valid
       # output after max retries (structured_output is empty). Keeps a
       # bare H2 header so the strict-mode gate sees a comment and falls
@@ -589,7 +627,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.28
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.29
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/update-skill-usage.test.js
+++ b/test/update-skill-usage.test.js
@@ -1,0 +1,113 @@
+// CLI tests for `clud-bug update-skill-usage --stdin` (v0.6.29, Component 4).
+//
+// Verifies the subcommand:
+// - reads structured-output JSON from stdin
+// - computes the per-skill loads/citations delta
+// - merges into .claude/skills/.clud-bug.json atomically
+// - is idempotent across repeated runs
+// - handles missing/malformed JSON gracefully
+
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtemp, writeFile, mkdir, readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const CLI = join(dirname(dirname(fileURLToPath(import.meta.url))), 'bin', 'clud-bug.js');
+
+function run(cwd, args, opts = {}) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...(opts.env || {}) },
+    input: opts.input,
+  });
+}
+
+async function makeWorkspace() {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-usage-'));
+  await mkdir(join(dir, '.claude', 'skills'), { recursive: true });
+  return dir;
+}
+
+test('update-skill-usage: errors when --stdin missing', () => {
+  const r = run(process.cwd(), ['update-skill-usage']);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /--stdin is required/);
+});
+
+test('update-skill-usage: empty stdin is a no-op (returns 0)', async () => {
+  const dir = await makeWorkspace();
+  await writeFile(join(dir, '.claude/skills/.clud-bug.json'), '{"version": 1}');
+  const r = run(dir, ['update-skill-usage', '--stdin'], { input: '' });
+  assert.equal(r.status, 0);
+  assert.match(r.stderr, /stdin empty/);
+});
+
+test('update-skill-usage: malformed JSON exits 2', async () => {
+  const dir = await makeWorkspace();
+  const r = run(dir, ['update-skill-usage', '--stdin'], { input: 'not-json{{{' });
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /invalid JSON/);
+});
+
+test('update-skill-usage: payload with no skills is a no-op', async () => {
+  const dir = await makeWorkspace();
+  await writeFile(join(dir, '.claude/skills/.clud-bug.json'), '{"version": 1}');
+  const payload = JSON.stringify({ summary: 'no findings', verdict: 'pass' });
+  const r = run(dir, ['update-skill-usage', '--stdin'], { input: payload });
+  assert.equal(r.status, 0);
+  assert.match(r.stderr, /no skills/);
+});
+
+test('update-skill-usage: writes usage block on first run', async () => {
+  const dir = await makeWorkspace();
+  await writeFile(join(dir, '.claude/skills/.clud-bug.json'), '{"version": 1}');
+  const payload = JSON.stringify({
+    per_skill_scan: [
+      { skill: 'critical-issues-only', outcome: 'scanned 3 files' },
+      { skill: 'evidence-based-review', outcome: '0 findings' },
+    ],
+    critical_findings: [
+      { skill: 'critical-issues-only', summary: 'nullderef', file: 'a.js', line: 12 },
+    ],
+  });
+  const r = run(dir, ['update-skill-usage', '--stdin'], { input: payload });
+  assert.equal(r.status, 0, r.stderr);
+  const json = JSON.parse(await readFile(join(dir, '.claude/skills/.clud-bug.json'), 'utf8'));
+  assert.equal(json.usage['critical-issues-only'].loads, 1);
+  assert.equal(json.usage['critical-issues-only'].citations, 1);
+  assert.equal(json.usage['evidence-based-review'].loads, 1);
+  assert.equal(json.usage['evidence-based-review'].citations, 0);
+  assert.ok(json.usage['critical-issues-only'].last_cited);
+});
+
+test('update-skill-usage: idempotent accumulation across two runs', async () => {
+  const dir = await makeWorkspace();
+  await writeFile(join(dir, '.claude/skills/.clud-bug.json'), '{"version": 1}');
+  const payload = JSON.stringify({
+    per_skill_scan: [{ skill: 'pii-and-compliance', outcome: 'scan' }],
+    critical_findings: [{ skill: 'pii-and-compliance', summary: 'pii', file: 'x.js', line: 1 }],
+  });
+  run(dir, ['update-skill-usage', '--stdin'], { input: payload });
+  run(dir, ['update-skill-usage', '--stdin'], { input: payload });
+  const json = JSON.parse(await readFile(join(dir, '.claude/skills/.clud-bug.json'), 'utf8'));
+  assert.equal(json.usage['pii-and-compliance'].loads, 2);
+  assert.equal(json.usage['pii-and-compliance'].citations, 2);
+});
+
+test('update-skill-usage: skips with warning when .clud-bug.json missing', async () => {
+  const dir = await makeWorkspace();
+  // No .clud-bug.json on disk — CLI returns 0 with a stderr note rather
+  // than failing the workflow. The workflow template bootstraps an
+  // empty shell before invoking, so this path only fires when the
+  // workspace is unusual (e.g., a consumer hasn't run `clud-bug init`).
+  const payload = JSON.stringify({
+    per_skill_scan: [{ skill: 'logmind', outcome: 'scan' }],
+  });
+  const r = run(dir, ['update-skill-usage', '--stdin'], { input: payload });
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stderr, /no \.clud-bug\.json/);
+});


### PR DESCRIPTION
## Summary

- New CLI subcommand `clud-bug update-skill-usage --stdin` — reads structured-output JSON, computes per-skill delta, merges into `.claude/skills/.clud-bug.json` (atomic temp+rename).
- Two new post-steps in all 3 workflow templates (workflow.yml.tmpl, workflow-ts, workflow-py):
  1. Pipe `STRUCTURED` through `update-skill-usage` (bootstraps empty `{"version": 1}` if workspace lacks one).
  2. Upload `.clud-bug.json` as a 90-day workflow artifact named `clud-bug-skill-usage-pr-<N>`.
- Both new steps `continue-on-error: true` — usage-tracking flakes never fail a review.
- Version bump 0.6.28 → 0.6.29 (package.json + 3 workflow pins + composite-action header).
- Dashboard placeholder message updated to reflect v0.6.29 wiring + v0.6.30 aggregation roadmap.
- `lib/skill-usage.js` unchanged from v0.6.28 — same pure functions, now actually invoked from CI.

## Why artifact instead of commit-back

`gh api PUT contents/.clud-bug.json` would require `contents: write` permission expansion. v0.6.23 hit a private-repo trigger-firing regression from a similar expansion; safer to use GitHub-native artifact persistence with zero permission widening + zero commit noise. v0.6.30 will add cross-review aggregation logic so `clud-bug usage --health` reads the artifact stream.

## Test plan

- [x] `npm test` — 340 tests pass (333 prior + 7 new CLI-level tests in `test/update-skill-usage.test.js`)
- [x] New tests cover: missing `--stdin`, empty stdin, malformed JSON, no-skills payload, first-write, idempotent accumulation, missing-file skip-with-warning
- [ ] Self-review (this PR's clud-bug-review) emits a skill-usage artifact
- [ ] Propagation cycle: consumer PRs after merge pull the new templates + write to their workspace