### PR TITLE
v0.6.32: release-discipline guard for v0.6.31 + stale dashboard text

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.31
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.32
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.6.32] — 2026-06-01
+
+### Added — release-discipline guard locks in v0.6.31's upload fix
+
+The v0.6.31 hotfix added `include-hidden-files: true` to the upload
+step in all 3 workflow templates. That flag is a single line easy
+to lose during a future template edit — and if it's lost, we go back
+to silent artifact-drop with no error surface (per the v0.6.31
+incident report).
+
+This release adds a release-discipline test that asserts the flag is
+present in every template. Any future edit that removes it fails CI
+with a message pointing back to v0.6.31's CHANGELOG entry. The fix
+is now self-policing.
+
+### Changed — dashboard placeholder text post-v0.6.30
+
+`formatHealthDashboard` previously read "v0.6.30 will add cross-review
+aggregation" when no data was available. v0.6.30 has shipped + v0.6.31
+fixed the upload — text is stale. New message tells the user
+artifacts accumulate from the next substantive PR review (workflow-only
+PRs auto-skip via 0.0.W²).
+
+### Tests
+
+`test/release-discipline.test.js` gains one new assertion
+(release discipline: Upload skill-usage artifact step must set
+`include-hidden-files: true`). Smoke-tested by temporarily removing
+the flag — test fails with the citation message. No other behavior
+changes.
+
 ## [0.6.31] — 2026-06-01
 
 ### Fixed — workflow upload step silently dropped every artifact

