### PR TITLE
[skip-logmind] fix(setup-logmind): correct broken @v1.0.1 pin → @v1.0.0

### DIFF
--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: thrillmade/setup-logmind@v1.0.1
+      - uses: thrillmade/setup-logmind@v1.0.0
 
       - name: Check markdown link integrity
         run: logmind check-links

--- a/.github/workflows/logmind-self-update.yml
+++ b/.github/workflows/logmind-self-update.yml
@@ -138,7 +138,7 @@ jobs:
       # `logmind init` (the refresh) runs against the same binary
       # version consumer repos will see after this workflow lands its
       # PR. The action's version tracks the LATEST step output.
-      - uses: thrillmade/setup-logmind@v1.0.1
+      - uses: thrillmade/setup-logmind@v1.0.0
         if: steps.compare.outputs.skip == 'false'
         with:
           version: ${{ steps.compare.outputs.latest }}

--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -57,7 +57,7 @@ jobs:
           # Falls through to GITHUB_TOKEN when absent (still allows checkout).
           token: ${{ secrets.LOGMIND_AUTO_REGEN_PAT || secrets.GITHUB_TOKEN }}
 
-      - uses: thrillmade/setup-logmind@v1.0.1
+      - uses: thrillmade/setup-logmind@v1.0.0
 
       - name: Regenerate derived docs
         run: |


### PR DESCRIPTION
Fixes CI on all workflows. Migration sweep yesterday hardcoded @v1.0.1 which doesn't exist; only v1.0.0 shipped. One-line fix in 3 workflows.