### PR TITLE
[skip-logmind] chore: bump logmind pin v1.0.0 → v1.0.1 (check-links exclude docs/reviews/)

### DIFF
--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -29,11 +29,11 @@ jobs:
         # binary stays backward-compatible across the line and CI tracks
         # the latest stable.
         run: |
-          # logmind install — pinned to v1.0.0 tag (immutable), per the
+          # logmind install — pinned to v1.0.1 tag (immutable), per the
           # security review on PR #143. Bumping to v1.x.y is a deliberate
           # change on each consumer repo, not a silent main-tracks-latest drift.
           # logmind.dev/install.sh CDN routing is a v1.x follow-up; pin to GitHub raw until that ships.
-          curl -fsSL https://raw.githubusercontent.com/thrillmade/logmind/v1.0.0/installer/install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/thrillmade/logmind/v1.0.1/installer/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Check markdown link integrity

--- a/docs/reviews/PR-149.md
+++ b/docs/reviews/PR-149.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #149
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: d179070e502ef14d0395ed9af88a5e240f2b4f31 -->
+<!-- review-sha: 024dd566fa57abd18d23e0c8100d4c0c00d1a938 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-149.md
+++ b/docs/reviews/PR-149.md
@@ -1,0 +1,15 @@
+# clud-bug review — PR #149
+<!-- protocol-version: 0.1.0 -->
+<!-- written-by: clud-bug[bot] -->
+<!-- review-sha: 1925ff6ffbbc150fddc1d4b0dea14b9edad4b7e7 -->
+
+**Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
+
+**Skills cited:**
+- _(none — see summary above)_
+
+**Findings:**
+
+---
+
+[Link to PR](https://github.com/thrillmade/clud-bug/pull/149)

--- a/docs/reviews/PR-149.md
+++ b/docs/reviews/PR-149.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #149
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 3539edd44cb5b033687d8ff814117e0e89697be6 -->
+<!-- review-sha: 56493d98a2827547f8f105c991024ac33ffd4b1d -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-149.md
+++ b/docs/reviews/PR-149.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #149
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 43ce5cc1856483c2d53c96e71ff83a93be43a574 -->
+<!-- review-sha: 3539edd44cb5b033687d8ff814117e0e89697be6 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-149.md
+++ b/docs/reviews/PR-149.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #149
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 024dd566fa57abd18d23e0c8100d4c0c00d1a938 -->
+<!-- review-sha: b6d819d77b1bbe27a84feaaee7dd68a8e97009f5 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-149.md
+++ b/docs/reviews/PR-149.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #149
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 1925ff6ffbbc150fddc1d4b0dea14b9edad4b7e7 -->
+<!-- review-sha: 43ce5cc1856483c2d53c96e71ff83a93be43a574 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-149.md
+++ b/docs/reviews/PR-149.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #149
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 08a619a892c3e7f3af2e87e686ae1942f2d71d29 -->
+<!-- review-sha: 6824fc6cf28a5f189013b204f4353dde50a3a907 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-149.md
+++ b/docs/reviews/PR-149.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #149
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: b6d819d77b1bbe27a84feaaee7dd68a8e97009f5 -->
+<!-- review-sha: d2bf89d0d3d408c703a0c056b81adb3ddda4e6ac -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-149.md
+++ b/docs/reviews/PR-149.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #149
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 6824fc6cf28a5f189013b204f4353dde50a3a907 -->
+<!-- review-sha: d179070e502ef14d0395ed9af88a5e240f2b4f31 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-149.md
+++ b/docs/reviews/PR-149.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #149
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 56493d98a2827547f8f105c991024ac33ffd4b1d -->
+<!-- review-sha: 3491a1acc9e39a0993c05027e1e214f6da2f6788 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-149.md
+++ b/docs/reviews/PR-149.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #149
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: d2bf89d0d3d408c703a0c056b81adb3ddda4e6ac -->
+<!-- review-sha: 082f32827dbffa2d6c142347a918f801c3b79d13 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-149.md
+++ b/docs/reviews/PR-149.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #149
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 786679a2867aed951fd5bed0eb10267d423d7c81 -->
+<!-- review-sha: 4274f051d9504444b9fd79c20d9e839fd872a62e -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-149.md
+++ b/docs/reviews/PR-149.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #149
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 4274f051d9504444b9fd79c20d9e839fd872a62e -->
+<!-- review-sha: 6d8b68ab431b20569ae89d61395569eb5a177998 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-149.md
+++ b/docs/reviews/PR-149.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #149
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 3491a1acc9e39a0993c05027e1e214f6da2f6788 -->
+<!-- review-sha: 786679a2867aed951fd5bed0eb10267d423d7c81 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-149.md
+++ b/docs/reviews/PR-149.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #149
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 6d8b68ab431b20569ae89d61395569eb5a177998 -->
+<!-- review-sha: 08a619a892c3e7f3af2e87e686ae1942f2d71d29 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 


### PR DESCRIPTION
## Summary

Bumps the logmind install pin in `.github/workflows/check-doc-links.yml` from `v1.0.0` → `v1.0.1` so this repo's CI picks up the orphan-markdown fix shipped in [logmind PR #145](https://github.com/thrillmade/logmind/pull/145).

## Why

logmind v1.0.1 (shipped 2026-06-05T20:13Z) carries the structural fix that excludes `docs/reviews/PR-*.md` from the orphan-markdown check. Without this bump, every PR that touches `docs/reviews/` trips the check-links gate — most recently hit on clud-bug#147 and the same false-positive pattern is recurring org-wide on consumers still pinned at v1.0.0.

This propagates the fix to clud-bug's CI. Surgical 2-line change:
- `curl ... /v1.0.0/installer/install.sh` → `/v1.0.1/installer/install.sh`
- Adjacent comment `pinned to v1.0.0 tag` → `pinned to v1.0.1 tag`

## Out of scope

Other workflows in this repo (`regen-timeline.yml`, `logmind-self-update.yml`) also pin logmind at v1.0.0. Those are intentionally not touched here — different concern (timeline regen / self-update plumbing, no check-links interaction). Separate PR can sweep them.

## Test plan

- [ ] CI green on this PR (check-doc-links job uses the new pin)
- [ ] After merge, next PR touching `docs/reviews/PR-*.md` no longer trips check-links

🤖 Generated with [Claude Code](https://claude.com/claude-code)