### PR TITLE
chore: self-propagate v0.6.30 (cross-review aggregation)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
   "installed": [],
-  "lastUpdate": "2026-05-31T18:21:39.827Z",
-  "lastUpdateVersion": "0.6.29",
+  "lastUpdate": "2026-06-01T04:04:57.419Z",
+  "lastUpdateVersion": "0.6.30",
   "strictMode": true,
   "strictSkills": []
 }

--- a/.cursorrules
+++ b/.cursorrules
@@ -19,5 +19,5 @@ For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
 (or pass `--quiet`) — suppresses progress chatter and emits a single
 `ok <key-value>` summary line per command.
 
-_Installed at clud-bug v0.6.29._
+_Installed at clud-bug v0.6.30._
 <!-- clud-bug-end -->

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -634,7 +634,7 @@ jobs:
           THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.29 render --stdin)
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.30 render --stdin)
           CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
           gh pr comment "$PR_NUMBER" --body "$BODY
 
@@ -652,7 +652,7 @@ jobs:
           if [ ! -f .claude/skills/.clud-bug.json ]; then
             echo '{"version": 1}' > .claude/skills/.clud-bug.json
           fi
-          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.29 update-skill-usage --stdin
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.30 update-skill-usage --stdin
           echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
 
       - name: Upload skill-usage artifact
@@ -720,7 +720,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.29
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.30
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,5 +44,5 @@ For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
 (or pass `--quiet`) — suppresses progress chatter and emits a single
 `ok <key-value>` summary line per command.
 
-_Installed at clud-bug v0.6.29._
+_Installed at clud-bug v0.6.30._
 <!-- clud-bug-end -->

--- a/docs/decisions-branches/chore__self-propagate-v0.6.30.md
+++ b/docs/decisions-branches/chore__self-propagate-v0.6.30.md
@@ -1,0 +1,8 @@
+## 2026-06-01 00:04 - chore: self-propagate v0.6.30 (cross-review aggregation)
+
+**Reasoning:** clud-bug eats its own templates — own workflow re-rendered with composite-action pin @v0.6.30
+
+**Implications:**
+- Composite-action pin bump only
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,6 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
+## 2026-06
+
+- **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
+
 ## 2026-05 (108 decisions)
 
 - **2026-05-31** — v0.6.30 fix: drop --paginate, use ?per_page=100 (clud-bug-review PR #127) *(feat/v0.6.30-cross-review-aggregation)* — [decisions-branches/feat__v0.6.30-cross-review-aggregation.md](decisions-branches/feat__v0.6.30-cross-review-aggregation.md)


### PR DESCRIPTION
Self-propagation — clud-bug eats its own templates at pin @v0.6.30.