### PR TITLE
chore: sibling-template version bump v12 → v13 (resolves PR #153 minor finding)

### DIFF
--- a/docs/decisions-branches/chore__bump-sibling-templates-v13.md
+++ b/docs/decisions-branches/chore__bump-sibling-templates-v13.md
@@ -1,0 +1,14 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-08 15:54 - Bump sibling templates workflow-py + workflow-ts to v13 (matches main JS template)
+
+**Reasoning:** PR #153's bot review surfaced this minor finding which shipped with v0.6.35 because we merged before fixing. workflow.yml.tmpl is at v13 (carries MAX_DIFF_BYTES 5MB + strict-mode-gate v0.6.35 ref); the python + ts siblings have the same body but stayed at v12. Propagation still works via content-drift (lib/update.js:172), but the update log reports v12→v12 hiding that anything changed. Follow-up to land that fix cleanly with a real clud-bug review.
+
+**Alternatives considered:** Squash into v0.6.36 release (rejected: ship this fix solo, version bump separately)
+
+**Implications:**
+- Three template version headers stay in sync going forward
+- Demonstrates that splitting cosmetic fixes into their own PR gets a real clud-bug review
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (16 decisions)
+## 2026-06 (17 decisions)
 
-- **2026-06-08** — Dogfood clud-bug on itself + bump setup-logmind pins to v1.0.1 *(chore/dogfood-clud-bug-on-itself)* — [decisions-branches/chore__dogfood-clud-bug-on-itself.md](decisions-branches/chore__dogfood-clud-bug-on-itself.md)
-- *... 14 more decisions ...*
+- **2026-06-08** — Bump sibling templates workflow-py + workflow-ts to v13 (matches main JS template) *(chore/bump-sibling-templates-v13)* — [decisions-branches/chore__bump-sibling-templates-v13.md](decisions-branches/chore__bump-sibling-templates-v13.md)
+- *... 15 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v12
+# clud-bug-template-version: v13
 name: Clud Bug 🐛 Crawls Your Code
 
 on:

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v12
+# clud-bug-template-version: v13
 name: Clud Bug 🐛 Crawls Your Code
 
 on:

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -60,7 +60,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // Workflow refreshed
     const wf = await readFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'utf8');
     assert.match(wf, /allowedTools/);
-    assert.match(wf, /^# clud-bug-template-version: v12/);
+    assert.match(wf, /^# clud-bug-template-version: v13/);
     // Baseline rewritten with current shipped content
     const baseline = await readFile(join(dir, '.claude/skills/critical-issues-only/SKILL.md'), 'utf8');
     assert.match(baseline, /critical-issues-only/);
@@ -75,7 +75,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // The refreshed workflow records a from/to version note.
     const wfChange = r.changed.find((c) => c.label === 'review workflow');
     assert.equal(wfChange.from, 'v0');
-    assert.equal(wfChange.to, 'v12');
+    assert.equal(wfChange.to, 'v13');
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
## Summary

Addresses the 1 minor finding from clud-bug-review on PR #153 that shipped to main alongside v0.6.35.

`workflow.yml.tmpl` was bumped v12→v13 with the MAX_DIFF_BYTES 5MB + strict-mode-gate v0.6.35 ref. Sibling templates `workflow-py.yml.tmpl` and `workflow-ts.yml.tmpl` had the same body changes but stayed at v12.

Propagation works via content-drift (`lib/update.js:172`), but the update log reports v12→v12 — hiding that anything changed for Python/TS consumers.

## Changes
- `templates/workflow-py.yml.tmpl`: v12 → v13
- `templates/workflow-ts.yml.tmpl`: v12 → v13  
- `test/update.test.js`: 2 assertions updated to match

## Test plan
- [x] `npm test` — 361/361 pass
- [ ] clud-bug-review on this PR runs cleanly (verifying the chain works on a workflow-file-untouched PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)