### PR TITLE
chore: refresh logmind v0.6.9 → v0.6.11

### DIFF
--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -30,7 +30,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.6.9"
+        run: pip install "logmind==0.6.11"
 
       - name: Check markdown link integrity
         run: logmind check-links

--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -41,7 +41,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.6.9"
+        run: pip install "logmind==0.6.11"
 
       - name: Verify docs/timeline.md is current
         run: |

--- a/docs/decisions-branches/chore__logmind-v0.6.11.md
+++ b/docs/decisions-branches/chore__logmind-v0.6.11.md
@@ -1,0 +1,8 @@
+## 2026-06-01 19:21 - chore: refresh logmind v0.6.9 → v0.6.11
+
+**Reasoning:** Manual propagation: pin bumps + AGENTS.md refresh.
+
+**Implications:**
+- v5 self-update template lands so future auto-propagation works cleanly with LOGMIND_AUTO_REGEN_PAT
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (8 decisions)
+## 2026-06 (9 decisions)
 
-- **2026-06-01** — chore: refresh logmind v0.5.13 → v0.6.9 *(chore/logmind-v0.6.9)* — [decisions-branches/chore__logmind-v0.6.9.md](decisions-branches/chore__logmind-v0.6.9.md)
-- *... 6 more decisions ...*
+- **2026-06-01** — chore: refresh logmind v0.6.9 → v0.6.11 *(chore/logmind-v0.6.11)* — [decisions-branches/chore__logmind-v0.6.11.md](decisions-branches/chore__logmind-v0.6.11.md)
+- *... 7 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)


### PR DESCRIPTION
Workflow pins v0.6.9 → v0.6.11. Manually propagated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)