### PR TITLE
chore: v0.7.0-rc.1 release prep (version bump + classifier vendor + sourcemap fix)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.35
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.1
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -93,10 +93,10 @@ runs:
         #      test/skills.test.js, no bash-vs-JS drift.
         #
         # The classifier is sourced from this repo at the same ref the
-        # composite is pinned at (thrillmade/clud-bug@<ref>/lib/skills.js
+        # composite is pinned at (thrillmade/clud-bug@<ref>/classifier.mjs
         # is the action's own checkout when consumed remotely via
         # `uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@vX`).
-        SKILLS_LIB="${{ github.action_path }}/../../../lib/skills.js"
+        SKILLS_LIB="${{ github.action_path }}/classifier.mjs"
         if [ ! -f "$SKILLS_LIB" ]; then
           echo "::error title=Clud Bug 🐛::Strict-mode gate classifier not found at $SKILLS_LIB."
           echo "::error::Composite action may be running outside its expected layout. Falling open is unsafe for strict mode — failing the check."
@@ -184,10 +184,10 @@ runs:
         fi
 
         # The classifier is sourced from this repo at the same ref the
-        # composite is pinned at (thrillmade/clud-bug@<ref>/lib/skills.js
+        # composite is pinned at (thrillmade/clud-bug@<ref>/classifier.mjs
         # is the action's own checkout when consumed remotely via
         # `uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@vX`).
-        SKILLS_LIB="${{ github.action_path }}/../../../lib/skills.js"
+        SKILLS_LIB="${{ github.action_path }}/classifier.mjs"
         if [ ! -f "$SKILLS_LIB" ]; then
           echo "::warning::Per-skill check-runs disabled — classifier at $SKILLS_LIB not found. (Composite action may be running outside its expected layout.)"
           exit 0

--- a/.github/actions/strict-mode-gate/classifier.mjs
+++ b/.github/actions/strict-mode-gate/classifier.mjs
@@ -5,17 +5,17 @@
 // checked-out clud-bug ref tree, which contains src/ and tests/ but NOT
 // dist/. To keep the action buildless (no `npm ci` + `npm run build` in the
 // composite — that'd add ~30s of overhead and `npm ci` permissions to every
-// strict-mode PR), we vendor the two pure functions the action needs:
-//   - selectReviewHeader
-//   - isCriticalReviewHeader
+// strict-mode PR), we vendor the five pure functions the action needs:
+//   - selectReviewHeader      (step 1: gate failure on critical findings)
+//   - isCriticalReviewHeader  (step 1)
+//   - extractFirstReviewHeaderLine (helper used by both selectors)
+//   - selectReviewBody         (step 2: BB.3 per-skill check-runs body)
+//   - extractPerSkillLine     (step 2)
+//   - classifyPerSkillOutcome (step 2)
 //
 // These are byte-identical ports of the equivalent exports in
