### PR TITLE
[skip-logmind] chore: migrate to setup-logmind action + Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      thrillmade:
+        patterns:
+          - "thrillmade/*"

--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -1,4 +1,4 @@
-# logmind-template-version: v3
+# logmind-template-version: v4
 name: doc link integrity
 
 # Fail PRs that introduce broken or orphaned markdown links so agents stay
@@ -22,19 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install logmind
-        # logmind ships as a single Go binary since v1.0. The install.sh
-        # script fetches the latest signed release, verifies SHA256, and
-        # drops the binary in $HOME/.local/bin. No version pin — the v1.x
-        # binary stays backward-compatible across the line and CI tracks
-        # the latest stable.
-        run: |
-          # logmind install — pinned to v1.0.1 tag (immutable), per the
-          # security review on PR #143. Bumping to v1.x.y is a deliberate
-          # change on each consumer repo, not a silent main-tracks-latest drift.
-          # logmind.dev/install.sh CDN routing is a v1.x follow-up; pin to GitHub raw until that ships.
-          curl -fsSL https://raw.githubusercontent.com/thrillmade/logmind/v1.0.1/installer/install.sh | bash
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: thrillmade/setup-logmind@v1.0.1
 
       - name: Check markdown link integrity
         run: logmind check-links

--- a/.github/workflows/logmind-self-update.yml
+++ b/.github/workflows/logmind-self-update.yml
@@ -1,16 +1,24 @@
-# logmind-template-version: v7
+# logmind-template-version: v8
 name: logmind self-update
 
-# Weekly check for a newer published logmind. If one exists, runs
-# `pip install --upgrade logmind && logmind init` (refresh mode — leaves
-# docs/ and .logmind/config.yml alone, refreshes stale workflow
-# templates) and opens a PR titled "logmind self-update: X.Y.Z → A.B.C".
+# Weekly check that the bundled logmind workflow templates are still on
+# the current template-version marker. When `logmind init` ships a new
+# template body (marker bump v3→v4 etc.), this workflow runs `logmind
+# init` in refresh mode and opens a PR with the marker-driven changes.
 #
-# Reads the currently installed version from this repo's pinned
-# workflow line (`pip install "logmind==X.Y.Z"` in regen-timeline.yml,
-# shipped since logmind v0.2.1). Pre-v0.2.1 installs aren't pinned and
-# self-update will skip with a notice — re-run `logmind init` once
-# manually to upgrade past that.
+# v8 / logmind v1.1.0 (2026-06-05) — distribution lock changed how
+# version pinning works for consumer repos:
+#
+#   - logmind itself is installed in CI via the
+#     `thrillmade/setup-logmind@vX.Y.Z` action, NOT
+#     `pip install logmind==X.Y.Z`.
+#   - The action ref is bumped by Dependabot's `github-actions`
+#     ecosystem entry (also shipped by `logmind init` via
+#     `.github/dependabot.yml`). Dependabot's job: keep the action pin
+#     current. This workflow's job: keep the template BODY current.
+#   - Pure version-pin bumps no longer flow through this workflow —
+#     Dependabot handles them, no PAT required, no smart-skip needed.
+#     We only run when a template body (marker line + content) shifts.
 #
 # To pin to a specific logmind version and stop self-updates, add a
 # `pinVersion: "X.Y.Z"` field to `.logmind/config.yml`. The cron will
@@ -24,14 +32,14 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  # NOTE (v5 / logmind v0.6.11): there is NO `permissions:` knob that
-  # lets GITHUB_TOKEN push to .github/workflows/*.yml — GitHub blocks
-  # that at the git layer for security. When a logmind refresh would
-  # touch a workflow file (e.g. an updated `check-doc-links.yml`
-  # template body), the only path that works is to push via a PAT with
-  # the `workflow` scope. We use the SAME `LOGMIND_AUTO_REGEN_PAT`
-  # secret that `regen-timeline.yml` v3 uses for the same reason
-  # (single secret to configure, both workflows benefit).
+  # NOTE: there is NO `permissions:` knob that lets GITHUB_TOKEN push
+  # to .github/workflows/*.yml — GitHub blocks that at the git layer
+  # for security. When a logmind refresh would touch a workflow file
+  # (e.g. an updated `check-doc-links.yml` template body), the only
+  # path that works is to push via a PAT with the `workflow` scope.
+  # We use the SAME `LOGMIND_AUTO_REGEN_PAT` secret that
+  # `regen-timeline.yml` v3+ uses for the same reason (single secret
+  # to configure, both workflows benefit).
   # Without the PAT: this workflow falls back to non-workflow-only
   # refreshes (AGENTS.md, .cursorrules, etc.) and prints a one-line
   # `::warning::` directing the user to configure the PAT to unlock
