### PR TITLE
chore: refresh logmind v0.5.13 → v0.6.9

### DIFF
--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -30,7 +30,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.5.13"
+        run: pip install "logmind==0.6.9"
 
       - name: Check markdown link integrity
         run: logmind check-links

--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -41,7 +41,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.5.13"
+        run: pip install "logmind==0.6.9"
 
       - name: Verify docs/timeline.md is current
         run: |

--- a/docs/decisions-branches/chore__logmind-v0.6.9.md
+++ b/docs/decisions-branches/chore__logmind-v0.6.9.md
@@ -1,0 +1,10 @@
+## 2026-06-01 17:16 - chore: refresh logmind v0.5.13 → v0.6.9
+
+**Reasoning:** Workflow pins from v0.5.13 → v0.6.9. Picks up v0.6.9 file-structure --check, v0.6.8 --with-skdd, v0.6.7 post-merge unstaged fix.
+
+**Alternatives considered:** Wait for auto-propagation (blocked by workflows: write permission gap)
+
+**Implications:**
+- Manual via local PAT
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (7 decisions)
+## 2026-06 (8 decisions)
 
-- **2026-06-01** — v0.6.33 fix: dead-code removal + drop redundant dynamic spawn imports + tighten vacuous test (PR #133) *(feat/v0.6.33-with-skdd-flag)* — [decisions-branches/feat__v0.6.33-with-skdd-flag.md](decisions-branches/feat__v0.6.33-with-skdd-flag.md)
-- *... 5 more decisions ...*
+- **2026-06-01** — chore: refresh logmind v0.5.13 → v0.6.9 *(chore/logmind-v0.6.9)* — [decisions-branches/chore__logmind-v0.6.9.md](decisions-branches/chore__logmind-v0.6.9.md)
+- *... 6 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)


### PR DESCRIPTION
Workflow pins from v0.5.13 → v0.6.9. Picks up v0.6.9 `logmind file-structure --check`, v0.6.8 `--with-skdd`, v0.6.7 post-merge unstaged fix.

Org self-update workflow failed at push step (GITHUB_TOKEN lacks `workflows: write`). Manually propagated via local logmind v0.6.9 + PAT. Captured as v0.6.10 candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)