--- a/docs/decisions-branches/feat__v0.6.32-include-hidden-files-guard.md
+++ b/docs/decisions-branches/feat__v0.6.32-include-hidden-files-guard.md
@@ -1,0 +1,11 @@
+## 2026-06-01 10:12 - clud-bug v0.6.32: release-discipline guard for v0.6.31 + stale dashboard text
+
+**Reasoning:** v0.6.31's include-hidden-files: true fix is a single config line easy to lose in future template edits. Without the guard, a regression would silently revert to the pre-v0.6.31 silent-failure state (zero artifacts uploaded, dashboard empty, no error surface). Test asserts the flag is present in all 3 templates with an anchored regex (rejects commented-out occurrences). Smoke-tested: removes flag → test fails with citation; restored → passes. Also drops 'v0.6.30 will add' from the dashboard placeholder (stale now that both ship).
+
+**Alternatives considered:** Wider integration test that uploads a real artifact + checks gh api (rejected: integration tests need GH_TOKEN + a live workflow run; release-discipline tests are pure-source assertions that run on every npm test, much faster feedback), Lint rule via actionlint (rejected: actionlint doesn't know domain-specific 'this flag must be present'; the discipline-test pattern matches our other lock-step assertions like composite-pin)
+
+**Implications:**
+- Pattern: release-discipline.test.js is the right home for 'this config must be present' assertions tied to past incidents. Other consumers may want similar guards (logmind side has fewer such gotchas but worth tracking)
+- Smoke-test pattern (cp file + sed + revert) verified the guard actually fails on regression. Future test additions in this file should follow the same verify-the-guard-fails pattern
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (3 decisions)
+## 2026-06 (4 decisions)
 
-- **2026-06-01** — chore: self-propagate v0.6.31 (hotfix) *(chore/self-propagate-v0.6.31)* — [decisions-branches/chore__self-propagate-v0.6.31.md](decisions-branches/chore__self-propagate-v0.6.31.md)
-- *... 1 more decision ...*
+- **2026-06-01** — clud-bug v0.6.32: release-discipline guard for v0.6.31 + stale dashboard text *(feat/v0.6.32-include-hidden-files-guard)* — [decisions-branches/feat__v0.6.32-include-hidden-files-guard.md](decisions-branches/feat__v0.6.32-include-hidden-files-guard.md)
+- *... 2 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/lib/skill-usage.js
+++ b/lib/skill-usage.js
@@ -224,10 +224,10 @@ export function formatHealthDashboard(rows) {
   if (!rows || rows.length === 0) {
     return (
       'Skill health: no usage data yet.\n\n' +
-      'Usage data accumulates after clud-bug reviews land in your repo.\n' +
-      'v0.6.29 wires up per-review delta writes via the workflow post-step\n' +
-      'and uploads them as 90-day artifacts. v0.6.30 will add cross-review\n' +
-      'aggregation so this dashboard reads the full artifact stream.'
+      'Skill-usage artifacts will start accumulating from your next\n' +
+      'clud-bug-review run on a substantive PR (workflow-only PRs auto-skip\n' +
+      'review via 0.0.W² and produce no artifact). Run this command again\n' +
+      'with `--repo owner/name` once a few reviews have completed.'
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.31",
+  "version": "0.6.32",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -366,7 +366,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.31
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.32
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -366,7 +366,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.31
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.32
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -632,7 +632,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.31
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.32
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/release-discipline.test.js
+++ b/test/release-discipline.test.js
@@ -122,3 +122,52 @@ test('release discipline: composite pin matches across all 3 review templates', 
     `All 3 review templates must pin the same composite version. Found:\n${refs.map(([t, r]) => `  ${t} → ${r}`).join('\n')}`,
   );
 });
+
+test('release discipline: Upload skill-usage artifact step must set include-hidden-files: true (v0.6.31)', async () => {
+  // v0.6.29 added the `Upload skill-usage artifact` workflow post-step
+  // that uploads `.claude/skills/.clud-bug.json` as a 90-day artifact
+  // for the v0.6.30 dashboard to read. The path is dot-prefixed AND
+  // sits under a dot-prefixed directory, both of which
+  // `actions/upload-artifact@v4` excludes by default.
+  //
+  // Without `include-hidden-files: true`, the action emits:
+  //   "##[warning]No files were found with the provided path: ..."
+  // BUT `continue-on-error: true` masks the warning as step-success.
+  // The bug shipped silently in v0.6.29 + v0.6.30; ZERO artifacts were
+  // uploaded across the entire org until v0.6.31 added the flag.
+  //
+  // This guard makes the fix self-policing: any future template edit
+  // that drops the flag fails CI immediately.
+  const templates = [
+    'workflow.yml.tmpl',
+    'workflow-ts.yml.tmpl',
+    'workflow-py.yml.tmpl',
+  ];
+  for (const tmpl of templates) {
+    const content = await readFile(join(REPO_ROOT, 'templates', tmpl), 'utf8');
+    // Locate the Upload skill-usage artifact step block. Anchor on the
+    // step name, then check the next ~15 lines for the flag.
+    const idx = content.indexOf('Upload skill-usage artifact');
+    assert.ok(
+      idx !== -1,
+      `${tmpl}: missing the 'Upload skill-usage artifact' step (v0.6.29).`,
+    );
+    // 1200-char window captures the step block + its comments. v0.6.31
+    // added a multi-line comment that pushed the flag past 600 chars
+    // in workflow.yml.tmpl.
+    const stepBlock = content.slice(idx, idx + 1200);
+    // Anchor to start-of-line + leading whitespace (not preceded by '#')
+    // so commented-out occurrences in adjacent prose don't satisfy the
+    // assertion. The regex matches lines like "          include-hidden-files: true"
+    // but not "          # include-hidden-files: true (removed)".
+    assert.match(
+      stepBlock,
+      /^\s+include-hidden-files:\s*true/m,
+      `${tmpl}: 'Upload skill-usage artifact' step is missing 'include-hidden-files: true'.
+       Background: actions/upload-artifact@v4 excludes hidden files by default
+       (both .claude/ and .clud-bug.json are dot-prefixed). v0.6.31 hotfix added
+       the flag after the silent-failure bug burned us org-wide. Do not remove.
+       See CHANGELOG [0.6.31] for the full incident report.`,
+    );
+  }
+});

--- a/test/skill-usage.test.js
+++ b/test/skill-usage.test.js
@@ -214,7 +214,9 @@ test('assessSkillHealth: empty input returns []', () => {
 test('formatHealthDashboard: empty rows shows structural placeholder', () => {
   const out = formatHealthDashboard([]);
   assert.match(out, /no usage data yet/i);
-  assert.match(out, /v0\.6\.29/, 'mentions when workflow integration ships');
+  // v0.6.32: placeholder no longer cites a specific version (v0.6.29-30
+  // were stale post-ship). Now points the user at what to do next.
+  assert.match(out, /substantive PR/i, 'guides reader on when artifacts arrive');
 });
 
 test('formatHealthDashboard: non-empty includes header + threshold legend', () => {


### PR DESCRIPTION
## Summary

Locks in the v0.6.31 hotfix (`include-hidden-files: true`) with a release-discipline assertion that fails CI if the flag is ever removed from any workflow template. Also drops the now-stale "v0.6.30 will add" framing from the dashboard placeholder.

## Why

v0.6.31's fix is a single config line. Without a guard, a future template edit could silently revert it — and the regression would re-introduce the v0.6.29 silent-failure pattern (zero artifacts uploaded, dashboard empty, no error surface). Self-policing this prevents recurrence.

## What changed

- **`test/release-discipline.test.js`** — new test asserts each of the 3 templates contains `include-hidden-files: true` (anchored regex, rejects commented-out occurrences). Smoke-tested: remove flag → test fails with citation to v0.6.31 CHANGELOG; restore → passes.
- **`lib/skill-usage.js`** — `formatHealthDashboard` placeholder text updated. Drops "v0.6.30 will add" (stale). New text points reader at what produces artifacts.
- **`test/skill-usage.test.js`** — placeholder assertion updated to match new text.
- **Version** 0.6.31 → 0.6.32 (package.json + 3 composite-pins + action.yml header).

## Test plan

- [x] `npm test` — 358 tests pass (357 prior + 1 new release-discipline assertion)
- [x] Smoke-test verified guard fails on regression
- [ ] Self-review on this PR via clud-bug-review