### PR TITLE
chore: refresh logmind-self-update.yml to v5 (PAT bootstrap)

### DIFF
--- a/.github/workflows/logmind-self-update.yml
+++ b/.github/workflows/logmind-self-update.yml
@@ -1,4 +1,4 @@
-# logmind-template-version: v4
+# logmind-template-version: v5
 name: logmind self-update
 
 # Weekly check for a newer published logmind. If one exists, runs
@@ -24,12 +24,31 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # NOTE (v5 / logmind v0.6.11): there is NO `permissions:` knob that
+  # lets GITHUB_TOKEN push to .github/workflows/*.yml — GitHub blocks
+  # that at the git layer for security. When a logmind refresh would
+  # touch a workflow file (e.g. an updated `check-doc-links.yml`
+  # template body), the only path that works is to push via a PAT with
+  # the `workflow` scope. We use the SAME `LOGMIND_AUTO_REGEN_PAT`
+  # secret that `regen-timeline.yml` v3 uses for the same reason
+  # (single secret to configure, both workflows benefit).
+  # Without the PAT: this workflow falls back to non-workflow-only
+  # refreshes (AGENTS.md, .cursorrules, etc.) and prints a one-line
+  # `::warning::` directing the user to configure the PAT to unlock
+  # workflow refreshes. See the "Push step" below.
 
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # v5 / logmind v0.6.11: use the regen PAT when available so we
+          # can push refreshed workflow files. Falls through to
+          # GITHUB_TOKEN when absent — push works for non-workflow files
+          # but will reject any workflow-file changes (handled in the
+          # push step below).
+          token: ${{ secrets.LOGMIND_AUTO_REGEN_PAT || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v6
         with:
@@ -98,6 +117,7 @@ jobs:
           INSTALLED: ${{ steps.compare.outputs.installed }}
           LATEST:    ${{ steps.compare.outputs.latest }}
           GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+          PAT:       ${{ secrets.LOGMIND_AUTO_REGEN_PAT }}
         run: |
           set -euo pipefail
           BRANCH="logmind/self-update-${LATEST}"
@@ -111,10 +131,24 @@ jobs:
           # + agent files untouched. Idempotent.
           logmind init --no-git --no-skill-install || logmind init
 
+          # v5 / logmind v0.6.11 — detect whether the refresh touched any
+          # `.github/workflows/*.yml`. If so, we NEED the PAT to push
+          # (GitHub blocks GITHUB_TOKEN from creating/updating workflow
+          # files for security). When the PAT is missing AND workflows
+          # changed, fail with a clear actionable error rather than the
+          # generic git push 403.
           git add -A
           if git diff --cached --quiet; then
             echo "::notice::No file changes after logmind init — nothing to PR."
             exit 0
+          fi
+          WORKFLOW_CHANGES=$(git diff --cached --name-only -- '.github/workflows/*.yml' '.github/workflows/*.yaml' || true)
+          if [ -n "$WORKFLOW_CHANGES" ] && [ -z "${PAT:-}" ]; then
+            echo "::error title=Missing LOGMIND_AUTO_REGEN_PAT::This release updated workflow file(s):"
+            echo "::error::$WORKFLOW_CHANGES"
+            echo "::error::GitHub blocks GITHUB_TOKEN from pushing workflow changes. Configure a fine-grained PAT with \`workflow\` scope as the \`LOGMIND_AUTO_REGEN_PAT\` repo or org secret (same secret used by regen-timeline.yml v3), then re-run this workflow."
+            echo "::error::Without the PAT, workflow-template refreshes can't propagate automatically — file the changes manually via \`logmind init\` locally + PR."
+            exit 1
           fi
           git commit -m "logmind self-update: ${INSTALLED} → ${LATEST}"
           git push -u origin "$BRANCH"

--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -1,19 +1,35 @@
-# logmind-template-version: v2
+# logmind-template-version: v3
 name: check derived docs
 
-# Derived-file architecture (v0.2+): docs/timeline.md is a derived
-# artifact, deterministically computed from sources (per-branch logs +
-# decisions.md + archive). This workflow VERIFIES that docs/timeline.md
-# on the PR matches what `logmind timeline` would produce — same
-# pattern as Prettier/ESLint/Black checks. If stale, the build fails
-# red with a clear message and the user regenerates locally + pushes.
+# Derived-file architecture (v0.2+): docs/timeline.md + docs/file-structure.md
+# are derived artifacts, deterministically computed from sources (per-branch
+# logs + decisions.md + archive for timeline; tree walk for file-structure).
 #
-# Why fail-fast instead of auto-commit: GitHub deliberately blocks
-# GITHUB_TOKEN-pushed commits from triggering downstream workflows
-# (anti-recursion safety). An auto-commit approach leaves required
-# status checks stuck on "Expected — Waiting for status to be reported"
-# forever, because the new commit never gets pytest runs. Fail-fast
-# avoids this entire class of problem — no PAT, no token games.
+# Two modes (v0.3.4+):
+#
+# 1. AUTO-FIX mode (preferred — happy path).
+#    Triggered when `LOGMIND_AUTO_REGEN_PAT` secret is configured on the repo
+#    (or inherited from the org). When derived docs are stale, the workflow
+#    regenerates them and pushes the fix back to the PR branch using the PAT.
+#    Downstream CI re-runs naturally (PAT-pushed commits DO trigger workflows,
+#    unlike GITHUB_TOKEN-pushed ones). Author sees one extra commit with a
+#    clear `[bot]` author; nothing else changes about their PR.
+#
+# 2. FAIL-FAST mode (fallback — when no PAT configured).
+#    Without the PAT, the workflow falls back to the v0.2 behavior: fails red
+#    with the regenerate-locally message. Required because GITHUB_TOKEN
+#    commits don't re-trigger required status checks (anti-recursion safety),
+#    so auto-commit via GITHUB_TOKEN would leave the merge gate stuck on
+#    "Expected — Waiting for status to be reported" forever.
+#
+# Forked PRs always run in fail-fast mode (can't push back to the fork's
+# head ref). Internal PRs use auto-fix when the PAT is available.
+#
+# Setup for the PAT path:
+#   1. Create a fine-grained PAT scoped to this repo with Contents: write.
+#   2. Add it as `LOGMIND_AUTO_REGEN_PAT` under
+#      Settings → Secrets and variables → Actions (or at the org level if
+#      multiple repos use logmind).
 #
 # Replaces the v0.1.x `logmind-aggregate.yml` workflow.
 
@@ -22,7 +38,8 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: read
+  contents: write   # needed for the auto-fix push when PAT is configured
+  pull-requests: read
 
 jobs:
   check-derived-docs:
@@ -31,7 +48,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          # For internal PRs, check out the PR's head ref so we can push
+          # back to it. For forks, github.head_ref is set but we can't
+          # push to forks — handled below.
+          ref: ${{ github.head_ref || github.ref }}
           fetch-depth: 0
+          # Use PAT if available so the push triggers downstream checks.
+          # Falls through to GITHUB_TOKEN when absent (still allows checkout).
+          token: ${{ secrets.LOGMIND_AUTO_REGEN_PAT || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v6
         with:
@@ -43,7 +67,7 @@ jobs:
         # locally. Bump after running `logmind init` against a new release.
         run: pip install "logmind==0.6.11"
 
-      - name: Verify docs/timeline.md is current
+      - name: Regenerate derived docs
         run: |
           set -euo pipefail
           if [ ! -f docs/timeline.md ]; then
@@ -51,9 +75,55 @@ jobs:
             exit 1
           fi
           logmind timeline --write docs/timeline.md
-          if ! git diff --quiet docs/timeline.md; then
-            echo "::error::docs/timeline.md is stale. Run \`logmind timeline --write docs/timeline.md\` locally and commit the regenerated file."
-            git --no-pager diff docs/timeline.md | head -50
+          logmind file-structure --write docs/file-structure.md
+
+      - name: Auto-fix or fail fast
+        env:
+          PAT: ${{ secrets.LOGMIND_AUTO_REGEN_PAT }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          # No diff → already current. Nothing to do.
+          if git diff --quiet docs/timeline.md docs/file-structure.md 2>/dev/null; then
+            echo "docs/timeline.md + docs/file-structure.md are up to date."
+            exit 0
+          fi
+
+          echo "Derived docs are stale on this PR."
+
+          # Forked PR — can't push back to the fork's head ref.
+          # Fall back to fail-fast (today's behaviour).
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error title=Stale derived docs::PR is from a fork ($HEAD_REPO). Auto-fix cannot push back. Run \`logmind timeline --write docs/timeline.md && logmind file-structure --write docs/file-structure.md\` locally and commit the regenerated files."
+            git --no-pager diff docs/timeline.md docs/file-structure.md | head -80
             exit 1
           fi
-          echo "docs/timeline.md is up to date."
+
+          # No PAT configured — fail-fast mode. GITHUB_TOKEN-pushed commits
+          # don't re-trigger required checks, so auto-commit would brick
+          # the merge gate. See workflow header comment for rationale.
+          if [ -z "${PAT:-}" ]; then
+            echo "::warning title=Stale derived docs::No \`LOGMIND_AUTO_REGEN_PAT\` configured — falling back to fail-fast."
+            echo "::warning::To enable auto-fix: create a fine-grained PAT with Contents: write on this repo, add it as \`LOGMIND_AUTO_REGEN_PAT\` secret. logmind will then push regenerated derived docs back to the PR branch on stale."
+            echo "::error title=Stale derived docs::Run \`logmind timeline --write docs/timeline.md && logmind file-structure --write docs/file-structure.md\` locally and commit the regenerated files."
+            git --no-pager diff docs/timeline.md docs/file-structure.md | head -80
+            exit 1
+          fi
+
+          # Auto-fix mode: commit + push back. The checkout step above
+          # already authenticated with the PAT, so `git push` here uses
+          # the PAT credentials and the push triggers downstream CI.
+          echo "::notice title=Auto-fixing stale derived docs::Regenerating and pushing back to ${HEAD_REF}."
+          git config user.name "logmind-auto-regen[bot]"
+          git config user.email "logmind-auto-regen@users.noreply.github.com"
+          git add docs/timeline.md docs/file-structure.md
+          git commit -m "chore: regen derived docs
+
+          Auto-fix by logmind's check-derived-docs workflow (v0.3.4+).
+          The PR's docs/timeline.md or docs/file-structure.md was stale
+          after a code change. Regenerated from the per-branch decision
+          files (timeline) and current tree (file-structure)."
+          git push origin "HEAD:${HEAD_REF}"
+          echo "::notice::Derived docs regenerated and pushed. CI will re-run on the new commit."

--- a/docs/decisions-branches/chore__refresh-self-update-v5.md
+++ b/docs/decisions-branches/chore__refresh-self-update-v5.md
@@ -1,0 +1,8 @@
+## 2026-06-01 19:26 - chore: refresh logmind-self-update.yml to v5 (bootstrap PAT-based workflow push)
+
+**Reasoning:** v0.6.11 self-update template uses LOGMIND_AUTO_REGEN_PAT for workflow-file pushes. `logmind agents update --apply` only does pin bumps; the v5 marker bump requires full `logmind init` refresh — caught by clud-bug-review on tokenomics PR #52.
+
+**Implications:**
+- Next auto-propagation cycle on this repo can finally work cleanly for workflow-file refreshes (assuming LOGMIND_AUTO_REGEN_PAT secret is configured).
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -39,7 +39,6 @@ clud-bug
 │   ├── update.js
 │   └── usage.js
 ├── site
-│   ├── .vercel
 │   ├── app
 │   ├── lib
 │   ├── .gitignore

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (9 decisions)
+## 2026-06 (10 decisions)
 
-- **2026-06-01** — chore: refresh logmind v0.6.9 → v0.6.11 *(chore/logmind-v0.6.11)* — [decisions-branches/chore__logmind-v0.6.11.md](decisions-branches/chore__logmind-v0.6.11.md)
-- *... 7 more decisions ...*
+- **2026-06-01** — chore: refresh logmind-self-update.yml to v5 (bootstrap PAT-based workflow push) *(chore/refresh-self-update-v5)* — [decisions-branches/chore__refresh-self-update-v5.md](decisions-branches/chore__refresh-self-update-v5.md)
+- *... 8 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)


### PR DESCRIPTION
Bootstrap fix for v0.6.11 propagation cycle: refreshes \`logmind-self-update.yml\` to v5 template (PAT-based push for workflow refreshes). The initial v0.6.11 propagation used \`logmind agents update --apply\` which only does pin bumps; the v5 template change came in via a marker bump that requires full \`logmind init\` refresh. Without this, the next auto-propagation cycle would hit the same workflow-push gap as the v0.6.9 cycle did today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)