@@ -43,43 +51,39 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # v5 / logmind v0.6.11: use the regen PAT when available so we
-          # can push refreshed workflow files. Falls through to
-          # GITHUB_TOKEN when absent — push works for non-workflow files
-          # but will reject any workflow-file changes (handled in the
-          # push step below).
+          # Use the regen PAT when available so we can push refreshed
+          # workflow files. Falls through to GITHUB_TOKEN when absent —
+          # push works for non-workflow files but will reject any
+          # workflow-file changes (handled in the push step below).
           token: ${{ secrets.LOGMIND_AUTO_REGEN_PAT || secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Compare installed vs PyPI latest
+      - name: Compare installed vs released
         id: compare
         run: |
           set -euo pipefail
-          # Installed version: parsed from the workflow pin line shipped
-          # since v0.2.1. If absent, skip with a clear notice.
-          REGEN_FILE=".github/workflows/regen-timeline.yml"
+          # Installed action ref: parsed from any workflow file's
+          # `uses: thrillmade/setup-logmind@vX.Y.Z` line. Since v1.1.0
+          # all logmind-installed workflows use the action; pre-v1.1.0
+          # installs still pin via `pip install logmind==X.Y.Z`.
           INSTALLED=""
-          if [ -f "$REGEN_FILE" ]; then
-            INSTALLED=$(grep -oE 'logmind==[0-9]+\.[0-9]+\.[0-9]+' "$REGEN_FILE" | head -1 | sed 's/logmind==//') || true
-          fi
+          for f in .github/workflows/check-doc-links.yml .github/workflows/regen-timeline.yml; do
+            if [ -f "$f" ]; then
+              INSTALLED=$(grep -oE 'thrillmade/setup-logmind@v[0-9]+\.[0-9]+\.[0-9]+' "$f" | head -1 | sed 's/thrillmade\/setup-logmind@v//') || true
+              if [ -n "$INSTALLED" ]; then break; fi
+              # Fall back to legacy pip pin so pre-v1.1.0 installs upgrade once.
+              INSTALLED=$(grep -oE 'logmind==[0-9]+\.[0-9]+\.[0-9]+' "$f" | head -1 | sed 's/logmind==//') || true
+              if [ -n "$INSTALLED" ]; then break; fi
+            fi
+          done
           if [ -z "$INSTALLED" ]; then
-            echo "::notice::Installed logmind version not detected (no pinned \`pip install\` in regen-timeline.yml). Re-run \`logmind init\` once locally to upgrade past pre-v0.2.1 installs, then self-update will work from then on."
+            echo "::notice::Installed logmind version not detected in workflow files. Re-run \`logmind init\` once locally to land the current install style, then self-update will work from then on."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Optional pin override from .logmind/config.yml. Parsed with
-          # grep — the field is a flat top-level scalar and the workflow
-          # runner can't be relied on to have any third-party Python
-          # library available. v0.2.7 and earlier invoked a python3
-          # one-liner that depended on a third-party YAML lib being
-          # importable; when the runner lacked it the import failed
-          # before the try block could catch it, and the surrounding
-          # `2>/dev/null || echo ""` swallowed the failure into empty
-          # pin — silently breaking opt-out.
+          # Optional pin override from .logmind/config.yml. Flat grep
+          # because the runner can't be relied on to have a third-party
+          # YAML lib importable.
           PIN=""
           if [ -f ".logmind/config.yml" ]; then
             PIN=$(grep -E '^[[:space:]]*pinVersion:[[:space:]]*' .logmind/config.yml \
@@ -88,18 +92,17 @@ jobs:
               || echo "")
           fi
 
-          # v7 / logmind v0.6.14 — CDN-aware retry. The PyPI JSON API + simple
-          # index propagate via a CDN that lags 30-60s behind a publish event.
-          # Cron-triggered self-update workflows can fire during the gap and
-          # see a stale "latest", silently no-op'ing. Three attempts with 0s
-          # / 30s / 60s backoff cover the typical CDN tail; if all three
-          # report the same version, accept it (legitimate no-op).
+          # Latest release: fetched from the GitHub /releases/latest
+          # JSON. CDN-aware retry (3 attempts: 0s / 30s / 60s) covers
+          # the ~30-60s lag between a release publish and the JSON
+          # endpoint reflecting the new tag_name. Lifted from the v7
+          # PyPI-side retry — same logic, different endpoint.
           fetch_latest() {
             local v
-            v=$(pip index versions logmind 2>/dev/null | grep -oE 'logmind \([0-9]+\.[0-9]+\.[0-9]+\)' | head -1 | sed 's/logmind (\(.*\))/\1/') || true
-            if [ -z "$v" ]; then
-              v=$(curl -fsSL https://pypi.org/pypi/logmind/json 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])" 2>/dev/null) || true
-            fi
+            v=$(curl -fsSL https://api.github.com/repos/thrillmade/logmind/releases/latest 2>/dev/null \
+              | sed -n 's/.*"tag_name": "\(.*\)".*/\1/p' \
+              | head -1 \
+              | sed 's/^v//') || true
             echo "$v"
           }
           LATEST=$(fetch_latest)
@@ -131,6 +134,15 @@ jobs:
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
+      # v1.1.0+ installs logmind itself via the setup-logmind action so
+      # `logmind init` (the refresh) runs against the same binary
+      # version consumer repos will see after this workflow lands its
+      # PR. The action's version tracks the LATEST step output.
+      - uses: thrillmade/setup-logmind@v1.0.1
+        if: steps.compare.outputs.skip == 'false'
+        with:
+          version: ${{ steps.compare.outputs.latest }}
+
       - name: Run logmind init + open PR
         if: steps.compare.outputs.skip == 'false'
         env:
@@ -145,32 +157,18 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
 
-          # v1.0 cutover: logmind is now a Go binary distributed via brew /
-          # install.sh, not a Python wheel on PyPI. The version-detection
-          # block above no longer finds a `pip install` pin in
-          # regen-timeline.yml after the v1 migration, so this self-update
-          # workflow soft-skips by design. Brew users get upgrades via
-          # `brew upgrade thrillmade/tap/logmind`; curl-installed users
-          # re-run install.sh (always grabs latest stable). When/if
-          # PyPI-based self-update is replaced with a release-feed-based
-          # equivalent, this step gets the new install command.
-          # logmind install — pinned to v1.0.0 tag (immutable), per the
-          # security review on PR #143. Bumping to v1.x.y is a deliberate
-          # change on each consumer repo, not a silent main-tracks-latest drift.
-          # logmind.dev/install.sh CDN routing is a v1.x follow-up; pin to GitHub raw until that ships.
-          curl -fsSL https://raw.githubusercontent.com/thrillmade/logmind/v1.0.0/installer/install.sh | bash
-          export PATH="$HOME/.local/bin:$PATH"
-          # Refresh mode (v0.2.1+) rewrites stale workflow templates by
-          # `# logmind-template-version:` marker, leaves docs/ + .logmind/
-          # + agent files untouched. Idempotent.
+          # Refresh mode rewrites stale workflow templates by the
+          # `# logmind-template-version:` marker, leaves docs/ +
+          # .logmind/ + agent files untouched. Idempotent.
           logmind init --no-git --no-skill-install || logmind init
 
-          # v6 / logmind v0.6.13 — SMART WORKFLOW-SKIP. Decouples pin-bump
-          # releases (no PAT needed) from template-body releases (PAT
-          # needed). If the refresh touched a workflow file AND no PAT is
-          # configured → skip the release with a clear `::notice::`
-          # instead of failing. Pin-bump-only releases (no workflow body
-          # change) propagate normally via GITHUB_TOKEN.
+          # SMART WORKFLOW-SKIP. Decouples action-pin bumps (now
+          # handled by Dependabot, no PAT needed) from template-body
+          # releases (PAT needed for workflow-file push). If the
+          # refresh touched a workflow file AND no PAT is configured
+          # → skip the release with a clear `::notice::` instead of
+          # failing. Pure pin-bump-only diffs never appear on this
+          # branch in v1.1.0+ because Dependabot owns the pins.
           git add -A
           if git diff --cached --quiet; then
             echo "::notice::No file changes after logmind init — nothing to PR."
@@ -180,32 +178,30 @@ jobs:
           if [ -n "$WORKFLOW_CHANGES" ] && [ -z "${PAT:-}" ]; then
             echo "::notice title=Skipping workflow-touching release::This release would update workflow file(s):"
             echo "::notice::$WORKFLOW_CHANGES"
-            echo "::notice::No \`LOGMIND_AUTO_REGEN_PAT\` is configured, so this run will skip (pin-bump-only releases would propagate normally without the PAT)."
-            echo "::notice::To enable: configure a fine-grained PAT with Contents:write + Workflows:write + Pull-requests:write as the \`LOGMIND_AUTO_REGEN_PAT\` repo or org secret (same secret used by regen-timeline.yml v3)."
+            echo "::notice::No \`LOGMIND_AUTO_REGEN_PAT\` is configured, so this run will skip."
+            echo "::notice::To enable: configure a fine-grained PAT with Contents:write + Workflows:write + Pull-requests:write as the \`LOGMIND_AUTO_REGEN_PAT\` repo or org secret (same secret used by regen-timeline.yml)."
             echo "::notice::OR: skip this release by running \`logmind init\` locally and opening a PR manually."
             exit 0
           fi
-          # v7 / logmind v0.6.14 — `[skip-logmind]` title prefix. These are
-          # bot-generated propagation PRs (pin-bump + template-body refresh)
-          # owned by the workflow itself; they're NOT decision commits.
-          # Without the prefix, consumer-repo `check-decisions.yml` fails
-          # because the diff exceeds the threshold AND no decision file is
-          # present. The prefix lets consumer-repo check-decisions skip via
-          # its existing maintainer-override path. Bot-PR semantics align
-          # with consumer-repo gates without manual title editing rituals.
+          # `[skip-logmind]` title prefix — these are bot-generated
+          # propagation PRs (template-body refresh) owned by the
+          # workflow itself; they're NOT decision commits. Without the
+          # prefix, consumer-repo `check-decisions.yml` fails because
+          # the diff exceeds the threshold AND no decision file is
+          # present. The prefix lets consumer-repo check-decisions
+          # skip via its existing maintainer-override path.
           git commit -m "[skip-logmind] logmind self-update: ${INSTALLED} → ${LATEST}"
           git push -u origin "$BRANCH"
-          # v6 / logmind v0.6.13 — `gh pr create` uses PAT too when available.
-          # Per-repo "Allow GitHub Actions to create and approve pull
-          # requests" setting blocks GITHUB_TOKEN from opening PRs on
-          # some org/repo configs (2/5 thrillmade consumers hit this
-          # during the v0.6.12 self-heal validation). Using the PAT for
-          # this step too eliminates the second per-repo setup checkbox.
+          # `gh pr create` uses PAT too when available. Per-repo "Allow
+          # GitHub Actions to create and approve pull requests" setting
+          # blocks GITHUB_TOKEN from opening PRs on some org/repo
+          # configs. Using the PAT for this step too eliminates the
+          # second per-repo setup checkbox.
           PR_TOKEN="${PAT:-${GH_TOKEN}}"
           GH_TOKEN="$PR_TOKEN" gh pr create \
             --title "[skip-logmind] logmind self-update: ${INSTALLED} → ${LATEST}" \
             --body "Automated upgrade from logmind ${INSTALLED} → ${LATEST}.
 
-          Refresh mode (v0.2.1+) only touched workflow templates whose \`# logmind-template-version:\` marker is stale; \`docs/\`, \`.logmind/config.yml\`, and agent files were left alone.
+          Refresh mode only touched workflow templates whose \`# logmind-template-version:\` marker is stale; \`docs/\`, \`.logmind/config.yml\`, and agent files were left alone.
 
           Review the diff. To stop self-updates after this, add \`pinVersion: \"${LATEST}\"\` to \`.logmind/config.yml\` before merging."

--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -1,4 +1,4 @@
-# logmind-template-version: v3
+# logmind-template-version: v4
 name: check derived docs
 
 # Derived-file architecture (v0.2+): docs/timeline.md + docs/file-structure.md
@@ -57,19 +57,7 @@ jobs:
           # Falls through to GITHUB_TOKEN when absent (still allows checkout).
           token: ${{ secrets.LOGMIND_AUTO_REGEN_PAT || secrets.GITHUB_TOKEN }}
 
-      - name: Install logmind
-        # logmind ships as a single Go binary since v1.0. The install.sh
-        # script fetches the latest signed release, verifies SHA256, and
-        # drops the binary in $HOME/.local/bin. No version pin — the v1.x
-        # binary stays backward-compatible across the line and CI tracks
-        # the latest stable.
-        run: |
-          # logmind install — pinned to v1.0.0 tag (immutable), per the
-          # security review on PR #143. Bumping to v1.x.y is a deliberate
-          # change on each consumer repo, not a silent main-tracks-latest drift.
-          # logmind.dev/install.sh CDN routing is a v1.x follow-up; pin to GitHub raw until that ships.
-          curl -fsSL https://raw.githubusercontent.com/thrillmade/logmind/v1.0.0/installer/install.sh | bash
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: thrillmade/setup-logmind@v1.0.1
 
       - name: Regenerate derived docs
         run: |

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 1496e0f98e3db4f310df4f5776d56ec67db84946 -->
+<!-- review-sha: 527d5bed05967bdfaff847cd87fb2b8523905a26 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: cf88d7e7b9192428522562bc576666ff65944960 -->
+<!-- review-sha: d5711029c3d570bfb350aa380223dda41af4d1ac -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 27146f3ee7be30d0ed18b2a961e3fe6e44c682bf -->
+<!-- review-sha: c3dd2f97d2ab6f15cc1d82800aa71668a5b41f4b -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: eab1cbb5b501fe37165fd4c79518cd799016a6b6 -->
+<!-- review-sha: a82c22121c686931b2e38f3973b2afdde8469ddd -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: e08d875c0ade45893fd34439ab140d6018c15e22 -->
+<!-- review-sha: 16112fece590f6333d16f84931c8dc14f65cfd9b -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 7fa094dc4f2beb2297ea44dcb993cf0a8b5681cf -->
+<!-- review-sha: 9ac4b8688e33ebf1a3423b48be6527998afe1b7c -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: c930a3270e618449ec15767099f77fa04cde4da2 -->
+<!-- review-sha: ee54701aa550204b5b04e0f6b4cd11add413e58a -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: c545a1e301ebcb0c41c3fcafc7f6213935860bda -->
+<!-- review-sha: 0cf13c4875c792f085f568d88175b10d12d05685 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 515d33a65c1c479ea2735df3a7454f12ae6dcaff -->
+<!-- review-sha: 7c433a8b268a084e35b19ad95f52054a01d91b6f -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 0c65a73e4616a35fd07ba218ab02d6a7b41c2ad5 -->
+<!-- review-sha: 5cbfff919bd4701402b73a44da049bc60e526538 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: d42d3a007d5dd15092ceffd29ef3418c57cc5652 -->
+<!-- review-sha: 8b844f1abf8bb75e04eb5d03e1ef8f5d96638f63 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 5d62169fa3bc32d4dc39a3a361a9ff114e59ad08 -->
+<!-- review-sha: a30d881a6d50ec7f2a3416e291fca11758a4c554 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 1d6f4e9489a0a1f0552f9a7825a4573ab828b981 -->
+<!-- review-sha: e9c4ea0912521e7194773ab0bcfdd088ac8653f5 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 1408ef48f2d10cc7417684fc3b7f08fcfbd8c7f3 -->
+<!-- review-sha: f606232ca7bb5e1c40380f1abc62d4929ed963ee -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 57093d1c8ea3da26d19f6f74f2e1ef47d0f21748 -->
+<!-- review-sha: 4443d53c9d7a9c7279f3ef698feda80a12af2e3d -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 8e2c7e2031f75c0889a0305343cd2e8c928d0431 -->
+<!-- review-sha: 7019c1aeb114c418e1ee4a02997d8dfd5dde915d -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 0766afb622964f912cb6e53bd6ccf4bd39defd58 -->
+<!-- review-sha: 5eecf2f08a0472298ff54058f14d0421904520bc -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 8df4b102725fa175f6a3b1b261b0efde085d0e2a -->
+<!-- review-sha: c7f4712bf132722a2cdfd156b5ad27d26255769c -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: bff479f849957918ea3bebe8f6916f78066f3da6 -->
+<!-- review-sha: 9c80b84d15415f50c6b06e87722a11e24481c23f -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: f8015c3799d44c08e3e9ae12750cd5a66342272c -->
+<!-- review-sha: 8e2c7e2031f75c0889a0305343cd2e8c928d0431 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: e75d731ae393c3d81afd9193247433581edcddcd -->
+<!-- review-sha: 2c096a6f60af4ddee49055a8ec53dc67d788001d -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: d29158c6d83dfb91a886f67641176316e1839594 -->
+<!-- review-sha: 1496e0f98e3db4f310df4f5776d56ec67db84946 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 091e993f5dc376fec58a56ec5ad8081ef1d0aa04 -->
+<!-- review-sha: 62cb873904672270740b1f2e2a22e92dcd20c32a -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: fcfa88edd716dd80a722b8f46c9c6985e8c75d49 -->
+<!-- review-sha: 55c6d3f6cd07598a9528082aacfc90612dadf091 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 7c433a8b268a084e35b19ad95f52054a01d91b6f -->
+<!-- review-sha: 1ba042a571504f97ec1fe0e5fa1c145f050a64e9 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 73b719f9461c55249a7cdc0b55f04222e23cc446 -->
+<!-- review-sha: 3a3c043637e06649ca1c3ce15180087b33aec713 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 46f33ab1f40f340109e537c7b8b1b8dbdd807c75 -->
+<!-- review-sha: 5532683428bdb0f3bf2884abd9cf6e600db23366 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: d5711029c3d570bfb350aa380223dda41af4d1ac -->
+<!-- review-sha: 4c6f4851a1814971f298642b5cc8ace34e214803 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 347034988057284416c0615b725f079976be3582 -->
+<!-- review-sha: c1bd92cbec939fa9faf9764c4f4ffd51dc032683 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 26d2d8423bdfe72e300b5725fa2ccd8a04a7c2e7 -->
+<!-- review-sha: df18f4f45502c3a2d4635ad0328362dafe0e21d9 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 51475f57807711a64dca104c17ebee31ee6da09f -->
+<!-- review-sha: 4de38ea7625e9f3fc0d417ff43634140f911ca77 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: ce3edd6499f6947ed04f7afe0f3742448751ff71 -->
+<!-- review-sha: b4c6faaff192837dc731f9e3a8bc89edc9087b4c -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 414a93df7e817437c434c918cc7599c6d24f8137 -->
+<!-- review-sha: d42d3a007d5dd15092ceffd29ef3418c57cc5652 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 79a4888448b8b48a4706c1bb91b88070be2cf23f -->
+<!-- review-sha: 667ce147cbdd7119b5bcabee3598233bf3815554 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 937dac6e02166dfd500fe13f9a69d7d123e1bee1 -->
+<!-- review-sha: e180d61e98cec1aa1fea77cee8eac039a28e7af0 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 14bc4d898c0a8cbcc143431ed2537bba96083c05 -->
+<!-- review-sha: 27146f3ee7be30d0ed18b2a961e3fe6e44c682bf -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 0e36d8d6afa5820ecc7dad522bf415ccb1fdcbb8 -->
+<!-- review-sha: 972dfc07f1777e5e4004535030857420cc021e2a -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 972dfc07f1777e5e4004535030857420cc021e2a -->
+<!-- review-sha: c545a1e301ebcb0c41c3fcafc7f6213935860bda -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 1fb0b94e501c4197d3974d51b731b7e0e1009e7d -->
+<!-- review-sha: ce3edd6499f6947ed04f7afe0f3742448751ff71 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 7f41f0145074c1a5482a0ebb388cf037f6d62bf9 -->
+<!-- review-sha: ba6aa81918f97fd8da7f736c02471350a166c408 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: a093d176ce42d82960770d2218d4e26f07f0b113 -->
+<!-- review-sha: 0c65a73e4616a35fd07ba218ab02d6a7b41c2ad5 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 726d86030a79ee60e6af30e59370b3dfbfd615ff -->
+<!-- review-sha: b1596c455ecab9607328cff919248ac64ec8e46a -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 98bb04a57d63d16182c476eba992b6e36745e730 -->
+<!-- review-sha: fb8441f0a9845d82175eb2b0b07abecef39ce1eb -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 872f3021545550e34336883d2572326729984a7a -->
+<!-- review-sha: 82b7ed1c6eba44abc8849268865c110297486ca9 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: e16c0d2af761b90c44f765ddd820204390d50da9 -->
+<!-- review-sha: f845f35488d242d169c75305eb9f6db674e59b7b -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 2961b3afdaeb5f34b2b295d3d5df43ad0738b348 -->
+<!-- review-sha: fd07681a4603c9e8f874fa1d14c6778201bd11f2 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 0b1e6a8e7a084054f00d051019d66f17119c1b8e -->
+<!-- review-sha: ef9cc6c29ba9c0bbbe5d519f7f20ea762c0338e0 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 634847e417150b750e9f84a800382f5e49122323 -->
+<!-- review-sha: 781cdc2b3985293e7a5f84b867c9ad6509b19548 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 06966c0f8c68bfa90b16f219e4c0b29163d09a2e -->
+<!-- review-sha: d74f3d85866ca4d3597a1ef5426aaa17936212ca -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: e7ca4687d51d25f6893df8efe468b9dcf26f62f8 -->
+<!-- review-sha: bf4275a47f612f9bb050702b5fc6a138f24a815b -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 12e86c785ed79b483ff153823e7b3fc54f1eb97c -->
+<!-- review-sha: 76bb9c03e2c4dae81c6541d52f2f328600752448 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: fdce843e7119a7acbcfff408c3a54bbfe1d87bfa -->
+<!-- review-sha: 85d72cdb97e3d04c84c741219e4935498eb4f7ae -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: a37a53e54af5ad26ba0234b6a80b14ee79ded08f -->
+<!-- review-sha: 57520550fb86fa4746689621c9300ea53072702e -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: fb8441f0a9845d82175eb2b0b07abecef39ce1eb -->
+<!-- review-sha: 0e36d8d6afa5820ecc7dad522bf415ccb1fdcbb8 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 62bd3d8a4870b78f31948f4a753f269f5182e4b2 -->
+<!-- review-sha: 040bb48cbf3dcb35b781100fae3eae8bde0dd6ff -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 944a7bf77e708d81619169bef330a5854ebedcae -->
+<!-- review-sha: ddd1aadf537167b8610825671efce9f33427dee0 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: ddd1aadf537167b8610825671efce9f33427dee0 -->
+<!-- review-sha: e08d875c0ade45893fd34439ab140d6018c15e22 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 62d74d5f154ed6bfb2228d7ab63142597d46d4df -->
+<!-- review-sha: 4e1693a6450c725535360569fe0bfabc387d413d -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: d74f3d85866ca4d3597a1ef5426aaa17936212ca -->
+<!-- review-sha: 46f33ab1f40f340109e537c7b8b1b8dbdd807c75 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: c27502c9ed03ab52f5a6e947f7673bccfae67211 -->
+<!-- review-sha: 4341f4443a285d71ec68f40cbb6e8d3e529c3ed4 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: df18f4f45502c3a2d4635ad0328362dafe0e21d9 -->
+<!-- review-sha: d549e0823b23c5d581708cd3b62f9f0102313b6a -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: ee54701aa550204b5b04e0f6b4cd11add413e58a -->
+<!-- review-sha: fdce843e7119a7acbcfff408c3a54bbfe1d87bfa -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 57520550fb86fa4746689621c9300ea53072702e -->
+<!-- review-sha: 296f401000c864644eba4ddfd3018811fc2c0072 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 5033dd0400cc9c500ebdd68861501ec5b4a1fe9d -->
+<!-- review-sha: 57093d1c8ea3da26d19f6f74f2e1ef47d0f21748 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 344f208378ebff28566252754a640941d7faf50c -->
+<!-- review-sha: 777dbc11ca6296e084baea8729df09720cbf04b0 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 85fb845a8856729473b86c36a969464ede25910a -->
+<!-- review-sha: 726d86030a79ee60e6af30e59370b3dfbfd615ff -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 589ddcccaf4fa7576cb2c56dabc26feb67383914 -->
+<!-- review-sha: e017b8edd1c50bdabfe87085c300b009e7d62bf6 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 296f401000c864644eba4ddfd3018811fc2c0072 -->
+<!-- review-sha: 5d62169fa3bc32d4dc39a3a361a9ff114e59ad08 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: a56887a85859c81f66d199510de5e26557b0c759 -->
+<!-- review-sha: eab1cbb5b501fe37165fd4c79518cd799016a6b6 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 2bf939ea7810386727fcd9051d768c89dd5fdbfa -->
+<!-- review-sha: 944a7bf77e708d81619169bef330a5854ebedcae -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: e2cb0673679889773ef583960b14050ad5881bb6 -->
+<!-- review-sha: 344f208378ebff28566252754a640941d7faf50c -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 06f2ebb84e0d7ffd82c527feb6c4528ad9ab4202 -->
+<!-- review-sha: 98bb04a57d63d16182c476eba992b6e36745e730 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 4e1693a6450c725535360569fe0bfabc387d413d -->
+<!-- review-sha: e53f18469bcd895cf90325e4ddf0432bfee275ea -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 7019c1aeb114c418e1ee4a02997d8dfd5dde915d -->
+<!-- review-sha: 04d7e06749104feffd51fb28a7a383f73e18aef7 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 80e6cf8952005dea2737b85ca3523a7ba292d09e -->
+<!-- review-sha: 3f1ce42c8b6b0afefb93da7a66e8fafa9ab3505b -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 077d866b8325be5803a4986529068942ddb172f8 -->
+<!-- review-sha: 6c43d40ea9517461ece4385f767c7ecc5530f8b5 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 7ef454e62354cc1b7ca86588086d19b0733fed8d -->
+<!-- review-sha: b52dadceacedae285ee774246bc32c6ee1178505 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 85d72cdb97e3d04c84c741219e4935498eb4f7ae -->
+<!-- review-sha: 7f41f0145074c1a5482a0ebb388cf037f6d62bf9 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: df4c1f61d1219f931fe883e8708be9c30ed8e9a6 -->
+<!-- review-sha: 7fa094dc4f2beb2297ea44dcb993cf0a8b5681cf -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: b2802c1304d176c8794abbb978b5f7500af5180a -->
+<!-- review-sha: f8015c3799d44c08e3e9ae12750cd5a66342272c -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 16112fece590f6333d16f84931c8dc14f65cfd9b -->
+<!-- review-sha: 1408ef48f2d10cc7417684fc3b7f08fcfbd8c7f3 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: ff8bd338ce58333e5abf12dbd5e3c3c00ebf9f25 -->
+<!-- review-sha: 9f89cbefdee30148d25852b7dc4f54f15a19f279 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: f606232ca7bb5e1c40380f1abc62d4929ed963ee -->
+<!-- review-sha: 06966c0f8c68bfa90b16f219e4c0b29163d09a2e -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 132547f57ff1a4ae91b08f6deb2848a7eea1ff8b -->
+<!-- review-sha: 04745fa371884fd72197d40122fb607d527995e9 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 4268db739c06b1d1a16d0930092214a119db2545 -->
+<!-- review-sha: ede6d3271913d2402ff9933c255914cb1d77411d -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 4de38ea7625e9f3fc0d417ff43634140f911ca77 -->
+<!-- review-sha: bd6cf046e7aab8da0ad6524e13d91a46f5597b15 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: e0ccb305451f6b88bfd7a9f9d71a6c9597b7a5b3 -->
+<!-- review-sha: 396ddb8fc8880ec4c74f06636c618bae253baf61 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 55c6d3f6cd07598a9528082aacfc90612dadf091 -->
+<!-- review-sha: e2cb0673679889773ef583960b14050ad5881bb6 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 040bb48cbf3dcb35b781100fae3eae8bde0dd6ff -->
+<!-- review-sha: 2961b3afdaeb5f34b2b295d3d5df43ad0738b348 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 527d5bed05967bdfaff847cd87fb2b8523905a26 -->
+<!-- review-sha: cca300b1953be4bf102a0bd5d25c7b8f791da067 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 3f1ce42c8b6b0afefb93da7a66e8fafa9ab3505b -->
+<!-- review-sha: fcfa88edd716dd80a722b8f46c9c6985e8c75d49 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: cf1b4e2e7c32a92ed56e373f0c7a4d702a772db0 -->
+<!-- review-sha: f273aab0cee362a5fa11cfc449dd82b59c541e11 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: bf4275a47f612f9bb050702b5fc6a138f24a815b -->
+<!-- review-sha: 2ac2a77951ef4afa6b0e4c2fd9c1a77683402ba8 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: a07aa68e3840d9a3de82bb8a55a6b294463e8589 -->
+<!-- review-sha: bb6283b65af4264627371a04e5f096204f314e66 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 82b7ed1c6eba44abc8849268865c110297486ca9 -->
+<!-- review-sha: e1790b85f5526fb4341efc623232ed6f62cad49a -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 6569e8c0c6b5d37fed81106b6061fac48c3c2c3e -->
+<!-- review-sha: 14bc4d898c0a8cbcc143431ed2537bba96083c05 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 667ce147cbdd7119b5bcabee3598233bf3815554 -->
+<!-- review-sha: 8fa3d46bdbf64b1e98c4e11a5d04546d33a82634 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: ede6d3271913d2402ff9933c255914cb1d77411d -->
+<!-- review-sha: 6e38bf087ab4faf95e09add19daae90db805ff72 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: ac199e1ba0015b486c6b821f6a891324014cae91 -->
+<!-- review-sha: 80e6cf8952005dea2737b85ca3523a7ba292d09e -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 123047ffac818f20dee610763b5f106507dc7529 -->
+<!-- review-sha: 76f6c09c32253320bac14df865357471f38e48b1 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: e53f18469bcd895cf90325e4ddf0432bfee275ea -->
+<!-- review-sha: 8df4b102725fa175f6a3b1b261b0efde085d0e2a -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: fd0f9a38e8b416a32721203f75cdec3f279eabf5 -->
+<!-- review-sha: bff479f849957918ea3bebe8f6916f78066f3da6 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: e1790b85f5526fb4341efc623232ed6f62cad49a -->
+<!-- review-sha: e16c0d2af761b90c44f765ddd820204390d50da9 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: f6b6725667b38e42c0cb73542a03fbd81b78eac7 -->
+<!-- review-sha: eaf53e0dc78d198599bd341f9b595f47e4b7096f -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 03c98cc08c2155ede5cdd8590960b73781965bef -->
+<!-- review-sha: 0766afb622964f912cb6e53bd6ccf4bd39defd58 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: cefbd718c0e313365efdce37c1a1f749e463beae -->
+<!-- review-sha: 872f3021545550e34336883d2572326729984a7a -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: bd6cf046e7aab8da0ad6524e13d91a46f5597b15 -->
+<!-- review-sha: fd0f9a38e8b416a32721203f75cdec3f279eabf5 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 8b844f1abf8bb75e04eb5d03e1ef8f5d96638f63 -->
+<!-- review-sha: ddbe2ccde70248adfdda42649bdd94701f20f4c5 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: eaf53e0dc78d198599bd341f9b595f47e4b7096f -->
+<!-- review-sha: 12e86c785ed79b483ff153823e7b3fc54f1eb97c -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 9f89cbefdee30148d25852b7dc4f54f15a19f279 -->
+<!-- review-sha: 51475f57807711a64dca104c17ebee31ee6da09f -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 76f6c09c32253320bac14df865357471f38e48b1 -->
+<!-- review-sha: b5428816c59bf69d95a9bc4dab87d94df694b7d1 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 4aa5b4df29348d7e3b2a62700d2bd6386153fcc1 -->
+<!-- review-sha: 937dac6e02166dfd500fe13f9a69d7d123e1bee1 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 9b174de22a76b732ed93acd083d9228d0bea0ef2 -->
+<!-- review-sha: a308592befaa9426bd0ac99333193a9394e32fb2 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 9c2896b50dca06aee7dcfeea9c940e554e5a4681 -->
+<!-- review-sha: 7a44b7a3822898559bdf1ca446f5deb7a3923249 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 7e421d476ec0caf21b221355dcda897fa094384b -->
+<!-- review-sha: 9c2896b50dca06aee7dcfeea9c940e554e5a4681 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: a9b98e3204e845921230bd6255af6f38359c18c2 -->
+<!-- review-sha: a7d9a126004d73a1d93a21fc6c7b9e50e2cee53b -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 9b736656f830f4a3b176e09af1090ec6557415b4 -->
+<!-- review-sha: c930a3270e618449ec15767099f77fa04cde4da2 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 9ac4b8688e33ebf1a3423b48be6527998afe1b7c -->
+<!-- review-sha: ac199e1ba0015b486c6b821f6a891324014cae91 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: f097ff11c3829e15e29b132a651b5bbadd60798f -->
+<!-- review-sha: 515d33a65c1c479ea2735df3a7454f12ae6dcaff -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 4178ad720dc25329fe10c4bab8f9f92d5b76679a -->
+<!-- review-sha: 9b736656f830f4a3b176e09af1090ec6557415b4 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: b4c6faaff192837dc731f9e3a8bc89edc9087b4c -->
+<!-- review-sha: 85fb845a8856729473b86c36a969464ede25910a -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 777dbc11ca6296e084baea8729df09720cbf04b0 -->
+<!-- review-sha: cf524910f424d64bfe83908c6735163c8744c166 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: e9c4ea0912521e7194773ab0bcfdd088ac8653f5 -->
+<!-- review-sha: de96bd65a89a69f256cf7ced99940d098b080ec2 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 744cfca7b90dffb7ee4158350f56651715497bb1 -->
+<!-- review-sha: 090ab416481c53e5025aa80234f0e3345c91a1af -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: a308592befaa9426bd0ac99333193a9394e32fb2 -->
+<!-- review-sha: 091e993f5dc376fec58a56ec5ad8081ef1d0aa04 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: ef9cc6c29ba9c0bbbe5d519f7f20ea762c0338e0 -->
+<!-- review-sha: 2bf939ea7810386727fcd9051d768c89dd5fdbfa -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: f3a42811762849acabbb93c7806349a38cf960c9 -->
+<!-- review-sha: 06f2ebb84e0d7ffd82c527feb6c4528ad9ab4202 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: f845f35488d242d169c75305eb9f6db674e59b7b -->
+<!-- review-sha: 4aa5b4df29348d7e3b2a62700d2bd6386153fcc1 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 781cdc2b3985293e7a5f84b867c9ad6509b19548 -->
+<!-- review-sha: df4c1f61d1219f931fe883e8708be9c30ed8e9a6 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: b1596c455ecab9607328cff919248ac64ec8e46a -->
+<!-- review-sha: 347034988057284416c0615b725f079976be3582 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 191221ff97fb16ca1b6a759a881874051f696502 -->
+<!-- review-sha: 06aa2cfcf9db38442ef9fbd99569a43eef0c1aac -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: c3dd2f97d2ab6f15cc1d82800aa71668a5b41f4b -->
+<!-- review-sha: 79a4888448b8b48a4706c1bb91b88070be2cf23f -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: e180d61e98cec1aa1fea77cee8eac039a28e7af0 -->
+<!-- review-sha: a9b98e3204e845921230bd6255af6f38359c18c2 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 6e38bf087ab4faf95e09add19daae90db805ff72 -->
+<!-- review-sha: 03c98cc08c2155ede5cdd8590960b73781965bef -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 2c096a6f60af4ddee49055a8ec53dc67d788001d -->
+<!-- review-sha: 1cca290b52c02b135ad85803eced299c53c2526c -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 207c63b76149d5a5349659a6c24950ba7d883827 -->
+<!-- review-sha: 414a93df7e817437c434c918cc7599c6d24f8137 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 1cca290b52c02b135ad85803eced299c53c2526c -->
+<!-- review-sha: b67357e5f6843944568451f0e57100daa2784daf -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: cca300b1953be4bf102a0bd5d25c7b8f791da067 -->
+<!-- review-sha: bb92a4d76c0d73f4291c0af930444a2161736eb1 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 06aa2cfcf9db38442ef9fbd99569a43eef0c1aac -->
+<!-- review-sha: 7ef454e62354cc1b7ca86588086d19b0733fed8d -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: a7d9a126004d73a1d93a21fc6c7b9e50e2cee53b -->
+<!-- review-sha: a7788e209d71660eb1bdd3d292e8f3aff3371b40 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 5eecf2f08a0472298ff54058f14d0421904520bc -->
+<!-- review-sha: c559adfc187f3bcd177afd35c9c8390a8d66e9cd -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 3a3c043637e06649ca1c3ce15180087b33aec713 -->
+<!-- review-sha: dc0ee7ca4e79778f58353fb9f3f46f20e4f11010 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: de96bd65a89a69f256cf7ced99940d098b080ec2 -->
+<!-- review-sha: 44baf21beead713c651965723697c9501f2d2b10 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 090ab416481c53e5025aa80234f0e3345c91a1af -->
+<!-- review-sha: a37a53e54af5ad26ba0234b6a80b14ee79ded08f -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 1d085b0d055ce31ee582ed08fc6c46cc281fd9e1 -->
+<!-- review-sha: 9b174de22a76b732ed93acd083d9228d0bea0ef2 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 56674c62b19ebc48961548d50c43ca4f97440b52 -->
+<!-- review-sha: 1d085b0d055ce31ee582ed08fc6c46cc281fd9e1 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 6b83df0bf73c79e7b53992d6b29a6b277d03699f -->
+<!-- review-sha: 02c39a83b3cf93c74f9fb01b2de6267a827be391 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,0 +1,15 @@
+# clud-bug review — PR #150
+<!-- protocol-version: 0.1.0 -->
+<!-- written-by: clud-bug[bot] -->
+<!-- review-sha: e0ccb305451f6b88bfd7a9f9d71a6c9597b7a5b3 -->
+
+**Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
+
+**Skills cited:**
+- _(none — see summary above)_
+
+**Findings:**
+
+---
+
+[Link to PR](https://github.com/thrillmade/clud-bug/pull/150)

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: a64cacd7523580b4a67548a33dc0aae3de2b8384 -->
+<!-- review-sha: 191221ff97fb16ca1b6a759a881874051f696502 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 6c43d40ea9517461ece4385f767c7ecc5530f8b5 -->
+<!-- review-sha: 60b6f9a75a7430f5586a8dd882d759510d5e17f0 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 35b7d21e962981f172f15cae450469e1d4c60d6a -->
+<!-- review-sha: e7ca4687d51d25f6893df8efe468b9dcf26f62f8 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: d549e0823b23c5d581708cd3b62f9f0102313b6a -->
+<!-- review-sha: cf1b4e2e7c32a92ed56e373f0c7a4d702a772db0 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: c559adfc187f3bcd177afd35c9c8390a8d66e9cd -->
+<!-- review-sha: 6569e8c0c6b5d37fed81106b6061fac48c3c2c3e -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 7a44b7a3822898559bdf1ca446f5deb7a3923249 -->
+<!-- review-sha: 0b1e6a8e7a084054f00d051019d66f17119c1b8e -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 1ba042a571504f97ec1fe0e5fa1c145f050a64e9 -->
+<!-- review-sha: ce7757db4fd4b1639e0604912e21cd9891b638ee -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: bb92a4d76c0d73f4291c0af930444a2161736eb1 -->
+<!-- review-sha: ff8bd338ce58333e5abf12dbd5e3c3c00ebf9f25 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 0cf13c4875c792f085f568d88175b10d12d05685 -->
+<!-- review-sha: 6b83df0bf73c79e7b53992d6b29a6b277d03699f -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: b5428816c59bf69d95a9bc4dab87d94df694b7d1 -->
+<!-- review-sha: 744cfca7b90dffb7ee4158350f56651715497bb1 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: fd07681a4603c9e8f874fa1d14c6778201bd11f2 -->
+<!-- review-sha: d50713033883fa88ea38b593d1eea1593ccadff2 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: bb6283b65af4264627371a04e5f096204f314e66 -->
+<!-- review-sha: 73b719f9461c55249a7cdc0b55f04222e23cc446 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 04745fa371884fd72197d40122fb607d527995e9 -->
+<!-- review-sha: a64cacd7523580b4a67548a33dc0aae3de2b8384 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 4443d53c9d7a9c7279f3ef698feda80a12af2e3d -->
+<!-- review-sha: f3a42811762849acabbb93c7806349a38cf960c9 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: a82c22121c686931b2e38f3973b2afdde8469ddd -->
+<!-- review-sha: 634847e417150b750e9f84a800382f5e49122323 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: c34871e0145b660845525b878b2ee93ef5d88f96 -->
+<!-- review-sha: 35b7d21e962981f172f15cae450469e1d4c60d6a -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 5532683428bdb0f3bf2884abd9cf6e600db23366 -->
+<!-- review-sha: 207c63b76149d5a5349659a6c24950ba7d883827 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: cf524910f424d64bfe83908c6735163c8744c166 -->
+<!-- review-sha: 0edf46c1f8f27899cf39de1c010c851ed3242ad4 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: a30d881a6d50ec7f2a3416e291fca11758a4c554 -->
+<!-- review-sha: 1fb0b94e501c4197d3974d51b731b7e0e1009e7d -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 2ac2a77951ef4afa6b0e4c2fd9c1a77683402ba8 -->
+<!-- review-sha: 4268db739c06b1d1a16d0930092214a119db2545 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 9c80b84d15415f50c6b06e87722a11e24481c23f -->
+<!-- review-sha: 56674c62b19ebc48961548d50c43ca4f97440b52 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 60b6f9a75a7430f5586a8dd882d759510d5e17f0 -->
+<!-- review-sha: 4178ad720dc25329fe10c4bab8f9f92d5b76679a -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: ce7757db4fd4b1639e0604912e21cd9891b638ee -->
+<!-- review-sha: 1d6f4e9489a0a1f0552f9a7825a4573ab828b981 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: d50713033883fa88ea38b593d1eea1593ccadff2 -->
+<!-- review-sha: da701b48280be199e5236a7abb9fdb3ddd0e8ad0 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: c7f4712bf132722a2cdfd156b5ad27d26255769c -->
+<!-- review-sha: 5033dd0400cc9c500ebdd68861501ec5b4a1fe9d -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 4c6f4851a1814971f298642b5cc8ace34e214803 -->
+<!-- review-sha: ee590c254e9b7f3659ab25e484c510df70b8294a -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 02c39a83b3cf93c74f9fb01b2de6267a827be391 -->
+<!-- review-sha: e75d731ae393c3d81afd9193247433581edcddcd -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: da701b48280be199e5236a7abb9fdb3ddd0e8ad0 -->
+<!-- review-sha: 5e975dc999f1a332dca0a6cda79e5164495204c8 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 1fa9fc036006837ddf4e4b856bd566f712e8d1ec -->
+<!-- review-sha: 62d74d5f154ed6bfb2228d7ab63142597d46d4df -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: b52dadceacedae285ee774246bc32c6ee1178505 -->
+<!-- review-sha: b2802c1304d176c8794abbb978b5f7500af5180a -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 62cb873904672270740b1f2e2a22e92dcd20c32a -->
+<!-- review-sha: 7e421d476ec0caf21b221355dcda897fa094384b -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: f273aab0cee362a5fa11cfc449dd82b59c541e11 -->
+<!-- review-sha: a093d176ce42d82960770d2218d4e26f07f0b113 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: dc0ee7ca4e79778f58353fb9f3f46f20e4f11010 -->
+<!-- review-sha: f6b6725667b38e42c0cb73542a03fbd81b78eac7 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 8fa3d46bdbf64b1e98c4e11a5d04546d33a82634 -->
+<!-- review-sha: 132547f57ff1a4ae91b08f6deb2848a7eea1ff8b -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 0ad720cb75704d56288cba6481059a1c1f04fe37 -->
+<!-- review-sha: d29158c6d83dfb91a886f67641176316e1839594 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 44baf21beead713c651965723697c9501f2d2b10 -->
+<!-- review-sha: 26d2d8423bdfe72e300b5725fa2ccd8a04a7c2e7 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: a7788e209d71660eb1bdd3d292e8f3aff3371b40 -->
+<!-- review-sha: cf88d7e7b9192428522562bc576666ff65944960 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 76bb9c03e2c4dae81c6541d52f2f328600752448 -->
+<!-- review-sha: b3b492919d56f812878148b2a1b9375c845daf64 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 04d7e06749104feffd51fb28a7a383f73e18aef7 -->
+<!-- review-sha: 123047ffac818f20dee610763b5f106507dc7529 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 0edf46c1f8f27899cf39de1c010c851ed3242ad4 -->
+<!-- review-sha: c34871e0145b660845525b878b2ee93ef5d88f96 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: b3b492919d56f812878148b2a1b9375c845daf64 -->
+<!-- review-sha: 62bd3d8a4870b78f31948f4a753f269f5182e4b2 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 5e975dc999f1a332dca0a6cda79e5164495204c8 -->
+<!-- review-sha: 1fa9fc036006837ddf4e4b856bd566f712e8d1ec -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: ddbe2ccde70248adfdda42649bdd94701f20f4c5 -->
+<!-- review-sha: 589ddcccaf4fa7576cb2c56dabc26feb67383914 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: b67357e5f6843944568451f0e57100daa2784daf -->
+<!-- review-sha: 077d866b8325be5803a4986529068942ddb172f8 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: e017b8edd1c50bdabfe87085c300b009e7d62bf6 -->
+<!-- review-sha: a56887a85859c81f66d199510de5e26557b0c759 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: ba6aa81918f97fd8da7f736c02471350a166c408 -->
+<!-- review-sha: f097ff11c3829e15e29b132a651b5bbadd60798f -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: ee590c254e9b7f3659ab25e484c510df70b8294a -->
+<!-- review-sha: 0ad720cb75704d56288cba6481059a1c1f04fe37 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 4341f4443a285d71ec68f40cbb6e8d3e529c3ed4 -->
+<!-- review-sha: a07aa68e3840d9a3de82bb8a55a6b294463e8589 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 5cbfff919bd4701402b73a44da049bc60e526538 -->
+<!-- review-sha: cefbd718c0e313365efdce37c1a1f749e463beae -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 

--- a/docs/reviews/PR-150.md
+++ b/docs/reviews/PR-150.md
@@ -1,7 +1,7 @@
 # clud-bug review — PR #150
 <!-- protocol-version: 0.1.0 -->
 <!-- written-by: clud-bug[bot] -->
-<!-- review-sha: 396ddb8fc8880ec4c74f06636c618bae253baf61 -->
+<!-- review-sha: c27502c9ed03ab52f5a6e947f7673bccfae67211 -->
 
 **Summary:** 0 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open
 


### PR DESCRIPTION
## Summary

Migrates this repo to the v1.1.0 distribution-lock pattern (per master plan §Architectural Decisions 2026-06-05).

- Replaces the curl-install block in `check-doc-links.yml` + `regen-timeline.yml` with `uses: thrillmade/setup-logmind@v1.0.1` (immutable pin).
- Rewrites `logmind-self-update.yml` to the v8 template — reads installed version from the action ref, decouples pure version-pin bumps (now Dependabot's job) from template-body releases (this workflow's job).
- Adds a `thrillmade` group to the existing `github-actions` dependabot ecosystem entry. Bundles all `thrillmade/*` action bumps into one PR per release.

Static-pin + Dependabot replaces the curl-pinned-version pattern. Industry-standard Go-CLI distribution.

**Last manual setup-logmind version touch on this repo.** Dependabot owns the pin from here.

## Test plan

- [x] `check-doc-links` workflow — runs `logmind check-links` via the action
- [x] `regen-timeline` workflow — runs `logmind timeline` + `logmind file-structure` via the action
- [x] `logmind-self-update` workflow — version detection reads `thrillmade/setup-logmind@vX.Y.Z` ref
- [x] Dependabot `thrillmade` group preserves the existing `minor-and-patch` group

[skip-logmind]: bot-flavored migration commit — no decision file required.