### PR TITLE
feat: dogfood clud-bug on itself (install own review workflow)

### DIFF
--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: thrillmade/setup-logmind@v1.0.0
+      - uses: thrillmade/setup-logmind@v1.0.1
 
       - name: Check markdown link integrity
         run: logmind check-links

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -1,0 +1,737 @@
+# clud-bug-template-version: v12
+name: Clud Bug 🐛 Crawls Your Code
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+# v0.6.25: workflow-level concurrency — see workflow.yml.tmpl.
+concurrency:
+  group: clud-bug-review-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Pre-flight (v0.6.14 / 0.0.W + v0.6.15 / 0.0.R) — see workflow.yml.tmpl.
+  paths-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      is_workflow_only: ${{ steps.classify.outputs.is_workflow_only }}
+      model: ${{ steps.classify.outputs.model }}
+      max_turns: ${{ steps.classify.outputs.max_turns }}
+      # v0.6.25 / §5.5 Layer 1.5 (calibration) — see workflow.yml.tmpl.
+      turns_estimated: ${{ steps.classify.outputs.turns_estimated }}
+      files_count: ${{ steps.classify.outputs.files_count }}
+      lines_added: ${{ steps.classify.outputs.lines_added }}
+      lines_deleted: ${{ steps.classify.outputs.lines_deleted }}
+      threads_count: ${{ steps.classify.outputs.threads_count }}
+    steps:
+      - name: Classify PR diff
+        id: classify
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          CHANGED=$(gh pr diff "$PR_NUMBER" -R "$REPO" --name-only)
+          MODEL=claude-sonnet-4-6
+          if [ -z "$CHANGED" ]; then
+            # v0.6.23 / §5: max_turns must always be emitted — see workflow.yml.tmpl for design notes.
+            # Grouped redirect (v0.6.24) silences the SC2129 style warning.
+            {
+              echo "is_workflow_only=false"
+              echo "model=$MODEL"
+              echo "max_turns=15"
+              echo "turns_estimated=0"
+              echo "files_count=0"
+              echo "lines_added=0"
+              echo "lines_deleted=0"
+              echo "threads_count=0"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # v0.6.26 / 0.0.W² — see workflow.yml.tmpl for design notes.
+          ALL_IN_ALLOWLIST=true
+          HAS_WORKFLOW_CHANGE=false
+          while IFS= read -r f; do
+            case "$f" in
+              .github/workflows/clud-bug-*.yml) HAS_WORKFLOW_CHANGE=true ;;
+              .github/actions/strict-mode-gate/*) HAS_WORKFLOW_CHANGE=true ;;
+              AGENTS.md) ;;
+              .cursorrules|.clinerules|.windsurfrules|.continuerules) ;;
+              .github/copilot-instructions.md) ;;
+              .claude/skills/.clud-bug.json) ;;
+              .claude/skills/critical-issues-only/SKILL.md) ;;
+              .claude/skills/evidence-based-review/SKILL.md) ;;
+              .claude/skills/respect-existing-conventions/SKILL.md) ;;
+              docs/timeline.md|docs/file-structure.md|docs/decisions.md) ;;
+              docs/decisions-branches/*.md) ;;
+              *) ALL_IN_ALLOWLIST=false; break ;;
+            esac
+          done <<< "$CHANGED"
+          IS_WORKFLOW_ONLY=false
+          if [ "$ALL_IN_ALLOWLIST" = "true" ] && [ "$HAS_WORKFLOW_CHANGE" = "true" ]; then
+            IS_WORKFLOW_ONLY=true
+          fi
+          echo "is_workflow_only=$IS_WORKFLOW_ONLY" >> "$GITHUB_OUTPUT"
+          if [ "$IS_WORKFLOW_ONLY" = "true" ]; then
+            echo "::notice title=Clud Bug 🐛::Skipping LLM review — clud-bug update output."
+            echo "model=$MODEL" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Triviality (0.0.R): dep-bumping bot OR small dep-manifest diff.
+          IS_TRIVIAL=false
+          case "$PR_AUTHOR" in
+            dependabot\[bot\]|renovate\[bot\]) IS_TRIVIAL=true ;;
+          esac
+          if [ "$IS_TRIVIAL" = "false" ]; then
+            DIFF_SIZE=$(gh pr diff "$PR_NUMBER" -R "$REPO" | wc -c | tr -d ' ')
+            if [ "$DIFF_SIZE" -lt 2048 ]; then
+              ALL_TRIVIAL=true
+              while IFS= read -r f; do
+                case "$f" in
+                  package.json|*/package.json|package-lock.json|*/package-lock.json) ;;
+                  pnpm-lock.yaml|*/pnpm-lock.yaml|yarn.lock|*/yarn.lock) ;;
+                  requirements*.txt|*/requirements*.txt) ;;
+                  pyproject.toml|*/pyproject.toml|poetry.lock|*/poetry.lock|uv.lock|*/uv.lock) ;;
+                  Gemfile|*/Gemfile|Gemfile.lock|*/Gemfile.lock) ;;
+                  go.mod|*/go.mod|go.sum|*/go.sum) ;;
+                  Cargo.toml|*/Cargo.toml|Cargo.lock|*/Cargo.lock) ;;
+                  *) ALL_TRIVIAL=false; break ;;
+                esac
+              done <<< "$CHANGED"
+              [ "$ALL_TRIVIAL" = "true" ] && IS_TRIVIAL=true
+            fi
+          fi
+          if [ "$IS_TRIVIAL" = "true" ]; then
+            MODEL=claude-haiku-4-5-20251001
+            echo "::notice title=Clud Bug 🐛::Trivial PR — routing to Haiku."
+          fi
+          echo "model=$MODEL" >> "$GITHUB_OUTPUT"
+
+          # Smart budget (v0.6.25 / §5.5 Layer 1) — see workflow.yml.tmpl for design notes + formula.
+          FILE_COUNT=$(echo "$CHANGED" | wc -l | tr -d ' ')
+          THREAD_COUNT=$(gh api graphql -f query='{repository(owner:"'"$(echo "$REPO" | cut -d/ -f1)"'",name:"'"$(echo "$REPO" | cut -d/ -f2)"'"){pullRequest(number:'"$PR_NUMBER"'){reviewThreads(first:50){nodes{isResolved comments(first:1){nodes{author{login}}}}}}}}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and (.comments.nodes[0].author.login == "claude" or .comments.nodes[0].author.login == "claude[bot]"))] | length' 2>/dev/null || echo 0)
+          THREAD_COUNT=${THREAD_COUNT:-0}
+
+          if [ "$IS_TRIVIAL" = "true" ]; then
+            MAX_TURNS=10
+            TURNS_ESTIMATED=10
+            LINES_ADDED=0
+            LINES_DELETED=0
+            echo "::notice title=Clud Bug 🐛::Trivial (Haiku) budget: max_turns=10."
+          else
+            FILES_JSON=$(gh pr view "$PR_NUMBER" -R "$REPO" --json files --jq '.files' 2>/dev/null || echo '[]')
+            LINES_ADDED=$(echo "$FILES_JSON" | jq '[.[].additions] | add // 0' 2>/dev/null || echo 0)
+            LINES_DELETED=$(echo "$FILES_JSON" | jq '[.[].deletions] | add // 0' 2>/dev/null || echo 0)
+            LINES_ADDED=${LINES_ADDED:-0}
+            LINES_DELETED=${LINES_DELETED:-0}
+
+            # jq implements the §5.5 Layer 1 formula — see workflow.yml.tmpl.
+            TURNS_ESTIMATED=$(echo "$FILES_JSON" | jq --argjson threads "$THREAD_COUNT" '
+              def per_line(path):
+                if (path | test("\\.(test|spec)\\.|__tests__|^tests?/")) then 0.01
+                elif (path | test("\\.(md|txt|rst|adoc|mdx)$")) then 0.00666667
+                elif (path | test("\\.(yml|yaml|toml|json|cfg|ini|conf|tmpl)$")) then 0.01
+                elif (path | test("\\.(ts|tsx|py|js|jsx|mjs|cjs|go|rs|java|kt|rb|php|cs|c|cpp|h|hpp|swift|scala)$")) then 0.02
+                else 0.0125 end;
+              map(
+                select(.path != "docs/timeline.md"
+                       and .path != "docs/file-structure.md"
+                       and .path != "docs/decisions.md")
+                | (.additions) as $add | (.deletions) as $del
+                | (if $add < $del then $add else $del end) as $mod
+                | ($add - $mod) as $pa | ($del - $mod) as $pd
+                | per_line(.path) as $tw
+                | 0.3 + ($pa * $tw) + ($mod * 1.5 * $tw) + ($pd * 0.1 * $tw)
+              ) | (add // 0) + 10 + ($threads * 1.5) | (. + 0.9999999) | floor
+            ' 2>/dev/null || echo 15)
+            TURNS_ESTIMATED=${TURNS_ESTIMATED:-15}
+            MAX_TURNS=$(( (TURNS_ESTIMATED * 12 + 9) / 10 ))
+            [ "$MAX_TURNS" -lt 15 ] && MAX_TURNS=15
+            [ "$MAX_TURNS" -gt 60 ] && MAX_TURNS=60
+            echo "::notice title=Clud Bug 🐛::Smart budget: estimated $TURNS_ESTIMATED turns → max_turns=$MAX_TURNS ($FILE_COUNT files, +$LINES_ADDED/-$LINES_DELETED lines, $THREAD_COUNT prior threads)."
+          fi
+          {
+            echo "max_turns=$MAX_TURNS"
+            echo "turns_estimated=$TURNS_ESTIMATED"
+            echo "files_count=$FILE_COUNT"
+            echo "lines_added=$LINES_ADDED"
+            echo "lines_deleted=$LINES_DELETED"
+            echo "threads_count=$THREAD_COUNT"
+          } >> "$GITHUB_OUTPUT"
+
+  clud-bug-review:
+    needs: paths-check
+    if: needs.paths-check.outputs.is_workflow_only != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      # checks: write — composite emits per-skill check-runs (BB.3).
+      checks: write
+      # v0.6.24: `actions: read` (added in v0.6.23) backed out — broke
+      # `pull_request` trigger firing on private consumer repos. See
+      # workflow.yml.tmpl for the diagnosis.
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # strict-mode gate reads base ref's manifest
+
+      # Three-way guard — see workflow.yml.tmpl for full design notes.
+      - name: Guard — require ANTHROPIC_API_KEY
+        id: guard
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then echo "skip=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          IS_FORK=false; [ "$HEAD_REPO" != "$BASE_REPO" ] && IS_FORK=true
+          IS_BOT=false; case "$PR_AUTHOR" in *\[bot\]) IS_BOT=true ;; esac
+          if $IS_FORK || $IS_BOT; then
+            REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
+            EXISTING=$(gh api "repos/${BASE_REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
+              --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("## 🐛 Clud Bug skipped")))] | length')
+            if [ "${EXISTING:-0}" = "0" ]; then
+              BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
+              gh pr comment "$PR_NUMBER" --body "$BODY" || true
+            fi
+            echo "::warning title=Clud Bug 🐛::Skipped — $REASON cannot access repository secrets."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::error title=Clud Bug 🐛::ANTHROPIC_API_KEY secret is not set on this repository."
+          echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
+          exit 1
+
+      - uses: anthropics/claude-code-action@v1.0.133
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          # HEAD_SHA (v0.6.10+) — see workflow.yml.tmpl for design notes.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Per-section byte budgets — see workflow.yml.tmpl for design notes.
+          # 2026-06-08: bumped MAX_DIFF_BYTES 80000 → 5000000 (5MB). CEO
+          # directive: "a large diff should NEVER be a blocker or guard."
+          # Silent truncation at 80KB led to half-reviews on real PRs.
+          # Companion fix in clud-bug-app/lib/orchestrator.ts (no more
+          # "diff too large" skip). Source-of-truth fix needs to ship in
+          # npm clud-bug v0.6.35 → workflow.yml.tmpl:404.
+          MAX_DIFF_BYTES: '5000000'
+          MAX_COMMENT_BYTES: '20000'
+          MAX_SKILL_BYTES: '4000'
+          # Thinking-budget cap (v0.6.8) — see workflow.yml.tmpl for design notes.
+          MAX_THINKING_TOKENS: '8000'
+          # Stable prefix → CLI auto-cached system layer (10% cost on hits).
+          # See workflow.yml.tmpl for design notes.
+          APPEND_SYSTEM_PROMPT: |
+            This project is "clud-bug" — the open-source npm package that powers AI PR review. CLI + workflow templates + skill catalog. Node.js + Vitest. Self-review IS the dogfood loop.
+
+            Review this pull request for critical issues only. Focus on:
+            - Bugs, logic errors, or incorrect behaviour
+            - Security vulnerabilities
+            - Performance problems
+            - Broken or missing test coverage for new code
+            - TypeScript type safety issues (unsafe casts, missing types, incorrect generics)
+            - Incorrect ESM/CJS module usage
+            - Improper async/await or Promise handling (unhandled rejections, missing awaits)
+            - Incorrect use of common Node.js patterns
+
+
+            Skip style suggestions, minor naming issues, or anything that
+            doesn't affect correctness, security, or performance.
+
+            Section budgets (v0.6.4+):
+            Cap fetched content with `head -c` to control input cost. Workflow
+            exposes MAX_DIFF_BYTES / MAX_COMMENT_BYTES / MAX_SKILL_BYTES. The
+            cached system prefix is free at 10%; per-PR fetches are not.
+
+              - PR diff (incremental on fix-push — v0.6.10+):
+                On a re-review (not first pass), fetch only the delta between
+                your prior pass and HEAD instead of the full PR. The handshake
+                state lives in your PRIOR SUMMARY COMMENT as an HTML marker:
+                `<!-- last-reviewed-sha: <sha> -->`.
+
+                Identifying the PRIOR SUMMARY (v0.6.22+ identity note):
+                From v0.6.22 (0.0.O) onward the summary is posted by a workflow
+                post-step under the `github-actions[bot]` identity, not
+                claude[bot]. Inline review threads are still claude[bot] (the
+                MCP tool routes through claude-code-action). Beware: the
+                in-progress `Claude Code is working…` comment claude-code-action
+                posts BEFORE this prompt runs is claude[bot]-authored but is NOT
+                your prior summary (no marker). Anchor on the H2 line
+                `## 🐛 Clud Bug review` — same anchor strict-mode uses.
+
+                Detection in three steps:
+
+                  1. Fetch github-actions[bot] comments newest-first:
+                     `gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$PR_NUMBER/comments?per_page=100&sort=created&direction=desc"`
+                     Walk them in order; filter to author `github-actions[bot]`,
+                     and find the FIRST whose body starts with
+                     `## 🐛 Clud Bug review`. THAT is your prior summary. In
+                     its body, look for `last-reviewed-sha: <sha>`. (Pre-v0.6.22 summaries are claude[bot]-authored — if you find a recent claude[bot] comment with the H2 anchor and no newer github-actions[bot] match, treat it as the prior summary.)
+
+                  2. If a SHA was found, verify it's still in HEAD's ancestry:
+                     `git merge-base --is-ancestor <prior_sha> $HEAD_SHA`
+                     (exit 0 = yes, ancestry intact; non-zero = rebased/force-pushed).
+
+                  3. Branch:
+                       - Marker present AND ancestor intact (well-behaved fix-push):
+                         `git diff <prior_sha>..$HEAD_SHA | head -c "$MAX_DIFF_BYTES"`
+                       - Marker missing OR not an ancestor (first review or rebase):
+                         `gh pr diff "$PR_NUMBER" | head -c "$MAX_DIFF_BYTES"`
+
+                Default cap is 80,000 bytes — covers ~95% of real PRs unbruised.
+                If output looks truncated mid-line, request the omitted hunks via
+                `gh pr diff "$PR_NUMBER" --name-only` + a targeted re-fetch.
+
+                Span check: if a delta-finding might affect callers outside the
+                delta, do a one-time full `gh pr diff` before flagging — the
+                incremental view is for fast re-confirmation, not blind trust.
+
+              - Skill files: `head -c "$MAX_SKILL_BYTES" .claude/skills/<name>/SKILL.md`
+                per file (default 4,000 bytes). Baseline skills fit easily;
+                bloated user-added skills get truncated.
+
+              - PR comments: `gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$PR_NUMBER/comments?per_page=20" --jq '.[] | select(.user.login != "claude[bot]" and .user.login != "github-actions[bot]")' | head -c "$MAX_COMMENT_BYTES"`
+                (default 20,000 bytes, 20 most-recent). Skips your own prior
+                comments — the FIX-PUSH FLOW handles those via reviewThreads
+                GraphQL instead.
+
+            Tee-hint on cap fire (v0.6.18, RTK-inspired):
+            When ANY `head -c "$MAX_*"` cap fires (last line cut mid-token, or
+            `wc -c` on the captured output equals the cap exactly), you MUST do
+            two things, in order:
+
+              1. Attempt ONE targeted re-fetch with double the cap on the specific
+                 truncated section. Example for diff: `gh pr diff "$PR_NUMBER" |
+                 head -c $((MAX_DIFF_BYTES * 2))`. For skills: re-fetch the
+                 specific `.claude/skills/<name>/SKILL.md` that hit the cap with
+                 `head -c $((MAX_SKILL_BYTES * 2))` — name the file. For
+                 comments: re-fetch with `per_page=40` AND `head -c
+                 $((MAX_COMMENT_BYTES * 2))` — doubling per_page alone is wasted
+                 work when the original truncation was byte-bound.
+
+              2. Add a `### Diagnostics` block above the Skills-referenced
+                 footer (the SHA marker still goes last on its own line —
+                 Diagnostics is not the last thing in the comment). Each line
+                 names a cap that fired, the section affected, and outcome
+                 ("recovered with 2x cap", "still truncated", "finding deferred").
+
+            Producer-side half of RTK's `force_tee_tail_hint`: never elide
+            without naming what was elided. If re-fetch still leaves you unable
+            to review safely, say so plainly instead of speculating.
+
+            Skills carry authority. Scan loaded skills in .claude/skills/ before
+            flagging any finding; if one applies, reference it by name (e.g.
+            "[evidence-based-review]: claim isn't anchored to a line"). Generic
+            advice contradicting a project skill is wrong by definition.
+
+            Skill routing — shared vs dedicated:
+            Each SKILL.md frontmatter (first `---`-delimited block) has a
+            `review_mode:` field:
+              - `shared` — bug-finding / convention / evidence. Findings bundle
+                into the standard "Critical findings" / "Minor findings" sections.
+              - `dedicated` — domain-specific (brand voice, compliance,
+                API-contract, test-discipline). Each gets its own H3 section.
+              - Missing → treat as `shared`.
+
+            Skill applies_to (v0.6.21 / 0.0.K):
+            Frontmatter may also have `applies_to:` with `paths:` (glob list)
+            and/or `extensions:` (extension list). Scan each skill's frontmatter
+            first (cheap — just the `---` block). If applies_to is present and
+            the PR's changed files (from `gh pr diff --name-only`) match NONE
+            of the declared paths or extensions, SKIP that skill's body — don't
+            read it, don't reference it. Skills without applies_to load
+            unconditionally (back-compat). Net effect: a UI-scoped skill stays
+            unread on a backend-only PR.
+
+            Read each applicable body capped: `head -c "$MAX_SKILL_BYTES" .claude/skills/<name>/SKILL.md`
+
+            At review end, append a single-line footer:
+              Skills referenced: [skill-name-1, skill-name-2, ...]
+            "[none]" with reason if no installed skill applied.
+
+            Output-token budget (v0.6.16 / 0.0.X):
+            Keep total output under ~600 tokens. Per finding:
+              - One-sentence claim
+              - <details>Reasoning</details> ≤ 80 words
+              - No code quotes > 2 lines
+              - Omit reasoning that doesn't change the verdict
+            Not a hard cap (SDK doesn't expose max_tokens); brevity compounds
+            across the org on every review.
+
+            Turn budget self-rationing (v0.6.25 / §5.5 Layer 2):
+            You are run with a finite `--max-turns` cap. The exact value, plus
+            the pre-flight estimate for this PR, lands in the per-PR prompt
+            section below as `max_turns=N, estimated=M, files=F, +A/-D lines, threads=T`.
+            Treat that as your budget, not a ceiling to test.
+
+            Rules:
+              - Reserve the LAST 5 turns for structured-output emit. It is
+                non-skippable; if you run out before emitting, the workflow
+                falls back to a synthetic summary scraped from your inline
+                findings (v0.6.26+ Layer 6) — strictly worse than a real one.
+              - Rough rates: ~1 turn per 50 lines of code, ~1 turn per 150 lines
+                of docs, ~1 turn per 100 lines of tests or config. Each prior
+                unresolved thread is ~1.5 turns to walk + decide.
+              - Every line of the diff MUST be in your scan. Never silently skip
+                a file. If you must shorten coverage to fit budget, switch from
+                deep-dive analysis to one-sentence per-file verdicts — but every
+                file gets a verdict, even if it's "no issues found".
+              - If you're falling behind pace (files_reviewed/files_total
+                materially less than turns_used/max_turns), broaden+shallow over
+                deep+narrow. Audit visibility lives in `per_skill_scan` — list
+                every file's verdict so a maintainer can verify nothing was
+                skipped.
+
+            Mid-review self-check-in (v0.6.27 / §5.5 Layer 3):
+            After every 5 tool_uses, write a single-line budget heartbeat as a
+            free-text "thinking" message (not a tool call — these don't cost a
+            turn) of the form:
+
+              [budget] files_reviewed=X/N, turns_used=Y/M, pace=ok|behind
+
+            Where:
+              - X / N is the count of files you've meaningfully looked at so far
+                over the total in this PR's diff.
+              - Y / M is your current turn count over max_turns.
+              - pace = "ok" when X / N >= Y / (M - 5). The denominator subtracts the
+                5-turn emit reservation: over the (M - 5) turns available for file
+                review, your file-coverage rate must match where you actually are
+                in the budget. (Don't subtract from Y — that would be saying "I've
+                used Y minus 5 turns" which double-counts the reservation.)
+                pace = "behind" otherwise.
+
+            When pace = "behind", immediately pivot strategy:
+              1. Stop deep-dive analysis on the current file.
+              2. Switch to one-sentence verdicts for every remaining file.
+              3. Keep going through the whole diff — silent skipping is
+                 non-negotiable. Cover everything, even if some files only get
+                 "no issues found in this file" as their verdict.
+
+            The heartbeat serves two purposes: (a) forces internal pacing — you
+            can't drift past budget without noticing; (b) lands in the action's
+            streaming output for post-hoc calibration of the per-line cost
+            coefficients used by paths-check's Layer 1 estimator.
+
+            Incremental-diff handshake (v0.6.10+) — emit the SHA marker:
+            At the very end of the summary (after the Skills-referenced footer,
+            on its own line), append:
+
+              <!-- last-reviewed-sha: $HEAD_SHA -->
+
+            (`$HEAD_SHA` from workflow env; literal value, not the variable
+            name.) Silent to humans (HTML comment), load-bearing for cost: every
+            subsequent fix-push re-fetches only the delta since this SHA. Omit
+            it and the next review falls back to full `gh pr diff`.
+
+            Strict-mode header (opt-in): if .claude/skills/.clud-bug.json has
+            `{ "strictMode": true }`, set the `status_header` schema field
+            to signal verdict:
+              - any critical issue flagged → `status_header: "critical findings"`
+                (renderer emits `## 🐛 Clud Bug review — critical findings`)
+              - otherwise → `status_header: "clean"` (renderer emits
+                `## 🐛 Clud Bug review — clean`)
+            The strict-mode gate post-step greps for "critical findings" and
+            fails the check.
+
+            If strictMode is unset or absent, set `status_header: "bare"` —
+            the renderer emits the bare `## 🐛 Clud Bug review` (no suffix),
+            matching the v0.6.21- visible behaviour for non-strict-mode repos.
+
+            Tone: conversational, concise field-naturalist voice (you are Clud
+            Bug examining specimens of code) — never at the cost of clarity,
+            evidence, or critical-issues-only discipline. Let precision speak.
+
+            Your review lives in TWO surfaces, in this order:
+
+            1. INLINE REVIEW THREADS — one per finding, anchored to
+               file:line via mcp__github_inline_comment__create_inline_comment
+               (critical, minor, AND per-skill findings). Body is the finding
+               text itself (no leading "- " bullet). Creates resolvable
+               conversations that branch protection's
+               required_review_thread_resolution rule gates on. Without inline
+               threads, the gate has nothing to gate on.
+
+               Pass `confirmed: true` on every call — these are final review
+               comments, not probes. Without it the tool defers to a post-hoc
+               classifier that can silently no-op a real finding.
+
+               Cross-cutting findings (no specific line) stay summary-only —
+               but default to inline whenever you can name file:line.
+
+            2. SUMMARY PR COMMENT — emitted as STRUCTURED JSON via the
+               workflow's `--json-schema` flag (0.0.O / v0.6.22+). Do NOT
+               post the summary yourself via `gh pr comment` — a post-step
+               reads your structured output and renders the comment with the
+               exact format the strict-mode gate expects. Populate every
+               schema field (`status_header`, `summary_counts`,
+               `per_skill_scan`, `critical_findings`, `minor_findings`,
+               `preexisting_findings`, `skills_referenced`,
+               `last_reviewed_sha`); `dedicated_sections` and
+               `diagnostics` are optional but emit them when applicable.
+               See workflow env for the schema; the format docs below describe
+               what each field becomes after rendering.
+
+            The comment body MUST start with:
+
+              ## 🐛 Clud Bug review
+
+            (The post-step renders this H2 anchor — the strict-mode gate greps it.)
+
+            On the next non-empty line, emit:
+
+              **This round:** N critical · N minor · N resolved from prior · N still open
+
+            Applies to all H2 variants (bare / "— critical findings" / "— clean").
+            Always include all four counters even when 0 — fixed format is
+            grep-able. Definitions:
+
+              • critical            — NEW critical findings (the ones strict mode gates on)
+              • minor               — non-critical findings (nits, suggestions)
+              • resolved from prior — prior unresolved threads YOU resolved this pass
+                                      via resolveReviewThread (proves the bot read fixes)
+              • still open          — prior unresolved threads whose issue still stands
+
+            First-time reviews → 0/0 on the last two. Fix-push reviews →
+            "resolved from prior" typically positive.
+
+            Stats header (line immediately after **This round:**):
+            ONE single-line header — emoji tiers let agents triage on re-read
+            without parsing the body:
+
+              🔴 important — bugs / security / perf / missing test coverage
+              🟡 nit       — suggestions, style nits, observations
+              🟣 pre-existing — issues pre-dating this PR (worth surfacing)
+
+              Found: N 🔴 / N 🟡 / N 🟣
+
+            When all three are 0, the substantive body is optional.
+
+            Per-finding format (severity emoji + collapsible reasoning):
+            The summary line is load-bearing; the long-form reasoning lives in
+            a `<details>` block so re-reads can skip it token-cheaply.
+
+              🔴 [skill-name]: One-line claim (file:line).
+              <details><summary>Reasoning</summary>
+
+              Evidence anchors, suggested fix, edge cases.
+
+              </details>
+
+            Tier emoji: 🔴 important (strict-mode gates these), 🟡 nit,
+            🟣 pre-existing.
+
+            Per-skill scan block (immediately under the status line):
+            Emit "### Per-skill scan" with ONE line per loaded skill — even
+            silent ones. Anti-dilution: authors see their skill ran.
+
+              ### Per-skill scan
+              - [<skill-name>]: <one-sentence outcome>
+
+            Examples:
+              - [critical-issues-only]: scanned all paths. 2 critical findings below.
+              - [evidence-based-review]: applied to all findings. ✓ all anchored.
+              - [respect-existing-conventions]: scanned for pattern fights. 0 findings.
+              - [brand-voice-review]: scanned 3 microcopy changes. 1 finding (below).
+              - [pii-and-compliance]: scanned logging + analytics. 0 findings.
+
+            Per-skill findings sections (dedicated-mode skills only):
+            For each dedicated-mode skill that produced one or more
+            findings, emit a dedicated H3 section before the standard
+            critical/minor buckets:
+
+              ### Brand voice [brand-voice-review]
+              - Finding: button label "Click here!" violates verb-noun rule
+                (lib/ui/Button.tsx:42). Suggested: "Open settings."
+
+            Shared-mode skill findings stay in the combined "Critical findings"
+            / "Minor findings" buckets — cross-correlation preserves signal
+            (e.g. a logging-PII issue belongs in both critical-issues-only and
+            pii-and-compliance at once).
+
+            Emit the summary as structured JSON output (the workflow's
+            --json-schema captures it; a post-step renders + posts via gh pr
+            comment). Do NOT post the summary yourself.
+
+            Inline findings still post via mcp__github_inline_comment__create_inline_comment
+            (with `confirmed: true`). Pass ordering: (a) post inline findings,
+            (b) resolve prior threads now fixed (FIX-PUSH FLOW below — feeds
+            "resolved_from_prior" counter in the JSON), (c) emit structured
+            summary output. Step (b) MUST complete before (c) so the counter
+            is accurate; (a)/(b) order between themselves doesn't matter.
+
+            FIX-PUSH FLOW (when prior claude[bot] threads exist):
+            List prior claude[bot] inline threads, resolve the ones whose issue
+            is verifiably fixed in the current diff. This closes the loop —
+            "resolved from prior" proves the bot read the fixes.
+
+            List threads:
+
+              gh api graphql -f query='{ repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") { pullRequest(number: '"$PR_NUMBER"') { reviewThreads(first: 30) { nodes { id isResolved comments(first: 1) { nodes { body author { login } } } } } } } }'
+
+            For each unresolved thread YOU (claude[bot]) authored that the head
+            diff now addresses:
+
+              gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<id>"}) { thread { isResolved } } }'
+
+            Only resolve threads where the fix is verifiable. Unresolved-but-
+            still-standing threads become "still open" in the status block.
+
+            If there are no critical findings, you still post the summary
+            comment with the H2 header and "**This round:** 0 critical · …"
+            status line — strict mode + the status counters need the
+            comment to exist for every review pass.
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          show_full_output: true
+          # v0.6.22 / 0.0.O: --json-schema captures the summary as
+          # structured output; post-step renders + posts. See workflow.yml.tmpl for design notes.
+          claude_args: |
+            --model ${{ needs.paths-check.outputs.model }}
+            --max-turns ${{ needs.paths-check.outputs.max_turns }}
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
+            --json-schema '{"type":"object","additionalProperties":false,"properties":{"status_header":{"type":"string","enum":["critical findings","clean","bare"],"description":"Strict-mode opt-in repos: `critical findings` when ANY 🔴 finding exists, otherwise `clean`. Non-strict-mode repos (the default): emit `bare` — the renderer produces a `## 🐛 Clud Bug review` H2 with no suffix, matching the v0.6.21- behaviour. Check .claude/skills/.clud-bug.json for `strictMode: true` to pick critical/clean vs bare."},"summary_counts":{"type":"object","additionalProperties":false,"properties":{"critical":{"type":"integer","minimum":0},"minor":{"type":"integer","minimum":0},"preexisting":{"type":"integer","minimum":0},"resolved_from_prior":{"type":"integer","minimum":0},"still_open":{"type":"integer","minimum":0}},"required":["critical","minor","preexisting","resolved_from_prior","still_open"]},"per_skill_scan":{"type":"array","description":"One entry per LOADED skill — even silent ones. Empty when no skills are installed.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string"},"outcome":{"type":"string","description":"One sentence describing what the skill found. Max ~15 words. Examples: \"scanned all paths. 2 critical findings below.\", \"0 findings.\", \"not applicable to this diff.\""}},"required":["skill","outcome"]}},"critical_findings":{"type":"array","description":"NEW 🔴 findings (bugs, security, perf, missing test coverage). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"minor_findings":{"type":"array","description":"NEW 🟡 findings (nits, style, observations). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"preexisting_findings":{"type":"array","description":"NEW 🟣 findings (issues that pre-date this PR). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"dedicated_sections":{"type":"array","description":"Per-dedicated-mode-skill section blocks. Each item carries the section header text and its findings.","items":{"type":"object","additionalProperties":false,"properties":{"section_name":{"type":"string","description":"Human-readable section title, e.g. \"Brand voice\"."},"skill":{"type":"string","description":"The dedicated skill name."},"findings":{"type":"array","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}}},"required":["section_name","skill","findings"]}},"diagnostics":{"type":"array","description":"0.0.T tee-hint diagnostics. One line per `head -c` cap that fired during fetch. Empty when no truncation occurred.","items":{"type":"string"}},"skills_referenced":{"type":"array","description":"Names of every skill cited in any finding. Empty list (or [\"(none)\"]) when no skill applied.","items":{"type":"string"}},"last_reviewed_sha":{"type":"string","description":"The HEAD SHA at review time, used by the incremental-diff handshake. Set to the literal value of the workflow env var $HEAD_SHA."}},"required":["status_header","summary_counts","per_skill_scan","critical_findings","minor_findings","preexisting_findings","skills_referenced","last_reviewed_sha"]}'
+          prompt: |
+            Review this pull request following the discipline in your
+            system prompt — every rule about skill routing, comment
+            format, the strict-mode header, the two-surface review
+            shape, the FIX-PUSH FLOW, and (v0.6.25+) turn-budget
+            self-rationing applies.
+
+            ## Your turn budget for this PR (v0.6.25 / §5.5 Layer 2)
+
+            max_turns=${{ needs.paths-check.outputs.max_turns }},
+            estimated=${{ needs.paths-check.outputs.turns_estimated }},
+            files=${{ needs.paths-check.outputs.files_count }},
+            +${{ needs.paths-check.outputs.lines_added }}/-${{ needs.paths-check.outputs.lines_deleted }} lines,
+            prior_threads=${{ needs.paths-check.outputs.threads_count }}.
+
+            Plan accordingly per the "Turn budget self-rationing"
+            section in your system prompt. Reserve 5 turns for emit.
+        id: clud-bug-review
+
+      # v0.6.22 / 0.0.O: render structured output → post via gh pr comment.
+      # v0.6.25 / §5.5 Layer 1.5: append calibration marker.
+      - name: Render + post structured review
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+          TURNS_ESTIMATED: ${{ needs.paths-check.outputs.turns_estimated }}
+          MAX_TURNS: ${{ needs.paths-check.outputs.max_turns }}
+          FILES_COUNT: ${{ needs.paths-check.outputs.files_count }}
+          LINES_ADDED: ${{ needs.paths-check.outputs.lines_added }}
+          LINES_DELETED: ${{ needs.paths-check.outputs.lines_deleted }}
+          THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
+        run: |
+          set -euo pipefail
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.32 render --stdin)
+          CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
+          gh pr comment "$PR_NUMBER" --body "$BODY
+
+          $CALIBRATION"
+
+      # v0.6.29 / Component 4 — see workflow.yml.tmpl for design notes.
+      - name: Update skill-usage tracking
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          mkdir -p .claude/skills
+          if [ ! -f .claude/skills/.clud-bug.json ]; then
+            echo '{"version": 1}' > .claude/skills/.clud-bug.json
+          fi
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.32 update-skill-usage --stdin
+          echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
+
+      - name: Upload skill-usage artifact
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}
+          path: .claude/skills/.clud-bug.json
+          # v0.6.31 hotfix: upload-artifact@v4 excludes hidden files
+          # by default. See workflow.yml.tmpl for full context.
+          include-hidden-files: true
+          retention-days: 90
+
+      # v0.6.26 / §5.5 Layer 6 fallback render-from-inlines — see workflow.yml.tmpl for design notes.
+      - name: Fallback summary (structured_output empty)
+        if: success() && steps.clud-bug-review.outputs.structured_output == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          TURNS_ESTIMATED: ${{ needs.paths-check.outputs.turns_estimated }}
+          MAX_TURNS: ${{ needs.paths-check.outputs.max_turns }}
+          FILES_COUNT: ${{ needs.paths-check.outputs.files_count }}
+          LINES_ADDED: ${{ needs.paths-check.outputs.lines_added }}
+          LINES_DELETED: ${{ needs.paths-check.outputs.lines_deleted }}
+          THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
+        run: |
+          set -euo pipefail
+          INLINES=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments?per_page=100" \
+            --jq "[.[] | select(.user.login == \"claude[bot]\" and .commit_id == \"$HEAD_SHA\")]")
+          INLINE_COUNT=$(echo "$INLINES" | jq 'length')
+          CRITICAL=$(echo "$INLINES" | jq '[.[] | select(.body | test("🔴"))] | length')
+          MINOR=$(echo "$INLINES" | jq '[.[] | select(.body | test("🟡"))] | length')
+          PREEXISTING=$(echo "$INLINES" | jq '[.[] | select(.body | test("🟣"))] | length')
+          CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT, structured_output=empty, inline_findings=$INLINE_COUNT -->"
+          if [ "$INLINE_COUNT" -gt 0 ]; then
+            STATUS=""
+            [ "$CRITICAL" -gt 0 ] && STATUS=" — critical findings"
+            gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug review${STATUS}
+
+          **This round:** $CRITICAL critical · $MINOR minor · 0 resolved from prior · 0 still open
+
+          Found: $CRITICAL 🔴 / $MINOR 🟡 / $PREEXISTING 🟣
+
+          ⚠️ **Synthetic summary** (v0.6.26 §5.5 Layer 6 fallback). Inline findings above ARE the substantive review.
+
+          <!-- last-reviewed-sha: $HEAD_SHA -->
+
+          $CALIBRATION"
+          else
+            gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug review
+
+          **This round:** 0 critical · 0 minor · 0 resolved from prior · 0 still open
+
+          Found: 0 🔴 / 0 🟡 / 0 🟣
+
+          ⚠️ Structured output (\`--json-schema\`) returned empty AND no inline findings posted. Investigate run logs.
+
+          Skills referenced: [none]
+
+          <!-- last-reviewed-sha: $HEAD_SHA -->
+
+          $CALIBRATION"
+          fi
+
+      # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
+      - name: Strict mode — fail check on critical findings
+        if: success()
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.32
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].
+          # See workflow.yml.tmpl for design notes.
+          bot-login: 'github-actions[bot]'

--- a/.github/workflows/logmind-self-update.yml
+++ b/.github/workflows/logmind-self-update.yml
@@ -138,7 +138,7 @@ jobs:
       # `logmind init` (the refresh) runs against the same binary
       # version consumer repos will see after this workflow lands its
       # PR. The action's version tracks the LATEST step output.
-      - uses: thrillmade/setup-logmind@v1.0.0
+      - uses: thrillmade/setup-logmind@v1.0.1
         if: steps.compare.outputs.skip == 'false'
         with:
           version: ${{ steps.compare.outputs.latest }}

--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -57,7 +57,7 @@ jobs:
           # Falls through to GITHUB_TOKEN when absent (still allows checkout).
           token: ${{ secrets.LOGMIND_AUTO_REGEN_PAT || secrets.GITHUB_TOKEN }}
 
-      - uses: thrillmade/setup-logmind@v1.0.0
+      - uses: thrillmade/setup-logmind@v1.0.1
 
       - name: Regenerate derived docs
         run: |

--- a/docs/decisions-branches/chore__dogfood-clud-bug-on-itself.md
+++ b/docs/decisions-branches/chore__dogfood-clud-bug-on-itself.md
@@ -1,0 +1,14 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-08 15:31 - Dogfood clud-bug on itself + bump setup-logmind pins to v1.0.1
+
+**Reasoning:** Workflow file install lets PR #154 and all subsequent clud-bug PRs get reviewed by the same npm-template-pinned workflow we ship to consumers (5MB MAX_DIFF_BYTES, paths-check classifier). Pin bumps (v1.0.0 → v1.0.1) fix the setup-logmind gh CLI fallback that breaks check-doc-links + regen-timeline checks org-wide on PRs without GH_TOKEN.
+
+**Alternatives considered:** Leave dogfood install bundled with v0.6.35 fix in PR #153 (rejected: CEO wanted separate PR so workflow lands FIRST and can review subsequent PRs), Leave pins at v1.0.0 and rely on Dependabot to bump (rejected: every PR until that lands stays red on check-doc-links — same blocker that hits PR #154 right now)
+
+**Implications:**
+- Once merged, clud-bug repo gets clud-bug-review as a check on every future PR
+- logmind-self-update.yml + check-doc-links.yml + regen-timeline.yml all on v1.0.1, matching plan §State/sweep-audit canonical
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (13 decisions)
+## 2026-06 (14 decisions)
 
-- **2026-06-02** — fix(v0.6.34): keep canonical workflow self-pin one release behind *(feat/v0.6.34-review-neutral-on-transient-error)* — [decisions-branches/feat__v0.6.34-review-neutral-on-transient-error.md](decisions-branches/feat__v0.6.34-review-neutral-on-transient-error.md)
-- *... 11 more decisions ...*
+- **2026-06-08** — Dogfood clud-bug on itself + bump setup-logmind pins to v1.0.1 *(chore/dogfood-clud-bug-on-itself)* — [decisions-branches/chore__dogfood-clud-bug-on-itself.md](decisions-branches/chore__dogfood-clud-bug-on-itself.md)
+- *... 12 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)


### PR DESCRIPTION
Small standalone PR so it can land FIRST, then review all subsequent PRs (including PR #153 — the v0.6.35 MAX_DIFF_BYTES fix).

## Why
- npm clud-bug never had \`clud-bug-review.yml\` installed in its own repo. Only \`claude-code-review.yml\` ran (stock Claude action, no skills, no clud-bug specifics).
- Until clud-bug-app GH App is proven ready (post Bug 9 shared library extraction), we want every repo using the npm workflow for self-review.
- This is the dogfood loop: clud-bug reviews its own development.

## What
Single file added: \`.github/workflows/clud-bug-review.yml\` (v12 template, customized).

- Project description string set to clud-bug (was tokenomics from the copy source).
- MAX_DIFF_BYTES pre-bumped to 5,000,000 to match the v0.6.35 default landing in PR #153 (so this PR doesn't itself re-introduce the 80KB silent truncation we just removed there).

## After merge
- Self-review fires on every PR in clud-bug, including PR #153 (the v0.6.35 fix).
- clud-bug-app already has the equivalent workflow (from PR #25 earlier today).
- Suspend the clud-bug-app GH App at the org level so its broken state can't interfere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)