### PR TITLE
v0.6.30: cross-review aggregation reads workflow artifacts into dashboard

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.29
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.30
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.30] — 2026-05-31
+
+### Added — cross-review aggregation closes the SkDD usage loop
+
+`clud-bug usage --health` now reads accumulated org-wide data from the
+per-PR artifacts uploaded by v0.6.29's workflow post-step. The
+deterministic dashboard goes from "placeholder waiting for data" to
+"live signal for which skills earn their place."
+
+#### `lib/skill-usage.js` additions
+
+- `fetchUsageArtifacts({owner, repo, since?, ghRunner?})` — lists
+  `clud-bug-skill-usage-pr-*` artifacts via `gh api repos/owner/repo/actions/artifacts`,
+  downloads each to a tmp dir via `gh run download`, parses the
+  `.clud-bug.json` payload, returns `{prNumber, artifactId, usage, fetchedAt}`
+  records. Filters expired artifacts + non-matching names. Tmp dirs
+  cleaned up after every artifact (no disk leak).
+- `aggregateUsageStream(artifacts)` — left-fold via `mergeSkillUsage`,
+  ordered by `fetchedAt` ascending so `last_cited` reflects the most
+  recent citing artifact. Pure function; commutative for `loads` +
+  `citations` counts, so out-of-order input produces identical output.
+- `DEFAULT_GH_RUNNER` — exported runner contract (`{json, run}`) that
+  tests can inject a mock against. Spawns local `gh` by default.
+
+#### `bin/clud-bug.js` wiring
+
+- `runUsageHealth` now picks read source in this priority:
+  1. `--no-artifacts` flag → force local `.clud-bug.json` (v0.6.28 behavior).
+  2. `--repo owner/name` flag → use artifacts from that repo.
+  3. Otherwise infer `owner/name` from `gh repo view` of the current dir.
+  4. Fall back to local file if artifact path returns nothing.
+- New `--no-artifacts` arg; existing `--repo` reused.
+- The `ok` line now reports the source so users see whether the
+  dashboard is showing local or org-wide data.
+
+#### Tests
+
+`test/skill-usage-aggregation.test.js` (new, 16 tests):
+- `aggregateUsageStream` — empty / single / multi-artifact / out-of-order /
+  partial-skill-overlap / `last_cited` timestamp semantics.
+- `fetchUsageArtifacts` — required-args / empty-list / null-runner /
+  malformed-name skip / valid-record / failed-download skip / since-filter /
+  malformed-json skip / missing-usage-field default-empty.
+- `ghRunner` is injected; no `gh` binary or `GH_TOKEN` required.
+
+#### Version bumps
+
+`package.json` 0.6.29 → 0.6.30 + composite-action pin in 3 templates +
+strict-mode-gate action header. Release-discipline test enforces.
+
 ## [0.6.29] — 2026-05-31
 
 ### Added — Component 4 of the pragmatic SkDD pivot (workflow integration)

--- a/bin/clud-bug.js
+++ b/bin/clud-bug.js
@@ -33,6 +33,10 @@ function parseArgs(argv) {
     repo: null, pr: null, limit: null, json: false,
     // 0.0.O (v0.6.22): `clud-bug render` reads its payload from stdin.
     stdin: false,
+    // v0.6.30: cross-review aggregation read source for `usage --health`.
+    // Defaults to true (artifact mode); `--no-artifacts` forces local
+    // .clud-bug.json read (matches v0.6.28 behavior).
+    artifacts: true,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -53,6 +57,7 @@ function parseArgs(argv) {
     else if (a === '--json') args.json = true;
     else if (a === '--stdin') args.stdin = true;
     else if (a === '--health') args.health = true;
+    else if (a === '--no-artifacts') args.artifacts = false;
     else args._.push(a);
   }
   return args;
@@ -80,13 +85,18 @@ Commands:
                         rate, 30-day rolling \$/LOC trend, per-repo/per-model
                         distributions, and outliers (> 2x org median).
                         Use --pr / --repo / --since / --limit / --json to filter.
-  usage --health        Deterministic skill-health dashboard (v0.6.28). Reads
-                        \`.claude/skills/.clud-bug.json\` usage block + renders
-                        archive-candidate / stale / new / healthy status per skill.
-                        Read-only — no automation acts on the output. Humans
-                        decide which skills to prune. v0.6.29 wires the workflow
-                        post-step that auto-writes per-review deltas; v0.6.30
-                        will aggregate across runs into the dashboard read path.
+  usage --health        Deterministic skill-health dashboard. Renders archive-
+                        candidate / stale / new / healthy status per skill, applying
+                        the v0.6.28 thresholds (citations==0 + loads>=5 → archive
+                        candidate; last cited >60d → stale; etc.). Read-only —
+                        humans decide what to prune.
+                        Read source (v0.6.30): by default, walks
+                        \`clud-bug-skill-usage-pr-*\` workflow artifacts uploaded
+                        by every clud-bug-review run and accumulates them into
+                        one org-level snapshot. Pass \`--repo owner/name\` to
+                        target a specific repo; otherwise infers from the local
+                        git remote. \`--no-artifacts\` falls back to reading the
+                        local \`.claude/skills/.clud-bug.json\` (v0.6.28 behavior).
   eval                  Run the golden-set regression gate against the rendered review
                         prompt (must-contain / must-not-contain / byte-budget). Same as
                         \`node --test test/prompts.eval.test.js\` but works from any cwd.
@@ -985,39 +995,119 @@ async function runUsage(args) {
 // v0.6.28 — `clud-bug usage --health` implementation. Reads the local
 // .claude/skills/.clud-bug.json usage block, applies deterministic
 // thresholds, renders a read-only dashboard. No I/O beyond the JSON
-// read. Workflow integration that POPULATES the usage block ships in
-// v0.6.29; today this command is the consumer half of the contract.
-async function runUsageHealth(_args) {
-  const fs = await import('node:fs/promises');
-  const path = await import('node:path');
+// read.
+//
+// v0.6.30 — read accumulated usage from workflow artifacts (uploaded
+// by v0.6.29's post-step). Defaults to artifact mode when --repo is
+// passed OR an `owner/name` can be inferred from `git remote`. Falls
+// back to the local-file path otherwise. The `--no-artifacts` flag
+// forces the v0.6.28 local-only behavior (handy for tests + offline).
+async function runUsageHealth(args) {
   const { assessSkillHealth, formatHealthDashboard } = await import('../lib/skill-usage.js');
 
-  const jsonPath = path.resolve(process.cwd(), '.claude', 'skills', '.clud-bug.json');
-
-  let parsed;
-  try {
-    const raw = await fs.readFile(jsonPath, 'utf-8');
-    parsed = JSON.parse(raw);
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      process.stderr.write(
-        `clud-bug usage --health: no .claude/skills/.clud-bug.json found in ${process.cwd()}.\n` +
-        `Run \`npx clud-bug init\` first to install the catalog state.\n`
-      );
-      process.exit(1);
-    }
-    process.stderr.write(`clud-bug usage --health: failed to parse .clud-bug.json: ${err.message}\n`);
-    process.exit(1);
+  // Decide read source. Priority: explicit --no-artifacts → local;
+  // explicit --repo OR inferred owner/repo → artifacts; else local.
+  const wantArtifacts = args.artifacts !== false;
+  let ownerRepo = null;
+  if (wantArtifacts) {
+    ownerRepo = args.repo || await inferOwnerRepoFromGit();
   }
 