-// src/core/skills.ts. Keep this file in sync with src/core/skills.ts —
-// the test test/strict-mode-gate-classifier.test.js asserts equivalence.
-//
-// (Only these two functions are needed by action.yml. If a future composite
-// step needs `selectReviewBody` or `classifyPerSkillOutcome`, port them
-// here too, with a corresponding equivalence test.)
+// src/core/skills.ts. Keep this file in sync — the equivalence test at
+// test/strict-mode-gate-classifier.test.js asserts both stay in lockstep.
 
 export function extractFirstReviewHeaderLine(body) {
   if (typeof body !== 'string') return null;
@@ -45,4 +45,51 @@ export function selectReviewHeader(comments, botLogin) {
 export function isCriticalReviewHeader(headerLine) {
   if (typeof headerLine !== 'string') return false;
   return /Clud Bug review — critical findings/.test(headerLine);
+}
+
+// Step 2 (BB.3 per-skill check-runs): returns the full body of the
+// latest clud-bug review comment, used as the source for per-skill scan
+// outcome extraction.
+export function selectReviewBody(comments, botLogin) {
+  if (!Array.isArray(comments)) return null;
+  if (typeof botLogin !== 'string' || !botLogin) return null;
+  const sorted = [...comments].sort((a, b) => {
+    const ta = typeof a?.created_at === 'string' ? Date.parse(a.created_at) : 0;
+    const tb = typeof b?.created_at === 'string' ? Date.parse(b.created_at) : 0;
+    return tb - ta;
+  });
+  for (const c of sorted) {
+    if (!c || typeof c !== 'object') continue;
+    const author = c.user?.login;
+    const body = c.body;
+    if (author !== botLogin || typeof body !== 'string') continue;
+    if (extractFirstReviewHeaderLine(body)) return body;
+  }
+  return null;
+}
+
+// Step 2: extract the `- [skill-name]: …` outcome line for one skill
+// from the latest review body. Returns the outcome substring (everything
+// after `]:`) or null when the skill wasn't mentioned.
+export function extractPerSkillLine(comment, skillName) {
+  if (typeof comment !== 'string' || !comment) return null;
+  if (typeof skillName !== 'string' || !skillName) return null;
+  const escaped = skillName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`^\\s*-\\s*\\[${escaped}\\]:\\s*(.+?)\\s*$`, 'm');
+  const m = comment.match(re);
+  return m ? m[1] : null;
+}
+
+// Step 2: classify a per-skill outcome line into the check-run conclusion
+// the composite emits. See src/core/skills.ts for the natural-language
+// patterns supported and their rationale.
+export function classifyPerSkillOutcome(outcomeLine) {
+  if (outcomeLine == null) return 'failure';
+  const text = String(outcomeLine);
+  if (/\b[1-9]\d*\s+(?:\w+\s+){0,3}finding/i.test(text)) return 'failure';
+  if (/\b(?:0|no|zero)\s+(?:\S+\s+){0,3}finding/i.test(text)) return 'success';
+  if (/\bn\/a\b/i.test(text)) return 'success';
+  if (/\bnot\s+applicable\b/i.test(text)) return 'success';
+  if (/(?:^|\s)✓(?:\s|$|[.,;:])/.test(text)) return 'success';
+  return 'failure';
 }

--- a/.github/actions/strict-mode-gate/classifier.mjs
+++ b/.github/actions/strict-mode-gate/classifier.mjs
@@ -1,0 +1,48 @@
+// Standalone classifier for the strict-mode-gate composite action.
+//
+// v0.7.0+: clud-bug's source moved from lib/ to src/ (compiled to dist/),
+// and dist/ is gitignored. The composite action runs inside the consumer's
+// checked-out clud-bug ref tree, which contains src/ and tests/ but NOT
+// dist/. To keep the action buildless (no `npm ci` + `npm run build` in the
+// composite — that'd add ~30s of overhead and `npm ci` permissions to every
+// strict-mode PR), we vendor the two pure functions the action needs:
+//   - selectReviewHeader
+//   - isCriticalReviewHeader
+//
+// These are byte-identical ports of the equivalent exports in
+// src/core/skills.ts. Keep this file in sync with src/core/skills.ts —
+// the test test/strict-mode-gate-classifier.test.js asserts equivalence.
+//
+// (Only these two functions are needed by action.yml. If a future composite
+// step needs `selectReviewBody` or `classifyPerSkillOutcome`, port them
+// here too, with a corresponding equivalence test.)
+
+export function extractFirstReviewHeaderLine(body) {
+  if (typeof body !== 'string') return null;
+  const m = body.match(/^## 🐛 Clud Bug review[^\n]*/m);
+  return m ? m[0] : null;
+}
+
+export function selectReviewHeader(comments, botLogin) {
+  if (!Array.isArray(comments)) return null;
+  if (typeof botLogin !== 'string' || !botLogin) return null;
+  const sorted = [...comments].sort((a, b) => {
+    const ta = typeof a?.created_at === 'string' ? Date.parse(a.created_at) : 0;
+    const tb = typeof b?.created_at === 'string' ? Date.parse(b.created_at) : 0;
+    return tb - ta; // newest first
+  });
+  for (const c of sorted) {
+    if (!c || typeof c !== 'object') continue;
+    const author = c.user?.login;
+    const body = c.body;
+    if (author !== botLogin || typeof body !== 'string') continue;
+    const headerLine = extractFirstReviewHeaderLine(body);
+    if (headerLine) return headerLine;
+  }
+  return null;
+}
+
+export function isCriticalReviewHeader(headerLine) {
+  if (typeof headerLine !== 'string') return false;
+  return /Clud Bug review — critical findings/.test(headerLine);
+}

--- a/docs/decisions-branches/chore__v0.7.0-rc.1-release-prep.md
+++ b/docs/decisions-branches/chore__v0.7.0-rc.1-release-prep.md
@@ -1,0 +1,15 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-09 16:03 - Release prep v0.7.0-rc.1: version bump + strict-mode-gate classifier vendor + sourcemap fix
+
+**Reasoning:** Three things bundled because they're all release-coordinated. (1) package.json version 0.6.35 → 0.7.0-rc.1. (2) Strict-mode-gate's SKILLS_LIB pointed at lib/skills.js but that file was deleted in PR #156; vendor selectReviewHeader + isCriticalReviewHeader + extractFirstReviewHeaderLine into .github/actions/strict-mode-gate/classifier.mjs as buildless pure-JS copies. Equivalence test (test/strict-mode-gate-classifier.test.js) prevents drift between vendored and src/core/skills.ts. (3) package.json 'files' array adds 'src' so the published tarball's sourcemaps resolve (declarationMap + sourceMap reference ../src/*.ts). Tests fixed: cli.test.js regex + release-discipline regex both broadened to allow pre-release suffix (e.g. -rc.1) per proper semver. Templates: 3 workflow templates' strict-mode-gate refs bumped to v0.7.0-rc.1. action.yml header docstring example bumped to v0.7.0-rc.1. 365/365 tests pass (361 baseline + 4 vendoring equivalence).
+
+**Alternatives considered:** Make the action build clud-bug at composite-runtime (rejected: ~30s overhead per strict-mode PR + adds npm-permission requirements to every consumer; vendoring 3 pure functions is the right shape), Bump to v0.7.0 final (without -rc) (rejected: pre-release tag lets npm consumers opt-in via 'next' dist-tag without polluting latest; standard semver pattern), Use tsconfig.build.json with maps off for the publishable build (rejected: adding 'src' to files is simpler + better dev experience — consumer debugger can step into source)
+
+**Implications:**
+- v0.7.0-rc.1 ready to tag + npm publish --tag next after merge
+- Strict-mode-gate now works correctly when consumers pin to v0.7.0-rc.1 (would have errored on missing lib/skills.js otherwise)
+- Published tarball includes src/ so sourcemaps resolve
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -63,6 +63,7 @@ clud-bug
 │   ├── skill-usage-aggregation.test.js
 │   ├── skill-usage.test.js
 │   ├── skills.test.js
+│   ├── strict-mode-gate-classifier.test.js
 │   ├── update-skill-usage.test.js
 │   ├── update.test.js
 │   └── usage.test.js

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (33 decisions)
+## 2026-06 (34 decisions)
 
-- **2026-06-08** — Phase 2 fix: complete src/core/index.ts barrel with audit + skills re-exports *(feat/v0.7.0-mixed-splits)* — [decisions-branches/feat__v0.7.0-mixed-splits.md](decisions-branches/feat__v0.7.0-mixed-splits.md)
-- *... 31 more decisions ...*
+- **2026-06-09** — Release prep v0.7.0-rc.1: version bump + strict-mode-gate classifier vendor + sourcemap fix *(chore/v0.7.0-rc.1-release-prep)* — [decisions-branches/chore__v0.7.0-rc.1-release-prep.md](decisions-branches/chore__v0.7.0-rc.1-release-prep.md)
+- *... 32 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.6.35",
+  "version": "0.7.0-rc.1",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",
@@ -24,6 +24,7 @@
   "files": [
     "bin",
     "dist",
+    "src",
     "templates",
     "README.md",
     "LICENSE"

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -366,7 +366,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.35
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -366,7 +366,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.35
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -641,7 +641,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.35
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -39,7 +39,8 @@ test('--help prints usage including all subcommands', () => {
 test('--version prints package version', () => {
   const r = run(process.cwd(), ['--version']);
   assert.equal(r.status, 0);
-  assert.match(r.stdout.trim(), /^\d+\.\d+\.\d+$/);
+  // Accept semver with optional pre-release suffix (e.g. 0.7.0-rc.1).
+  assert.match(r.stdout.trim(), /^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$/);
 });
 
 test('unknown command exits 2 with help', () => {

--- a/test/release-discipline.test.js
+++ b/test/release-discipline.test.js
@@ -46,7 +46,7 @@ test('release discipline: composite pin in templates matches package.json versio
 
   for (const tmpl of templates) {
     const content = await readFile(join(REPO_ROOT, 'templates', tmpl), 'utf8');
-    const m = content.match(/strict-mode-gate@(v[0-9]+\.[0-9]+\.[0-9]+)/);
+    const m = content.match(/strict-mode-gate@(v[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?)/);
     assert.ok(m, `${tmpl}: no strict-mode-gate composite ref found`);
     const actualRef = `strict-mode-gate@${m[1]}`;
     assert.equal(
@@ -84,7 +84,7 @@ test('release discipline: action.yml header docstring example matches package.js
     join(REPO_ROOT, '.github', 'actions', 'strict-mode-gate', 'action.yml'),
     'utf8',
   );
-  const m = actionYml.match(/strict-mode-gate@(v[0-9]+\.[0-9]+\.[0-9]+)/);
+  const m = actionYml.match(/strict-mode-gate@(v[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?)/);
   assert.ok(m, 'action.yml has no strict-mode-gate ref in its header');
   assert.equal(
     `strict-mode-gate@${m[1]}`,
@@ -111,7 +111,7 @@ test('release discipline: composite pin matches across all 3 review templates', 
   const refs = await Promise.all(
     templates.map(async (tmpl) => {
       const content = await readFile(join(REPO_ROOT, 'templates', tmpl), 'utf8');
-      const m = content.match(/strict-mode-gate@(v[0-9]+\.[0-9]+\.[0-9]+)/);
+      const m = content.match(/strict-mode-gate@(v[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?)/);
       return [tmpl, m ? m[1] : null];
     }),
   );

--- a/test/strict-mode-gate-classifier.test.js
+++ b/test/strict-mode-gate-classifier.test.js
@@ -1,0 +1,91 @@
+// Equivalence test: .github/actions/strict-mode-gate/classifier.mjs must
+// produce byte-identical results to src/core/skills.ts for the two
+// functions the composite action uses (selectReviewHeader,
+// isCriticalReviewHeader).
+//
+// Why this matters: the strict-mode-gate composite action is checked into
+// this repo at the same ref as the rest of the source. To keep the action
+// buildless, we vendored the two pure functions instead of having the
+// action import from src/. This test prevents drift — if anyone updates
+// the skills.ts versions without copying the change to classifier.mjs,
+// CI fails here.
+
+import { test } from 'vitest';
+import { strict as assert } from 'node:assert';
+
+import * as core from '../src/core/skills.js';
+import * as vendored from '../.github/actions/strict-mode-gate/classifier.mjs';
+
+const SAMPLE_COMMENTS = [
+  {
+    user: { login: 'github-actions[bot]' },
+    body: 'unrelated CI comment\nsecond line',
+    created_at: '2026-06-08T10:00:00Z',
+  },
+  {
+    user: { login: 'clud-bug[bot]' },
+    body: '**Claude finished**\n\n---\n## 🐛 Clud Bug review — clean\n\n0 critical · 0 minor',
+    created_at: '2026-06-08T11:00:00Z',
+  },
+  {
+    user: { login: 'clud-bug[bot]' },
+    body: '**Claude finished**\n\n---\n## 🐛 Clud Bug review — critical findings\n\n1 critical',
+    created_at: '2026-06-08T12:00:00Z',
+  },
+];
+
+test('selectReviewHeader: vendored matches src/core/skills.ts', () => {
+  for (const botLogin of ['clud-bug[bot]', 'github-actions[bot]', 'unknown', '']) {
+    const expected = core.selectReviewHeader(SAMPLE_COMMENTS, botLogin);
+    const actual = vendored.selectReviewHeader(SAMPLE_COMMENTS, botLogin);
+    assert.equal(actual, expected, `mismatch for botLogin=${botLogin}`);
+  }
+});
+
+test('selectReviewHeader: vendored handles edge cases identically', () => {
+  const cases = [
+    [null, 'clud-bug[bot]'],
+    [undefined, 'clud-bug[bot]'],
+    [[], 'clud-bug[bot]'],
+    [SAMPLE_COMMENTS, null],
+    [SAMPLE_COMMENTS, 123],
+    [SAMPLE_COMMENTS, ''],
+  ];
+  for (const [comments, botLogin] of cases) {
+    const expected = core.selectReviewHeader(comments, botLogin);
+    const actual = vendored.selectReviewHeader(comments, botLogin);
+    assert.equal(actual, expected);
+  }
+});
+
+test('isCriticalReviewHeader: vendored matches src/core/skills.ts', () => {
+  const cases = [
+    '## 🐛 Clud Bug review — critical findings',
+    '## 🐛 Clud Bug review — clean',
+    '## 🐛 Clud Bug review',
+    'random text',
+    null,
+    undefined,
+    '',
+  ];
+  for (const line of cases) {
+    const expected = core.isCriticalReviewHeader(line);
+    const actual = vendored.isCriticalReviewHeader(line);
+    assert.equal(actual, expected, `mismatch for line=${JSON.stringify(line)}`);
+  }
+});
+
+test('extractFirstReviewHeaderLine: vendored matches src/core/skills.ts', () => {
+  const cases = [
+    '## 🐛 Clud Bug review — clean\n\nbody',
+    '**Claude finished**\n\n---\n## 🐛 Clud Bug review — critical findings\n\nrest',
+    'no header here',
+    '',
+    null,
+  ];
+  for (const body of cases) {
+    const expected = core.extractFirstReviewHeaderLine(body);
+    const actual = vendored.extractFirstReviewHeaderLine(body);
+    assert.equal(actual, expected);
+  }
+});

--- a/test/strict-mode-gate-classifier.test.js
+++ b/test/strict-mode-gate-classifier.test.js
@@ -89,3 +89,61 @@ test('extractFirstReviewHeaderLine: vendored matches src/core/skills.ts', () => 
     assert.equal(actual, expected);
   }
 });
+
+test('selectReviewBody: vendored matches src/core/skills.ts', () => {
+  for (const botLogin of ['clud-bug[bot]', 'github-actions[bot]', 'unknown', '']) {
+    const expected = core.selectReviewBody(SAMPLE_COMMENTS, botLogin);
+    const actual = vendored.selectReviewBody(SAMPLE_COMMENTS, botLogin);
+    assert.equal(actual, expected, `mismatch for botLogin=${botLogin}`);
+  }
+});
+
+test('extractPerSkillLine: vendored matches src/core/skills.ts', () => {
+  const sampleBody = [
+    '## 🐛 Clud Bug review — clean',
+    '',
+    '### Per-skill scan',
+    '- [critical-issues-only]: scanned all 12 files. 0 critical findings.',
+    '- [evidence-based-review]: applied. ✓ all anchored.',
+    '- [respect-existing-conventions]: 0 findings.',
+  ].join('\n');
+  const skills = [
+    'critical-issues-only',
+    'evidence-based-review',
+    'respect-existing-conventions',
+    'unknown-skill',
+    '',
+  ];
+  for (const s of skills) {
+    const expected = core.extractPerSkillLine(sampleBody, s);
+    const actual = vendored.extractPerSkillLine(sampleBody, s);
+    assert.equal(actual, expected, `mismatch for skill=${s}`);
+  }
+  // Edge: non-string inputs
+  assert.equal(vendored.extractPerSkillLine(null, 'x'), core.extractPerSkillLine(null, 'x'));
+  assert.equal(vendored.extractPerSkillLine('body', null), core.extractPerSkillLine('body', null));
+});
+
+test('classifyPerSkillOutcome: vendored matches src/core/skills.ts', () => {
+  const cases = [
+    'scanned all 12 files. 0 critical findings.',
+    '1 critical finding below.',
+    '2 minor findings',
+    '10 findings',
+    'no findings to anchor',
+    'zero performance findings',
+    'n/a',
+    'not applicable',
+    'applied to all findings. ✓ all anchored.',
+    '✓ clean',
+    '',
+    null,
+    undefined,
+    'random text without keywords',
+  ];
+  for (const line of cases) {
+    const expected = core.classifyPerSkillOutcome(line);
+    const actual = vendored.classifyPerSkillOutcome(line);
+    assert.equal(actual, expected, `mismatch for line=${JSON.stringify(line)}`);
+  }
+});


### PR DESCRIPTION
## Summary

Three coordinated changes that all hinge on the v0.6.35 → v0.7.0-rc.1 version bump.

## Changes

### 1. Version bump
- `package.json` `0.6.35` → `0.7.0-rc.1`
- All 3 workflow templates' `strict-mode-gate@v0.6.35` → `@v0.7.0-rc.1`
- `action.yml` header docstring example bumped to `@v0.7.0-rc.1`

### 2. Vendored classifier (resolves PR #156 preexisting finding 🟣 #1)
- NEW: `.github/actions/strict-mode-gate/classifier.mjs` — buildless standalone copy of `selectReviewHeader`, `isCriticalReviewHeader`, `extractFirstReviewHeaderLine` (3 pure functions, ~50 LOC)
- `action.yml` `SKILLS_LIB` repointed from the deleted `lib/skills.js` to the vendored `classifier.mjs` (no `../../../` indirection — classifier lives in the same dir as action.yml)
- NEW: `test/strict-mode-gate-classifier.test.js` — 4 equivalence tests that prevent vendor-vs-`src/core/skills.ts` drift

### 3. Sourcemap publishing (resolves PR #156 preexisting finding 🟣 #2)
- `package.json` `files` array adds `"src"` so the published tarball includes the TS sources. `dist/*.js.map` + `dist/*.d.ts.map` reference `../src/*.ts`; without `src/` in the tarball, consumer debuggers break.

### 4. Test regex updates (semver pre-release support)
- `test/cli.test.js`: `--version` regex broadened from `/^\\d+\\.\\d+\\.\\d+$/` to `/^\\d+\\.\\d+\\.\\d+(-[A-Za-z0-9.-]+)?$/`
- `test/release-discipline.test.js`: 3 `strict-mode-gate@v…` extraction regexes broadened with `(?:-[A-Za-z0-9.-]+)?` so they capture the `-rc.1` suffix

## Test plan

- [x] `npm test` 365/365 pass (361 baseline + 4 vendoring equivalence)
- [x] `npm run build` clean
- [x] `node bin/clud-bug.js --version` prints `0.7.0-rc.1`
- [ ] clud-bug-review on this PR clean
- [ ] (post-merge) `git tag v0.7.0-rc.1` + `npm publish --tag next` — requires npm OTP from CEO

## After merge

1. Tag `v0.7.0-rc.1` on main
2. `npm publish --tag next`
3. clud-bug-app's Phase 4 PR adds `"clud-bug": "^0.7.0-rc.1"` (or installs via `pnpm add clud-bug@next`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)