### PR TITLE
v0.6.31: hotfix — upload-artifact excludes hidden files (v0.6.29-30 silent breakage)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.30
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.31
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.31] — 2026-06-01
+
+### Fixed — workflow upload step silently dropped every artifact
+
+Critical hotfix. v0.6.29's `Upload skill-usage artifact` workflow
+step has been silently dropping **every** artifact across the entire
+org since 2026-05-31. Root cause: `actions/upload-artifact@v4`
+excludes hidden files by default, and both `.claude/` and
+`.clud-bug.json` are dot-prefixed.
+
+The step reported `success` (because no files were found is a
+warning, not an error). The CLI's `update-skill-usage` ran
+successfully, wrote a usage block to `.claude/skills/.clud-bug.json`,
+and the upload step then **uploaded nothing**.
+
+Verified by inspecting v0.6.30 propagation cycle artifacts via
+`gh api repos/THRILLMADE/$repo/actions/artifacts` — every workflow
+that should have produced a `clud-bug-skill-usage-pr-N` artifact
+returned an empty list. Run logs confirm:
+
+> `##[warning]No files were found with the provided path:
+> .claude/skills/.clud-bug.json. No artifacts will be uploaded.`
+
+### Fix
+
+Add `include-hidden-files: true` to the upload step in all three
+workflow templates (`workflow.yml.tmpl`, `workflow-ts.yml.tmpl`,
+`workflow-py.yml.tmpl`). The flag opts the artifact upload into
+including dot-prefixed paths.
+
+Composite-action pin bumped 0.6.30 → 0.6.31 + `package.json`
+version bump + CHANGELOG. Propagation cycle to follow so the
+hotfix reaches every consumer's workflow.
+
+### Lesson
+
+`continue-on-error: true` + a step that warns-but-succeeds is a
+silent-failure pattern. The next dashboard run surfaced the issue
+when artifacts didn't materialize. v0.6.30's aggregation dashboard
+made the problem observable — without it the breakage would have
+gone unnoticed indefinitely.
+
 ## [0.6.30] — 2026-05-31
 
 ### Added — cross-review aggregation closes the SkDD usage loop

--- a/docs/decisions-branches/fix__v0.6.31-upload-include-hidden.md
+++ b/docs/decisions-branches/fix__v0.6.31-upload-include-hidden.md
@@ -1,0 +1,12 @@
+## 2026-06-01 08:40 - clud-bug v0.6.31: hotfix — upload-artifact excludes hidden files (v0.6.29-30 silent breakage)
+
+**Reasoning:** Discovered during dogfood validation that ZERO clud-bug-skill-usage artifacts existed across the entire org despite the workflow steps reporting success. Root cause: actions/upload-artifact@v4 excludes hidden files by default; .claude/ and .clud-bug.json are both dot-prefixed. The step printed warning 'No files were found' but continue-on-error: true masked it as success. v0.6.30's cross-review aggregation made the breakage observable — without that dashboard, the bug would have lurked indefinitely. Fix: add include-hidden-files: true to all 3 workflow templates' upload step.
+
+**Alternatives considered:** Move .clud-bug.json out of .claude/ (rejected: breaks existing v0.6.28 dashboard read path + agent-skills SKILL.md path conventions), Use action.yml composite-action wrapper that pre-stages files to a non-hidden path (rejected: heavy refactor for a one-line config change)
+
+**Implications:**
+- v0.6.30's dashboard placeholder still says 'no usage data yet' for repos with no successful artifacts — which is now correct since the v0.6.31 hotfix is the FIRST version that actually uploads. After propagation, v0.6.31's reviews will be the first to produce artifact data
+- Lesson: continue-on-error: true + warn-not-error is a silent-failure pattern. Consider adding a smoke-test that asserts artifact upload non-empty in v0.6.32+
+- v0.6.29 and v0.6.30 are NOT broken-as-shipped — the architecture works. Only the upload step config was wrong. The CLI, the aggregation logic, the dashboard read path all function correctly when given real artifact data
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-06
 