-  const usage = parsed && parsed.usage ? parsed.usage : {};
+  let usage;
+  let source;
+  if (wantArtifacts && ownerRepo) {
+    const result = await loadUsageFromArtifacts(ownerRepo, args);
+    if (result) {
+      usage = result.usage;
+      source = `${result.artifactCount} artifact${result.artifactCount === 1 ? '' : 's'} from ${ownerRepo}`;
+    }
+  }
+
+  // Fallback to local .clud-bug.json (v0.6.28 behavior).
+  if (usage == null) {
+    const localResult = await loadUsageFromLocalFile();
+    if (localResult == null) {
+      // Both paths failed. The local helper has already written its
+      // own stderr explanation; we just exit.
+      process.exit(1);
+    }
+    usage = localResult;
+    source = `local .clud-bug.json`;
+  }
+
   const rows = assessSkillHealth(usage, new Date());
   process.stdout.write(formatHealthDashboard(rows) + '\n');
 
   // Exit code semantics: 0 (informational). The dashboard is read-only;
   // archive-candidates being present is NOT a failure mode — humans
   // decide. CI gates should NOT block on this.
-  ok(`skill health: ${rows.length} skill${rows.length === 1 ? '' : 's'} tracked`);
+  ok(`skill health: ${rows.length} skill${rows.length === 1 ? '' : 's'} tracked (source: ${source})`);
+}
+
+// Helpers split out from runUsageHealth so the two read paths are
+// independently testable + composable in future commands.
+
+async function loadUsageFromArtifacts(ownerRepo, args) {
+  const { fetchUsageArtifacts, aggregateUsageStream } = await import('../lib/skill-usage.js');
+  const [owner, repo] = ownerRepo.split('/');
+  if (!owner || !repo) {
+    process.stderr.write(`clud-bug usage --health: --repo must be in owner/name form, got "${ownerRepo}".\n`);
+    return null;
+  }
+  const since = parseSinceArg(args.since);
+  let artifacts;
+  try {
+    artifacts = await fetchUsageArtifacts({ owner, repo, since });
+  } catch (err) {
+    process.stderr.write(`::notice::clud-bug usage --health: artifact fetch failed (${err.message}) — falling back to local .clud-bug.json\n`);
+    return null;
+  }
+  if (artifacts.length === 0) {
+    process.stderr.write(`::notice::clud-bug usage --health: no skill-usage artifacts found in ${ownerRepo} — falling back to local .clud-bug.json\n`);
+    return null;
+  }
+  return {
+    usage: aggregateUsageStream(artifacts),
+    artifactCount: artifacts.length,
+  };
+}
+
+async function loadUsageFromLocalFile() {
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  const jsonPath = path.resolve(process.cwd(), '.claude', 'skills', '.clud-bug.json');
+  try {
+    const raw = await fs.readFile(jsonPath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    return (parsed && parsed.usage) ? parsed.usage : {};
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      process.stderr.write(
+        `clud-bug usage --health: no .claude/skills/.clud-bug.json found in ${process.cwd()}.\n` +
+        `Run \`npx clud-bug init\` first OR pass --repo owner/name to read from workflow artifacts.\n`
+      );
+      return null;
+    }
+    process.stderr.write(`clud-bug usage --health: failed to parse .clud-bug.json: ${err.message}\n`);
+    return null;
+  }
+}
+
+async function inferOwnerRepoFromGit() {
+  // `gh repo view --json nameWithOwner` reads the current dir's git
+  // remote AND respects gh's config. Returns null on non-git dirs.
+  const result = await ghJson(['repo', 'view', '--json', 'nameWithOwner']);
+  return result && result.nameWithOwner ? result.nameWithOwner : null;
+}
+
+function parseSinceArg(since) {
+  if (!since) return null;
+  if (since instanceof Date) return since;
+  const m = String(since).match(/^(\d+)([dwmy])$/);
+  if (!m) return null;
+  const n = Number(m[1]);
+  const unitMs = { d: 86400e3, w: 7 * 86400e3, m: 30 * 86400e3, y: 365 * 86400e3 }[m[2]];
+  return new Date(Date.now() - n * unitMs);
 }
 
 // limit to 100 to avoid pagination explosions.

