### PR TITLE
[skip-logmind] chore: add dependabot auto-merge caller workflow (§8.1)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,20 @@
+name: Dependabot auto-merge
+
+# Auto-approve + squash-merge Dependabot patch/minor PRs once required CI passes.
+# Major bumps are left for human review. See §8.1 for org-level rationale.
+#
+# Calls the reusable workflow at thrillmade/.github.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    uses: thrillmade/.github/.github/workflows/dependabot-auto-merge.yml@main
+    secrets: inherit

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,5 +16,6 @@ permissions:
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
-    uses: thrillmade/.github/.github/workflows/dependabot-auto-merge.yml@main
+    # Pinned to thrillmade/.github commit e4dfd7e for supply-chain immutability (per clud-bug-review on PR #144). Bump via dependabot or manual edit.
+    uses: thrillmade/.github/.github/workflows/dependabot-auto-merge.yml@e4dfd7ea66a4917ea85b7880c0e700628ced409f
     secrets: inherit


### PR DESCRIPTION
## Summary

- Adds a tiny caller workflow that delegates Dependabot patch + minor auto-merge to the reusable workflow at `thrillmade/.github`.
- Major bumps are still surfaced for human review.

## Why

Path A from org master plan §8.1 — near-term unblock for org-wide dependency hygiene. Without this, Dependabot PRs accumulate (CI churn, security tail) until a human babysits each one.

## Depends on

`thrillmade/.github#1` (the reusable workflow itself). This PR can land first or after — the workflow is dormant until the reusable target exists at `main`.

## Test plan

- [ ] Land `thrillmade/.github#1` first.
- [ ] Land this PR.
- [ ] Watch the next Dependabot patch/minor PR get auto-approved and merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