+- **2026-06-01** — clud-bug v0.6.31: hotfix — upload-artifact excludes hidden files (v0.6.29-30 silent breakage) *(fix/v0.6.31-upload-include-hidden)* — [decisions-branches/fix__v0.6.31-upload-include-hidden.md](decisions-branches/fix__v0.6.31-upload-include-hidden.md)
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.30",
+  "version": "0.6.31",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -305,6 +305,9 @@ jobs:
         with:
           name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}
           path: .claude/skills/.clud-bug.json
+          # v0.6.31 hotfix: upload-artifact@v4 excludes hidden files
+          # by default. See workflow.yml.tmpl for full context.
+          include-hidden-files: true
           retention-days: 90
 
       # v0.6.26 / §5.5 Layer 6 fallback render-from-inlines — see workflow.yml.tmpl for design notes.
@@ -363,7 +366,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.30
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.31
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -305,6 +305,9 @@ jobs:
         with:
           name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}
           path: .claude/skills/.clud-bug.json
+          # v0.6.31 hotfix: upload-artifact@v4 excludes hidden files
+          # by default. See workflow.yml.tmpl for full context.
+          include-hidden-files: true
           retention-days: 90
 
       # v0.6.26 / §5.5 Layer 6 fallback render-from-inlines — see workflow.yml.tmpl for design notes.
@@ -363,7 +366,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.30
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.31
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -530,6 +530,11 @@ jobs:
         with:
           name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}
           path: .claude/skills/.clud-bug.json
+          # v0.6.31 hotfix: actions/upload-artifact@v4 excludes hidden
+          # files by default. .clud-bug.json + .claude/ are both
+          # dot-prefixed, so v0.6.29-v0.6.30 silently uploaded zero
+          # artifacts org-wide. Must opt in explicitly.
+          include-hidden-files: true
           retention-days: 90
 
       # Fallback comment when the model couldn't produce schema-valid
@@ -627,7 +632,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.30
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.31
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow


### PR DESCRIPTION
## Summary

**Critical hotfix.** v0.6.29's `Upload skill-usage artifact` step has been silently dropping every artifact across the entire org since 2026-05-31.

## Root cause

`actions/upload-artifact@v4` excludes hidden files by default. `.claude/` (directory) and `.clud-bug.json` (file) are both dot-prefixed, so the action found nothing at the specified path. The step printed:

> `##[warning]No files were found with the provided path: .claude/skills/.clud-bug.json. No artifacts will be uploaded.`

`continue-on-error: true` masked the warning as step-success, so it never surfaced. **The CLI side worked correctly** — `update-skill-usage` wrote the usage block — but the upload then silently no-op'd.

## Discovery

Found during dogfood validation: ran `clud-bug usage --health --repo thrillmade/tokenomics` (v0.6.30's new aggregation read), got "no artifacts found." Cross-checked `gh api repos/.../actions/artifacts` on every consumer repo: zero `clud-bug-skill-usage-pr-*` artifacts existed despite many successful runs.

v0.6.30's dashboard made the breakage observable. Without it, the bug would have lurked indefinitely.

## Fix

Add `include-hidden-files: true` to the upload step in all three workflow templates:

```yaml
- name: Upload skill-usage artifact
  uses: actions/upload-artifact@v4
  with:
    name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}
    path: .claude/skills/.clud-bug.json
    include-hidden-files: true  # ← v0.6.31 fix
    retention-days: 90
```

Plus version bump 0.6.30 → 0.6.31 + composite-action pin in 4 spots.

## Test plan

- [x] `npm test` — all tests pass (no new tests; this is a config fix that can only be validated post-propagation)
- [ ] Self-review on this PR uploads the first real artifact ever
- [ ] Post-propagation cycle: run `clud-bug usage --health` on tokenomics + verify artifacts now appear

## Lesson

`continue-on-error: true` + a step that warns-but-succeeds is a silent-failure pattern. Consider a smoke-test in v0.6.32+ that asserts non-empty artifact upload.