--- a/docs/decisions-branches/feat__v0.6.30-cross-review-aggregation.md
+++ b/docs/decisions-branches/feat__v0.6.30-cross-review-aggregation.md
@@ -10,3 +10,14 @@
 - Artifact retention is 90 days, so the dashboard covers a rolling 3-month window without needing a separate retention policy
 
 ---
+## 2026-05-31 23:59 - v0.6.30 fix: drop --paginate, use ?per_page=100 (clud-bug-review PR #127)
+
+**Reasoning:** clud-bug-review caught a silent-failure bug on PR #127: gh api --paginate --jq <expr> applies the jq filter to each page independently, producing concatenated [...] [...] which is not valid JSON. JSON.parse returns null and the dashboard silently shows empty for repos with >30 artifacts (default page size). Fixing by switching to a single ?per_page=100 call.
+
+**Alternatives considered:** Manual pagination loop with explicit ?page=N (rejected as overkill for v0.6.30 — most repos won't exceed 100 artifacts in the 90-day window; per_page=100 is the smaller fix, scale up later if needed), Server-side aggregation via separate API (rejected: GitHub artifacts API has no aggregate endpoint)
+
+**Implications:**
+- Repos with >100 active artifacts in the 90-day window won't see older ones in the dashboard. Document this limitation; revisit in v0.6.31+ if a consumer saturates
+- Added regression guard test that asserts the URL contains per_page=100 AND --paginate is not in args. Prevents future re-introduction
+
+---

--- a/docs/decisions-branches/feat__v0.6.30-cross-review-aggregation.md
+++ b/docs/decisions-branches/feat__v0.6.30-cross-review-aggregation.md
@@ -1,0 +1,12 @@
+## 2026-05-31 23:42 - clud-bug v0.6.30: cross-review aggregation reads workflow artifacts into dashboard
+
+**Reasoning:** v0.6.29 wired up per-PR artifact uploads but the v0.6.28 dashboard still read only the local .clud-bug.json (always empty unless someone ran update-skill-usage locally). v0.6.30 adds fetchUsageArtifacts + aggregateUsageStream so the dashboard walks workflow artifacts + merges them into one org-level snapshot — the deterministic SkDD loop is now closed end-to-end.
+
+**Alternatives considered:** Read artifacts directly via ZIP-byte parsing in Node (rejected: no built-in ZIP parser, would add adm-zip/yauzl dep — gh run download auto-extracts cleanly), Commit per-review usage data back to main from CI (rejected as v0.6.29 — contents:write expansion = v0.6.23-style regression risk + race-handling complexity), Build a separate aggregation service that crons through artifacts and writes a merged blob (rejected: read-on-demand from CLI is simpler + has no infra to maintain)
+
+**Implications:**
+- Dashboard now infers owner/repo from gh repo view of current dir — Just Works when run from the repo root. Falls back to local file in non-git dirs
+- Tests inject a mock ghRunner via DEFAULT_GH_RUNNER contract — no shelling out, no GH_TOKEN, no network. 16 tests cover both aggregation purity + fetch error paths
+- Artifact retention is 90 days, so the dashboard covers a rolling 3-month window without needing a separate retention policy
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -68,6 +68,7 @@ clud-bug
 │   ├── release-discipline.test.js
 │   ├── render-review.test.js
 │   ├── render.test.js
+│   ├── skill-usage-aggregation.test.js
 │   ├── skill-usage.test.js
 │   ├── skills.test.js
 │   ├── update-skill-usage.test.js

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (106 decisions)
+## 2026-05 (107 decisions)
 
-- **2026-05-31** — chore: self-propagate v0.6.29 (skill-usage workflow integration eats its own dogfood) *(chore/self-propagate-v0.6.29)* — [decisions-branches/chore__self-propagate-v0.6.29.md](decisions-branches/chore__self-propagate-v0.6.29.md)
-- *... 104 more decisions ...*
+- **2026-05-31** — clud-bug v0.6.30: cross-review aggregation reads workflow artifacts into dashboard *(feat/v0.6.30-cross-review-aggregation)* — [decisions-branches/feat__v0.6.30-cross-review-aggregation.md](decisions-branches/feat__v0.6.30-cross-review-aggregation.md)
+- *... 105 more decisions ...*
 - **2026-05-15** — Initialize logmind decision tracking *(feat/logmind-redo)* — [decisions-branches/feat__logmind-redo.md](decisions-branches/feat__logmind-redo.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (107 decisions)
+## 2026-05 (108 decisions)
 
-- **2026-05-31** — clud-bug v0.6.30: cross-review aggregation reads workflow artifacts into dashboard *(feat/v0.6.30-cross-review-aggregation)* — [decisions-branches/feat__v0.6.30-cross-review-aggregation.md](decisions-branches/feat__v0.6.30-cross-review-aggregation.md)
-- *... 105 more decisions ...*
+- **2026-05-31** — v0.6.30 fix: drop --paginate, use ?per_page=100 (clud-bug-review PR #127) *(feat/v0.6.30-cross-review-aggregation)* — [decisions-branches/feat__v0.6.30-cross-review-aggregation.md](decisions-branches/feat__v0.6.30-cross-review-aggregation.md)
+- *... 106 more decisions ...*
 - **2026-05-15** — Initialize logmind decision tracking *(feat/logmind-redo)* — [decisions-branches/feat__logmind-redo.md](decisions-branches/feat__logmind-redo.md)

--- a/lib/skill-usage.js
+++ b/lib/skill-usage.js
@@ -333,12 +333,22 @@ export async function fetchUsageArtifacts({ owner, repo, since = null, ghRunner 
     throw new Error('fetchUsageArtifacts: owner + repo are required');
   }
 
-  // List artifacts (paginated). We filter client-side because the API
-  // doesn't support `name` filtering directly.
+  // List artifacts in one call. We deliberately do NOT use `--paginate`:
+  // `gh api --paginate --jq <expr>` applies the jq filter to EACH page
+  // independently and concatenates the outputs with newlines, which
+  // produces `[...]\n[...]` — invalid as a single JSON document.
+  // `JSON.parse` returns null and the dashboard silently shows nothing
+  // for repos with >30 artifacts (default page size). Caught by
+  // clud-bug-review on PR #127.
+  //
+  // `?per_page=100` covers up to 100 artifacts in one call. The 90-day
+  // artifact retention means most repos won't hit that ceiling (>100
+  // PR reviews in 90 days = >1/day sustained). If a future repo
+  // saturates this, paginate manually in v0.6.31+ (per_page=100 +
+  // explicit `?page=N` loop, parse each response as JSON, concatenate).
   const list = await ghRunner.json([
     'api',
-    `repos/${owner}/${repo}/actions/artifacts`,
-    '--paginate',
+    `repos/${owner}/${repo}/actions/artifacts?per_page=100`,
     '--jq',
     '[.artifacts[] | select(.name | startswith("clud-bug-skill-usage-pr-")) | select(.expired == false) | {id, name, workflow_run_id: .workflow_run.id, created_at}]',
   ]);

--- a/lib/skill-usage.js
+++ b/lib/skill-usage.js
@@ -260,3 +260,163 @@ export function formatHealthDashboard(rows) {
   lines.push('  healthy           = cited within 60 days');
   return lines.join('\n');
 }
+
+// ---------------------------------------------------------------------------
+// v0.6.30 — cross-review aggregation
+//
+// The v0.6.29 workflow post-step uploads `.clud-bug.json` as a per-PR
+// artifact named `clud-bug-skill-usage-pr-<N>` (90-day retention). This
+// section walks the artifact stream + accumulates into one dashboard read.
+//
+// Artifact persistence design choice (recap from v0.6.29): we picked
+// artifacts over commit-back-to-main because commit-back required
+// `contents: write` permission expansion — v0.6.23 hit a regression
+// from a similar expansion. Artifacts are GitHub-native, zero perm
+// widening, zero commit noise. v0.6.30 reads them back here.
+// ---------------------------------------------------------------------------
+
+/**
+ * Default `gh` runner — spawns the local gh CLI. Tests inject a mock.
+ *
+ * The runner has two methods:
+ *   - json(args): returns parsed JSON stdout, or null on error.
+ *   - run(args): returns {code, stdout, stderr}. For commands that
+ *     download files etc. — no JSON parsing.
+ */
+async function defaultGhJson(args) {
+  const { spawn } = await import('node:child_process');
+  return new Promise((resolve) => {
+    const child = spawn('gh', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    child.stdout.on('data', (d) => { stdout += d; });
+    child.on('error', () => resolve(null));
+    child.on('close', (code) => {
+      if (code !== 0) return resolve(null);
+      try { resolve(JSON.parse(stdout)); } catch { resolve(null); }
+    });
+  });
+}
+
+async function defaultGhRun(args) {
+  const { spawn } = await import('node:child_process');
+  return new Promise((resolve) => {
+    const child = spawn('gh', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => { stdout += d; });
+    child.stderr.on('data', (d) => { stderr += d; });
+    child.on('error', () => resolve({ code: 1, stdout: '', stderr: 'gh not on PATH' }));
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+export const DEFAULT_GH_RUNNER = {
+  json: defaultGhJson,
+  run: defaultGhRun,
+};
+
+/**
+ * Fetch all per-PR skill-usage artifacts from a repo. Each artifact is
+ * downloaded to a temp dir, its `.clud-bug.json` is parsed, and the
+ * usage block is returned.
+ *
+ * @param {object} opts
+ * @param {string} opts.owner - GitHub repo owner.
+ * @param {string} opts.repo - GitHub repo name.
+ * @param {Date|null} opts.since - Filter to artifacts created on/after this date.
+ * @param {object} opts.ghRunner - Injected gh CLI runner (see DEFAULT_GH_RUNNER).
+ *
+ * @returns {Promise<{prNumber: number, artifactId: number, usage: object, fetchedAt: string}[]>}
+ */
+export async function fetchUsageArtifacts({ owner, repo, since = null, ghRunner = DEFAULT_GH_RUNNER }) {
+  if (!owner || !repo) {
+    throw new Error('fetchUsageArtifacts: owner + repo are required');
+  }
+
+  // List artifacts (paginated). We filter client-side because the API
+  // doesn't support `name` filtering directly.
+  const list = await ghRunner.json([
+    'api',
+    `repos/${owner}/${repo}/actions/artifacts`,
+    '--paginate',
+    '--jq',
+    '[.artifacts[] | select(.name | startswith("clud-bug-skill-usage-pr-")) | select(.expired == false) | {id, name, workflow_run_id: .workflow_run.id, created_at}]',
+  ]);
+
+  // `--jq '[...]'` wraps the stream into a single array. If the runner
+  // returns null (404, no auth, etc.), bail to empty list.
+  if (!Array.isArray(list)) return [];
+
+  const filtered = since
+    ? list.filter((a) => new Date(a.created_at) >= since)
+    : list;
+
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  const os = await import('node:os');
+
+  const results = [];
+  for (const art of filtered) {
+    const prMatch = art.name.match(/^clud-bug-skill-usage-pr-(\d+)$/);
+    if (!prMatch) continue;
+    const prNumber = Number(prMatch[1]);
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'clud-bug-art-'));
+    try {
+      const dl = await ghRunner.run([
+        'run', 'download', String(art.workflow_run_id),
+        '-R', `${owner}/${repo}`,
+        '-n', art.name,
+        '-D', tmpDir,
+      ]);
+      if (dl.code !== 0) continue;
+
+      // The workflow uploaded `.clud-bug.json` (single file under the
+      // path key). `gh run download -D <dir>` writes it to the dest as
+      // `<dir>/.clud-bug.json` (preserves the source path).
+      const jsonPath = path.join(tmpDir, '.clud-bug.json');
+      let parsed;
+      try {
+        const raw = await fs.readFile(jsonPath, 'utf-8');
+        parsed = JSON.parse(raw);
+      } catch {
+        continue; // artifact corrupted or layout unexpected
+      }
+      const usage = parsed && parsed.usage ? parsed.usage : {};
+      results.push({
+        prNumber,
+        artifactId: art.id,
+        usage,
+        fetchedAt: art.created_at,
+      });
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Reduce an array of per-PR artifact records into a single accumulated
+ * usage block by left-folding `mergeSkillUsage` over them, ordered by
+ * `fetchedAt` ascending so the last_cited timestamp is deterministic.
+ *
+ * Because `mergeSkillUsage` is commutative for loads + citations counts
+ * AND keeps the LATEST timestamp it sees as last_cited (we sort
+ * ascending so newest wins on the final pass), out-of-order input
+ * produces an identical result.
+ *
+ * @param {{usage: object, fetchedAt: string}[]} artifacts
+ * @returns {object} accumulated usage block, shape matches mergeSkillUsage output
+ */
+export function aggregateUsageStream(artifacts) {
+  if (!Array.isArray(artifacts) || artifacts.length === 0) return {};
+  const sorted = [...artifacts].sort(
+    (a, b) => new Date(a.fetchedAt) - new Date(b.fetchedAt)
+  );
+  return sorted.reduce(
+    (acc, art) => mergeSkillUsage(acc, art.usage || {}, art.fetchedAt),
+    {}
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.29",
+  "version": "0.6.30",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -363,7 +363,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.29
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.30
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -363,7 +363,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.29
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.30
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -627,7 +627,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.29
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.30
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/skill-usage-aggregation.test.js
+++ b/test/skill-usage-aggregation.test.js
@@ -145,6 +145,31 @@ function makeMockRunner({ artifactList = [], onDownload = null } = {}) {
   };
 }
 
+test('fetchUsageArtifacts: uses per_page=100 (NOT --paginate, which breaks JSON parse across pages)', async () => {
+  // Regression guard for the clud-bug-review finding on PR #127:
+  // `gh api --paginate --jq <expr>` applies the jq filter to each
+  // page independently, producing `[...]\n[...]` — invalid as a
+  // single JSON document. `JSON.parse` returns null and the
+  // dashboard silently shows empty for repos with >30 artifacts.
+  let capturedArgs = null;
+  const runner = {
+    async json(args) {
+      capturedArgs = args;
+      return [];
+    },
+    async run() { return { code: 0, stdout: '', stderr: '' }; },
+  };
+  await fetchUsageArtifacts({ owner: 't', repo: 'r', ghRunner: runner });
+  assert.ok(capturedArgs, 'json runner should have been called');
+  assert.ok(
+    !capturedArgs.includes('--paginate'),
+    '--paginate must NOT be passed (breaks --jq across pages)',
+  );
+  const urlArg = capturedArgs.find((a) => a.includes('/actions/artifacts'));
+  assert.ok(urlArg, 'should call the artifacts endpoint');
+  assert.match(urlArg, /per_page=100/, 'URL must include per_page=100 to cover up to 100 artifacts in one call');
+});
+
 test('fetchUsageArtifacts: requires owner + repo', async () => {
   await assert.rejects(
     () => fetchUsageArtifacts({ owner: null, repo: 'logmind' }),

--- a/test/skill-usage-aggregation.test.js
+++ b/test/skill-usage-aggregation.test.js
@@ -1,0 +1,300 @@
+// v0.6.30 — cross-review aggregation tests.
+//
+// Covers `fetchUsageArtifacts` + `aggregateUsageStream` from
+// `lib/skill-usage.js`. The fetch path is exercised against a mocked
+// gh-runner so tests don't shell out + don't require GH_TOKEN.
+
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  fetchUsageArtifacts,
+  aggregateUsageStream,
+} from '../lib/skill-usage.js';
+
+// ---------------------------------------------------------------------------
+// aggregateUsageStream (pure function — no I/O)
+// ---------------------------------------------------------------------------
+
+test('aggregateUsageStream: empty array returns {}', () => {
+  assert.deepEqual(aggregateUsageStream([]), {});
+});
+
+test('aggregateUsageStream: non-array returns {}', () => {
+  assert.deepEqual(aggregateUsageStream(null), {});
+  assert.deepEqual(aggregateUsageStream(undefined), {});
+});
+
+test('aggregateUsageStream: single artifact returns its usage', () => {
+  const out = aggregateUsageStream([
+    {
+      prNumber: 1,
+      fetchedAt: '2026-05-01T00:00:00Z',
+      usage: {
+        'critical-issues-only': { loads: 1, citations: 1, last_cited: '2026-05-01T00:00:00Z' },
+      },
+    },
+  ]);
+  assert.equal(out['critical-issues-only'].loads, 1);
+  assert.equal(out['critical-issues-only'].citations, 1);
+  assert.equal(out['critical-issues-only'].last_cited, '2026-05-01T00:00:00Z');
+});
+
+test('aggregateUsageStream: three artifacts sum loads + citations', () => {
+  const out = aggregateUsageStream([
+    {
+      prNumber: 1, fetchedAt: '2026-05-01T00:00:00Z',
+      usage: { 'pii': { loads: 1, citations: 1, last_cited: '2026-05-01T00:00:00Z' } },
+    },
+    {
+      prNumber: 2, fetchedAt: '2026-05-02T00:00:00Z',
+      usage: { 'pii': { loads: 1, citations: 0, last_cited: null } },
+    },
+    {
+      prNumber: 3, fetchedAt: '2026-05-03T00:00:00Z',
+      usage: { 'pii': { loads: 1, citations: 1, last_cited: '2026-05-03T00:00:00Z' } },
+    },
+  ]);
+  assert.equal(out['pii'].loads, 3);
+  assert.equal(out['pii'].citations, 2);
+});
+
+test('aggregateUsageStream: out-of-order input produces same result as chronological', () => {
+  const arts = [
+    {
+      prNumber: 1, fetchedAt: '2026-05-01T00:00:00Z',
+      usage: { 'a': { loads: 2, citations: 1, last_cited: '2026-05-01T00:00:00Z' } },
+    },
+    {
+      prNumber: 2, fetchedAt: '2026-05-02T00:00:00Z',
+      usage: { 'a': { loads: 3, citations: 2, last_cited: '2026-05-02T00:00:00Z' } },
+    },
+    {
+      prNumber: 3, fetchedAt: '2026-05-03T00:00:00Z',
+      usage: { 'a': { loads: 1, citations: 1, last_cited: '2026-05-03T00:00:00Z' } },
+    },
+  ];
+  const chrono = aggregateUsageStream(arts);
+  const reversed = aggregateUsageStream([...arts].reverse());
+  const shuffled = aggregateUsageStream([arts[1], arts[2], arts[0]]);
+  assert.deepEqual(reversed, chrono);
+  assert.deepEqual(shuffled, chrono);
+});
+
+test('aggregateUsageStream: last_cited = most recent citing artifact', () => {
+  const out = aggregateUsageStream([
+    {
+      prNumber: 1, fetchedAt: '2026-05-01T00:00:00Z',
+      usage: { 'x': { loads: 1, citations: 1, last_cited: '2026-05-01T00:00:00Z' } },
+    },
+    {
+      prNumber: 2, fetchedAt: '2026-05-05T00:00:00Z',
+      usage: { 'x': { loads: 1, citations: 0, last_cited: null } }, // load only, no citation
+    },
+    {
+      prNumber: 3, fetchedAt: '2026-05-03T00:00:00Z',
+      usage: { 'x': { loads: 1, citations: 1, last_cited: '2026-05-03T00:00:00Z' } },
+    },
+  ]);
+  // citing artifacts: PR1 (5/1) + PR3 (5/3). After chronological merge,
+  // last_cited should be 5/3 (the latest citing artifact).
+  assert.equal(out['x'].last_cited, '2026-05-03T00:00:00Z');
+  assert.equal(out['x'].loads, 3);
+  assert.equal(out['x'].citations, 2);
+});
+
+test('aggregateUsageStream: skills only in some artifacts are preserved', () => {
+  const out = aggregateUsageStream([
+    {
+      prNumber: 1, fetchedAt: '2026-05-01T00:00:00Z',
+      usage: { 'only-in-pr1': { loads: 1, citations: 0, last_cited: null } },
+    },
+    {
+      prNumber: 2, fetchedAt: '2026-05-02T00:00:00Z',
+      usage: { 'only-in-pr2': { loads: 1, citations: 1, last_cited: '2026-05-02T00:00:00Z' } },
+    },
+  ]);
+  assert.ok(out['only-in-pr1']);
+  assert.ok(out['only-in-pr2']);
+  assert.equal(Object.keys(out).length, 2);
+});
+
+// ---------------------------------------------------------------------------
+// fetchUsageArtifacts (with mocked ghRunner)
+// ---------------------------------------------------------------------------
+
+function makeMockRunner({ artifactList = [], onDownload = null } = {}) {
+  return {
+    async json(args) {
+      // The list call uses `gh api repos/X/Y/actions/artifacts --paginate --jq ...`
+      if (args.includes('api') && args.some((a) => a.includes('/actions/artifacts'))) {
+        return artifactList;
+      }
+      return null;
+    },
+    async run(args) {
+      if (args[0] === 'run' && args[1] === 'download') {
+        if (onDownload) return onDownload(args);
+        return { code: 0, stdout: '', stderr: '' };
+      }
+      return { code: 1, stdout: '', stderr: 'unexpected mock invocation' };
+    },
+  };
+}
+
+test('fetchUsageArtifacts: requires owner + repo', async () => {
+  await assert.rejects(
+    () => fetchUsageArtifacts({ owner: null, repo: 'logmind' }),
+    /owner \+ repo are required/,
+  );
+});
+
+test('fetchUsageArtifacts: empty artifact list returns []', async () => {
+  const runner = makeMockRunner({ artifactList: [] });
+  const out = await fetchUsageArtifacts({ owner: 't', repo: 'r', ghRunner: runner });
+  assert.deepEqual(out, []);
+});
+
+test('fetchUsageArtifacts: null from runner returns []', async () => {
+  const runner = { json: async () => null, run: async () => ({ code: 1, stdout: '', stderr: '' }) };
+  const out = await fetchUsageArtifacts({ owner: 't', repo: 'r', ghRunner: runner });
+  assert.deepEqual(out, []);
+});
+
+test('fetchUsageArtifacts: skips artifacts with malformed names', async () => {
+  const runner = makeMockRunner({
+    artifactList: [
+      { id: 1, name: 'unrelated-artifact', workflow_run_id: 100, created_at: '2026-05-01T00:00:00Z' },
+      { id: 2, name: 'clud-bug-skill-usage-pr-notanumber', workflow_run_id: 101, created_at: '2026-05-01T00:00:00Z' },
+    ],
+    // The --jq filter would normally filter these out at the API layer.
+    // Our mock returns them anyway to exercise the client-side guard.
+  });
+  // Inject a downloader that would error if called — none of these should be downloaded.
+  const out = await fetchUsageArtifacts({
+    owner: 't', repo: 'r',
+    ghRunner: {
+      json: runner.json,
+      run: async () => ({ code: 1, stdout: '', stderr: 'should not be called' }),
+    },
+  });
+  // The malformed entries are filtered (no PR number match), but the
+  // "unrelated-artifact" passes the --jq filter at API layer in
+  // production. In the mock it leaks through and gets dropped here.
+  assert.deepEqual(out, []);
+});
+
+test('fetchUsageArtifacts: returns one record per valid artifact', async () => {
+  // Set up a temp dir + payload that the mock downloader writes to.
+  // We can't easily intercept tmpdir creation, so we rely on the
+  // downloader to write the file at the path the impl expects.
+
+  const runner = makeMockRunner({
+    artifactList: [
+      { id: 42, name: 'clud-bug-skill-usage-pr-7', workflow_run_id: 999, created_at: '2026-05-15T12:00:00Z' },
+    ],
+    onDownload: async (args) => {
+      // args = ['run', 'download', '999', '-R', 't/r', '-n', 'clud-bug-skill-usage-pr-7', '-D', <tmpDir>]
+      const tmpDir = args[args.length - 1];
+      const file = join(tmpDir, '.clud-bug.json');
+      await writeFile(file, JSON.stringify({
+        version: 1,
+        usage: {
+          'critical-issues-only': { loads: 5, citations: 3, last_cited: '2026-05-15T12:00:00Z' },
+        },
+      }));
+      return { code: 0, stdout: '', stderr: '' };
+    },
+  });
+
+  const out = await fetchUsageArtifacts({ owner: 't', repo: 'r', ghRunner: runner });
+  assert.equal(out.length, 1);
+  assert.equal(out[0].prNumber, 7);
+  assert.equal(out[0].artifactId, 42);
+  assert.equal(out[0].fetchedAt, '2026-05-15T12:00:00Z');
+  assert.equal(out[0].usage['critical-issues-only'].loads, 5);
+});
+
+test('fetchUsageArtifacts: skips artifacts whose download fails', async () => {
+  const runner = makeMockRunner({
+    artifactList: [
+      { id: 1, name: 'clud-bug-skill-usage-pr-1', workflow_run_id: 100, created_at: '2026-05-01T00:00:00Z' },
+      { id: 2, name: 'clud-bug-skill-usage-pr-2', workflow_run_id: 101, created_at: '2026-05-02T00:00:00Z' },
+    ],
+    onDownload: async (args) => {
+      const tmpDir = args[args.length - 1];
+      const artifactName = args[args.length - 3];
+      // Only PR-2 download succeeds.
+      if (artifactName === 'clud-bug-skill-usage-pr-2') {
+        await writeFile(join(tmpDir, '.clud-bug.json'), JSON.stringify({
+          version: 1,
+          usage: { 'pii': { loads: 1, citations: 1, last_cited: '2026-05-02T00:00:00Z' } },
+        }));
+        return { code: 0, stdout: '', stderr: '' };
+      }
+      return { code: 1, stdout: '', stderr: 'download failed' };
+    },
+  });
+
+  const out = await fetchUsageArtifacts({ owner: 't', repo: 'r', ghRunner: runner });
+  assert.equal(out.length, 1);
+  assert.equal(out[0].prNumber, 2);
+});
+
+test('fetchUsageArtifacts: filters by `since` date', async () => {
+  const runner = makeMockRunner({
+    artifactList: [
+      { id: 1, name: 'clud-bug-skill-usage-pr-1', workflow_run_id: 100, created_at: '2026-04-01T00:00:00Z' }, // old
+      { id: 2, name: 'clud-bug-skill-usage-pr-2', workflow_run_id: 101, created_at: '2026-05-15T00:00:00Z' }, // recent
+    ],
+    onDownload: async (args) => {
+      const tmpDir = args[args.length - 1];
+      await writeFile(join(tmpDir, '.clud-bug.json'), JSON.stringify({ version: 1, usage: {} }));
+      return { code: 0, stdout: '', stderr: '' };
+    },
+  });
+
+  const out = await fetchUsageArtifacts({
+    owner: 't', repo: 'r',
+    since: new Date('2026-05-01T00:00:00Z'),
+    ghRunner: runner,
+  });
+  assert.equal(out.length, 1);
+  assert.equal(out[0].prNumber, 2);
+});
+
+test('fetchUsageArtifacts: malformed .clud-bug.json in artifact is skipped', async () => {
+  const runner = makeMockRunner({
+    artifactList: [
+      { id: 1, name: 'clud-bug-skill-usage-pr-1', workflow_run_id: 100, created_at: '2026-05-01T00:00:00Z' },
+    ],
+    onDownload: async (args) => {
+      const tmpDir = args[args.length - 1];
+      await writeFile(join(tmpDir, '.clud-bug.json'), 'not-json{{{');
+      return { code: 0, stdout: '', stderr: '' };
+    },
+  });
+
+  const out = await fetchUsageArtifacts({ owner: 't', repo: 'r', ghRunner: runner });
+  assert.deepEqual(out, []);
+});
+
+test('fetchUsageArtifacts: missing usage field treats as empty {}', async () => {
+  const runner = makeMockRunner({
+    artifactList: [
+      { id: 1, name: 'clud-bug-skill-usage-pr-1', workflow_run_id: 100, created_at: '2026-05-01T00:00:00Z' },
+    ],
+    onDownload: async (args) => {
+      const tmpDir = args[args.length - 1];
+      await writeFile(join(tmpDir, '.clud-bug.json'), JSON.stringify({ version: 1 })); // no usage key
+      return { code: 0, stdout: '', stderr: '' };
+    },
+  });
+
+  const out = await fetchUsageArtifacts({ owner: 't', repo: 'r', ghRunner: runner });
+  assert.equal(out.length, 1);
+  assert.deepEqual(out[0].usage, {});
+});


### PR DESCRIPTION
## Summary

Closes the SkDD usage loop. v0.6.29 wired up per-PR artifact uploads, but the v0.6.28 dashboard still read only the local `.clud-bug.json` (always empty unless someone ran `update-skill-usage` locally). v0.6.30 makes `clud-bug usage --health` walk workflow artifacts + merge them into one org-level snapshot — the dashboard goes from placeholder to live data.

## What changed

- **`lib/skill-usage.js`** — added `fetchUsageArtifacts({owner, repo, since?, ghRunner?})` + `aggregateUsageStream(artifacts)` + `DEFAULT_GH_RUNNER` (the injectable contract).
- **`bin/clud-bug.js`** — `runUsageHealth` now picks read source by priority: `--no-artifacts` → local; `--repo` → that repo's artifacts; else infer from `gh repo view`. Falls back to local if artifact path returns empty.
- **`test/skill-usage-aggregation.test.js`** — 16 new tests covering aggregation purity + fetch error paths via mocked `ghRunner` (no shelling out, no `GH_TOKEN`).
- **Version**: 0.6.29 → 0.6.30 in `package.json` + 3 composite-action pins in workflow templates + `strict-mode-gate/action.yml` header.

## Why artifacts (recap from v0.6.29)

Commit-back to main would have required `contents: write` expansion → v0.6.23-style trigger-firing regression risk on private repos + race-handling complexity. Artifacts are GitHub-native, 90-day retention by default, zero permission widening.

## Test plan

- [x] `npm test` — 356 tests pass (340 prior + 16 new)
- [x] Aggregation is commutative — out-of-order input identical to chronological
- [x] Mocked `ghRunner` exercises both success + every error branch
- [ ] Self-review on this PR uploads its own artifact (regression check on v0.6.29 wiring)
- [ ] Post-merge: run `node bin/clud-bug.js usage --health --repo thrillmade/tokenomics` against the v0.6.29 propagation cycle's accumulated artifacts → expect real `loads` + `citations` data instead of placeholder