### PR TITLE
feat: v0.7.0-rc.3 — SPEC §1.8.1 + §7.2.1 + §6.7.3 closure (Phase 7 PR A)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.2
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.3
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/decisions-branches/release__v0.7.0-rc.3.md
+++ b/docs/decisions-branches/release__v0.7.0-rc.3.md
@@ -38,3 +38,14 @@
 
 ---
 
+## 2026-06-10 11:16 - v0.7.0-rc.3: fix-closed unrecognized PR_AUTHOR_ASSOCIATION to NONE (clud-bug-review #163 fix)
+
+**Reasoning:** clud-bug-review on PR #163 (both baseline + clud-bug) flagged that the CLI's runSelectReviewEvent fallback mapped unrecognized author_association tokens to CONTRIBUTOR (org-trusted → APPROVE). This contradicts the §7.2.1 gate's defensive intent — a future REST-API rename of an external tier would silently re-open the drive-by auto-merge surface. Fixed by splitting empty (back-compat → CONTRIBUTOR) from non-empty unrecognized (fail-closed → NONE → COMMENT). Asymmetric risk: extra human Approve click vs auto-merge exploit.
+
+**Alternatives considered:** Reject any non-OWNER/MEMBER as external (rejected: breaks legitimate CONTRIBUTOR clean-review APPROVE flow)
+
+**Implications:**
+- Operator sees stderr warning when an unrecognized token arrives — early-warning signal for the rename
+
+---
+

--- a/docs/decisions-branches/release__v0.7.0-rc.3.md
+++ b/docs/decisions-branches/release__v0.7.0-rc.3.md
@@ -14,3 +14,15 @@
 
 ---
 
+## 2026-06-10 10:46 - v0.7.0-rc.3 core: selectReviewEvent + parsePriorReviewFile + diffFindings + renderReviewFile extensions
+
+**Reasoning:** Ported and extended formal-review for §7.2.1 with authorAssociation gate; added diff-findings module for §1.8.1 Resolved/Still-open block emission; extended renderReviewFile with three optional inputs (resolvedFindings, stillOpenFindings, cacheStats); barrel re-exports all three. 88 new tests passing.
+
+**Alternatives considered:** Inline author_association check at every caller (rejected: rule lives once), Hash-based identity using crypto.subtle SHA-256 (rejected: string identity is enough)
+
+**Implications:**
+- Phase 7 PR B in clud-bug-app deletes lib/formal-review.ts and imports from clud-bug/core
+- renderReviewFile inputs grew by 3 optional fields — back-compat preserved
+
+---
+

--- a/docs/decisions-branches/release__v0.7.0-rc.3.md
+++ b/docs/decisions-branches/release__v0.7.0-rc.3.md
@@ -1,0 +1,16 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-10 10:37 - v0.7.0-rc.3: port selectReviewEvent into core w/ author_association + diff-findings + writeback extensions + workflow post-step
+
+**Reasoning:** Phase 7 PR A closes SPEC §1.8.1 + §7.2.1 + §6.7.3 conformance gaps in clud-bug core so clud-bug-app (PR B) can consume via dep bump + npm workflow inherits via new template post-step. Without (1) auto-approves drive-by external PRs (security bug), (2) misses Resolved/Still-open blocks, (3) misses cache comment, (4) workflow path never satisfies required_approving_review_count: 1 floor.
+
+**Alternatives considered:** Keep selectReviewEvent in clud-bug-app only (rejected: workflow path inherits nothing), Skip author_association gate (rejected: drive-by exploit of auto-merge), Server-side gate in App only (rejected: workflow consumers still uncovered)
+
+**Implications:**
+- clud-bug-app must bump dep + pass author_association in Phase 7 PR B
+- Renderer input shape grows by 3 optional fields (back-compat)
+- Template post-step runs Node inline reading clud-bug/core import; needs install step
+- All 3 workflow templates + action.yml header bump to v0.7.0-rc.3
+
+---
+

--- a/docs/decisions-branches/release__v0.7.0-rc.3.md
+++ b/docs/decisions-branches/release__v0.7.0-rc.3.md
@@ -26,3 +26,15 @@
 
 ---
 
+## 2026-06-10 10:58 - v0.7.0-rc.3: workflow template post-step + CLI select-review-event subcommand + version bumps
+
+**Reasoning:** Added new clud-bug CLI subcommand 'select-review-event --stdin' that the workflow templates invoke via 'npx --yes clud-bug@<version>' to post a formal pulls.createReview, satisfying canonical-ruleset's required_approving_review_count: 1 floor on the npm workflow path. continue-on-error: true ensures the formal review NEVER fails the workflow; degrades to skip on any caller-side error. Bumped package.json + action.yml header + all 3 template strict-mode-gate pins to v0.7.0-rc.3. Added release-discipline test guarding the new post-step.
+
+**Alternatives considered:** node -e inline import (rejected: brittle, hard to test), Shell-only jq rule table (rejected: rule lives in TS for cross-tool reuse)
+
+**Implications:**
+- Workflow consumers will see one extra 'Formal review' step + a per-PR APPROVE review (clud-bug[bot]) on clean PRs
+- Old workflows (pre-rc.3) keep working — they just never post APPROVE, status quo
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -53,7 +53,9 @@ clud-bug
 │   ├── branch-protection.test.js
 │   ├── cli.test.js
 │   ├── detect.test.js
+│   ├── diff-findings.test.js
 │   ├── edit-workflow.test.js
+│   ├── formal-review.test.js
 │   ├── init-with-skdd.test.js
 │   ├── prompt-builder.test.js
 │   ├── prompts.eval.test.js

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (37 decisions)
+## 2026-06 (40 decisions)
 
-- **2026-06-09** — v0.7.0-rc.2: fix clud-bug-review #158 critical + 2 minor on first pass *(release/v0.7.0-rc.2)* — [decisions-branches/release__v0.7.0-rc.2.md](decisions-branches/release__v0.7.0-rc.2.md)
-- *... 35 more decisions ...*
+- **2026-06-10** — v0.7.0-rc.3: workflow template post-step + CLI select-review-event subcommand + version bumps *(release/v0.7.0-rc.3)* — [decisions-branches/release__v0.7.0-rc.3.md](decisions-branches/release__v0.7.0-rc.3.md)
+- *... 38 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (40 decisions)
+## 2026-06 (41 decisions)
 
-- **2026-06-10** — v0.7.0-rc.3: workflow template post-step + CLI select-review-event subcommand + version bumps *(release/v0.7.0-rc.3)* — [decisions-branches/release__v0.7.0-rc.3.md](decisions-branches/release__v0.7.0-rc.3.md)
-- *... 38 more decisions ...*
+- **2026-06-10** — v0.7.0-rc.3: fix-closed unrecognized PR_AUTHOR_ASSOCIATION to NONE (clud-bug-review #163 fix) *(release/v0.7.0-rc.3)* — [decisions-branches/release__v0.7.0-rc.3.md](decisions-branches/release__v0.7.0-rc.3.md)
+- *... 39 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.2",
+  "version": "0.7.0-rc.3",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -138,6 +138,17 @@ Commands:
                         GitHub-markdown summary comment shape. Invoked by the
                         workflow post-step; output is what \`gh pr comment\`
                         receives. Empty stdin or non-object payload exits 2.
+  select-review-event   Compute the SPEC §7.2.1 formal-review event (APPROVE /
+   --stdin               REQUEST_CHANGES / COMMENT / skip) from a structured-output
+                        JSON payload + a few env-passed PR-author fields. Used by
+                        the v0.7.0-rc.3 workflow post-step to post a formal
+                        \`pulls.createReview\` call so the canonical ruleset's
+                        \`required_approving_review_count: 1\` floor is auto-
+                        satisfied by clud-bug[bot] on clean reviews.
+                        Required env vars: PR_AUTHOR_LOGIN, PR_AUTHOR_ASSOCIATION,
+                        STRICT_MODE ("true"/"false"). Empty/malformed stdin →
+                        exits 0 with "skip" on stdout (no-op; workflow degrades
+                        gracefully to the existing comment-only behavior).
 
 Options:
   --offline             Skip skills.sh; pin only the bundled baseline specimens.
@@ -191,6 +202,7 @@ async function main() {
     case 'eval':    return runEval();
     case 'render':  return runRender(args);
     case 'update-skill-usage': return runUpdateSkillUsage(args);
+    case 'select-review-event': return runSelectReviewEvent(args);
     default:
       process.stderr.write(`Unknown command: ${cmd || '(none)'}\n\n${HELP}`);
       process.exit(2);
@@ -332,6 +344,116 @@ async function runUpdateSkillUsage(args) {
 
   const skillCount = Object.keys(delta).length;
   ok(`update-skill-usage: merged ${skillCount} skill${skillCount === 1 ? '' : 's'} from review`);
+}
+
+
+// v0.7.0-rc.3 — SPEC §7.2.1 formal-review event selector for the npm
+// workflow path. Reads the action's structured_output JSON from stdin,
+// PR-author metadata from env, and emits ONE word on stdout:
+//
+//     APPROVE | REQUEST_CHANGES | COMMENT | skip
+//
+// The workflow template post-step pipes the structured_output payload
+// in, reads the verdict, then conditionally calls `gh api ... /reviews`
+// with `event=$VERDICT` (skipping the API call when verdict is "skip").
+//
+// Robustness contract: this command MUST NEVER fail the workflow on
+// caller-side problems (missing/malformed payload, missing env). Any
+// such case prints "skip" to stdout + a warning to stderr and exits 0
+// — the workflow then degrades to the existing comment-only behavior.
+// We only exit non-zero on programmer error (unknown command flags),
+// which the workflow templates don't pass.
+//
+// Required env vars (the workflow templates set all four):
+//   PR_AUTHOR_LOGIN          — github.event.pull_request.user.login
+//   PR_AUTHOR_ASSOCIATION    — github.event.pull_request.author_association
+//   STRICT_MODE              — "true" / "false" from the base-ref manifest
+// (PR_AUTHOR_ASSOCIATION missing → "CONTRIBUTOR" default which preserves
+// pre-§7.2.1 trusted-author semantics; PR_AUTHOR_LOGIN missing → "skip".)
+async function runSelectReviewEvent(args) {
+  const { selectReviewEvent } = await import('../core/formal-review.js');
+
+  if (!args.stdin) {
+    process.stderr.write(
+      'clud-bug select-review-event: --stdin is required.\n',
+    );
+    process.stdout.write('skip\n');
+    return;
+  }
+
+  let raw = '';
+  for await (const chunk of process.stdin) raw += chunk;
+  raw = raw.trim();
+  if (!raw) {
+    process.stderr.write(
+      'clud-bug select-review-event: stdin empty — emitting "skip".\n',
+    );
+    process.stdout.write('skip\n');
+    return;
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch (e) {
+    process.stderr.write(
+      `clud-bug select-review-event: JSON parse failed: ${e.message} — emitting "skip".\n`,
+    );
+    process.stdout.write('skip\n');
+    return;
+  }
+  if (!payload || typeof payload !== 'object') {
+    process.stderr.write(
+      'clud-bug select-review-event: payload must be a JSON object — emitting "skip".\n',
+    );
+    process.stdout.write('skip\n');
+    return;
+  }
+
+  // Count findings from the structured_output array shape. Each is
+  // optional — the model may emit absent / null / wrong-type arrays
+  // when its output drifts from schema; we tolerate all of those.
+  const criticalCount = Array.isArray(payload.critical_findings)
+    ? payload.critical_findings.length
+    : 0;
+  const minorCount = Array.isArray(payload.minor_findings)
+    ? payload.minor_findings.length
+    : 0;
+
+  // Env-passed metadata. Empty PR_AUTHOR_LOGIN means we have no idea
+  // who opened the PR — safer to skip than to attempt a formal review
+  // that might collide with the self-PR guard mis-routed.
+  const prAuthorLogin = String(process.env.PR_AUTHOR_LOGIN ?? '').trim();
+  if (prAuthorLogin === '') {
+    process.stderr.write(
+      'clud-bug select-review-event: PR_AUTHOR_LOGIN unset — emitting "skip".\n',
+    );
+    process.stdout.write('skip\n');
+    return;
+  }
+
+  // author_association defaults to 'CONTRIBUTOR' (org-trusted tier in
+  // pre-§7.2.1 semantics) when the caller doesn't pass one. Old
+  // webhook payloads + tests use this branch.
+  const rawAssoc = String(process.env.PR_AUTHOR_ASSOCIATION ?? '').trim();
+  const validAssociations = new Set([
+    'OWNER', 'MEMBER', 'COLLABORATOR', 'CONTRIBUTOR',
+    'FIRST_TIME_CONTRIBUTOR', 'FIRST_TIMER', 'NONE', 'MANNEQUIN',
+  ]);
+  const authorAssociation = validAssociations.has(rawAssoc)
+    ? rawAssoc
+    : 'CONTRIBUTOR';
+
+  const strictMode = String(process.env.STRICT_MODE ?? '').trim() === 'true';
+
+  const event = selectReviewEvent({
+    criticalCount,
+    minorCount,
+    strictMode,
+    prAuthorLogin,
+    authorAssociation,
+  });
+  process.stdout.write(event + '\n');
 }
 
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -432,17 +432,47 @@ async function runSelectReviewEvent(args) {
     return;
   }
 
-  // author_association defaults to 'CONTRIBUTOR' (org-trusted tier in
-  // pre-§7.2.1 semantics) when the caller doesn't pass one. Old
-  // webhook payloads + tests use this branch.
+  // author_association resolution — security-critical fallback ladder.
+  //
+  // SPEC §7.2.1 + clud-bug-review #163 feedback: the §7.2.1 gate exists
+  // precisely so a future REST-API rename of an external tier doesn't
+  // silently degrade to "trusted → APPROVE". The fallback below splits
+  // the two error cases by what they MEAN:
+  //
+  //   1. EMPTY ("") — caller didn't pass author_association at all.
+  //      This is the "older webhook payload / non-GH caller" case.
+  //      Pre-§7.2.1, those callers got APPROVE on clean reviews; we
+  //      preserve that by defaulting to 'CONTRIBUTOR' (org-trusted).
+  //      Documented + tested under "missing PR_AUTHOR_ASSOCIATION".
+  //
+  //   2. NON-EMPTY UNRECOGNIZED ("FUTURE_TIER") — caller passed a
+  //      token this build doesn't know about. This is the rename
+  //      scenario the §7.2.1 gate is explicitly defending against.
+  //      Fail CLOSED: treat as external → 'NONE' → COMMENT, NEVER
+  //      APPROVE. If the rename was for a still-trusted tier (e.g.
+  //      'STAFF'), the cost is one extra COMMENT review pending
+  //      human approval; if it was a new external tier, we've closed
+  //      the drive-by exploit. Asymmetric risk → fail closed.
   const rawAssoc = String(process.env.PR_AUTHOR_ASSOCIATION ?? '').trim();
   const validAssociations = new Set([
     'OWNER', 'MEMBER', 'COLLABORATOR', 'CONTRIBUTOR',
     'FIRST_TIME_CONTRIBUTOR', 'FIRST_TIMER', 'NONE', 'MANNEQUIN',
   ]);
-  const authorAssociation = validAssociations.has(rawAssoc)
-    ? rawAssoc
-    : 'CONTRIBUTOR';
+  let authorAssociation;
+  if (rawAssoc === '') {
+    // Back-compat for legacy callers without author_association.
+    authorAssociation = 'CONTRIBUTOR';
+  } else if (validAssociations.has(rawAssoc)) {
+    authorAssociation = rawAssoc;
+  } else {
+    // Fail-closed for unrecognized future tokens. 'NONE' is the
+    // weakest external tier and the safest default — selectReviewEvent
+    // routes it to COMMENT (never APPROVE, never REQUEST_CHANGES).
+    process.stderr.write(
+      `clud-bug select-review-event: unrecognized PR_AUTHOR_ASSOCIATION="${rawAssoc}" — treating as external (fail-closed per SPEC §7.2.1).\n`,
+    );
+    authorAssociation = 'NONE';
+  }
 
   const strictMode = String(process.env.STRICT_MODE ?? '').trim() === 'true';
 

--- a/src/core/diff-findings.ts
+++ b/src/core/diff-findings.ts
@@ -1,0 +1,323 @@
+// SPEC §1.8.1 multi-pass diff: prior `docs/reviews/PR-<n>.md` vs current
+// review findings. Produces the `**Resolved this round:**` /
+// `**Still open:**` lists that `renderReviewFile` consumes.
+//
+// Identity model
+// --------------
+// Each finding's identity is a stable hash of:
+//
+//   `${file}:${line}:${severity}:${skillName}:${summary.slice(0, 100)}`
+//
+// A 100-character truncation on `summary` is enough to discriminate
+// distinct findings without being so long that whitespace/punctuation
+// drift between passes breaks identity. A severity-bucket change (e.g.
+// the same skill flags the same line as 🔴 then 🟡 the next round)
+// produces a DIFFERENT identity — by design — so a severity downgrade
+// counts as one resolved finding + one new finding (the user gets
+// credit for the fix AND can see the bot still has a concern, just at
+// a lower severity).
+//
+// The same identity shape is what auto-fix / auto-resolve in
+// clud-bug-app uses for thread anchoring; keeping it identical means a
+// future per-finding cross-reference between the doc-file diff and the
+// inline-thread surface is trivial.
+
+import {
+  flattenFindings,
+  type Finding,
+  type Review,
+} from './review-schema-zod.js';
+
+import { SEVERITY_EMOJI } from './review-writeback.js';
+
+/** One parsed finding from a prior `docs/reviews/PR-<n>.md`. */
+export type ParsedFinding = {
+  /** Relative path. Falls back to '(unknown file)' when the prior file
+   *  itself rendered the unknown-file marker; we keep it intact for
+   *  identity stability. */
+  file: string;
+  /**
+   * 1-indexed line number. Zero when the prior file had no `:N` suffix
+   * (cross-cutting findings). Zero participates in identity as-is.
+   */
+  line: number;
+  severity: 'critical' | 'minor' | 'preexisting';
+  skillName: string;
+  summary: string;
+};
+
+export type ParsedReview = { findings: ParsedFinding[] };
+
+/**
+ * Parse a `docs/reviews/PR-<n>.md` markdown back into structured findings.
+ *
+ * Robust to:
+ *   - `null` / `undefined` input            → returns `null`
+ *   - empty / whitespace-only markdown      → returns `null`
+ *   - missing severity sections             → those sections contribute 0
+ *   - lines that don't match the SPEC bullet shape → silently dropped
+ *   - mixed unknown-file markers (`(unknown file)` vs absent)
+ *
+ * Parsing strategy: walk top-down, switch active severity on each
+ * `### <emoji> <Label>` header (one of the three SPEC §1.8.1 buckets),
+ * then collect every line starting with `- **` until the next header
+ * (or `---` end marker). Each `- **<file>:<line>** — <skill>: <summary>`
+ * line is split into its 4 fields; `:<line>` is optional (cross-cutting).
+ *
+ * `(unknown file)` files are preserved verbatim — they participate in
+ * identity, so the same cross-cutting finding can still be diffed across
+ * rounds even when neither pass has a line anchor.
+ */
+export function parsePriorReviewFile(
+  markdown: string | null | undefined,
+): ParsedReview | null {
+  if (markdown == null) return null;
+  if (markdown.trim() === '') return null;
+
+  const lines = markdown.split('\n');
+  const out: ParsedFinding[] = [];
+  let current: ParsedFinding['severity'] | null = null;
+
+  for (const raw of lines) {
+    // Strip trailing whitespace; leading indent is meaningful for
+    // sub-lines (Reasoning, attribution) which we deliberately ignore.
+    const line = raw.replace(/\s+$/, '');
+
+    // The SPEC §1.8.1 trailing `---` separator ends the findings region.
+    // Anything after it (the [Link to PR] line) is metadata and parsed
+    // by short-circuit so we don't mistake the literal `---` for a
+    // missing header.
+    if (line === '---') {
+      current = null;
+      continue;
+    }
+
+    // Switch active severity on every `### <emoji> <Label>` heading.
+    // We pattern-match on the emoji codepoint (not the label text) so a
+    // future SPEC tweak to "Critical" → "Blocking" doesn't break us.
+    if (line.startsWith('### ')) {
+      if (line.includes(SEVERITY_EMOJI.critical)) {
+        current = 'critical';
+      } else if (line.includes(SEVERITY_EMOJI.minor)) {
+        current = 'minor';
+      } else if (line.includes(SEVERITY_EMOJI.preexisting)) {
+        current = 'preexisting';
+      } else {
+        current = null;
+      }
+      continue;
+    }
+
+    // Resolved / Still-open blocks under SPEC §1.8.1 — these list
+    // findings from PRIOR rounds, NOT this-round findings. Skip them
+    // so a multi-round PR doesn't double-count its own history.
+    // (`**Resolved this round:**` / `**Still open:**` headings.)
+    if (line.startsWith('**Resolved this round:') || line.startsWith('**Still open:')) {
+      current = null;
+      continue;
+    }
+
+    if (current == null) continue;
+
+    // SPEC §1.8.1 bullet: `- **<file>:<line>** — <skill>: <summary>`
+    //                  OR `- **<file>** — <skill>: <summary>`
+    //                  OR `- **(unknown file)** — <skill>: <summary>`
+    //
+    // The multi-pass renderer prepends `[Pass N — Role · model]` to the
+    // bullet; we accept that prefix and discard it for parsing.
+    const parsed = parseFindingBullet(line);
+    if (parsed) {
+      out.push({ ...parsed, severity: current });
+    }
+  }
+
+  if (out.length === 0) return null;
+  return { findings: out };
+}
+
+/**
+ * Diff prior vs current.
+ *
+ * `resolvedFindings`: findings that appeared in `prior` but NOT in
+ * `current`. The PR author (or auto-fix) addressed them.
+ *
+ * `stillOpenFindings`: findings that appeared in BOTH `prior` and
+ * `current`. These are persistent — the PR author hasn't fixed them
+ * (or the bot still considers them findings post-fix-push).
+ *
+ * Findings unique to `current` (newly raised this round) appear in
+ * neither list — those are surfaced directly by the renderer's normal
+ * severity-bucket emission.
+ *
+ * Order is preserved from `prior` for stability across rounds.
+ */
+export function diffFindings(
+  prior: ParsedReview | null,
+  current: {
+    critical_findings?: Array<{
+      skill: string;
+      file?: string;
+      line?: number;
+      summary: string;
+    }>;
+    minor_findings?: Array<{
+      skill: string;
+      file?: string;
+      line?: number;
+      summary: string;
+    }>;
+    preexisting_findings?: Array<{
+      skill: string;
+      file?: string;
+      line?: number;
+      summary: string;
+    }>;
+  },
+): {
+  resolvedFindings: ParsedFinding[];
+  stillOpenFindings: ParsedFinding[];
+} {
+  if (prior === null || prior.findings.length === 0) {
+    return { resolvedFindings: [], stillOpenFindings: [] };
+  }
+
+  // Build identity set for the current round. We do not need the
+  // current-round ParsedFinding objects — we only need to know which
+  // identities are still present.
+  //
+  // Cast through `Review` shape — the schema's three arrays mirror our
+  // input slice exactly (skill / file / line / summary), so we can lean
+  // on `flattenFindings` to produce a tagged list.
+  const currentReview: Review = {
+    status_header: 'clean',
+    summary_counts: {
+      critical: 0,
+      minor: 0,
+      preexisting: 0,
+      resolved_from_prior: 0,
+      still_open: 0,
+    },
+    per_skill_scan: [],
+    critical_findings: current.critical_findings ?? [],
+    minor_findings: current.minor_findings ?? [],
+    preexisting_findings: current.preexisting_findings ?? [],
+    skills_referenced: [],
+    last_reviewed_sha: '',
+  };
+  const currentFlat: Finding[] = flattenFindings(currentReview);
+  const currentIds = new Set<string>(currentFlat.map((f) => findingIdentity({
+    file: f.file ?? '(unknown file)',
+    line: f.line ?? 0,
+    severity: f.severity,
+    skillName: f.skill,
+    summary: f.summary,
+  })));
+
+  const resolved: ParsedFinding[] = [];
+  const stillOpen: ParsedFinding[] = [];
+  for (const f of prior.findings) {
+    const id = findingIdentity(f);
+    if (currentIds.has(id)) {
+      stillOpen.push(f);
+    } else {
+      resolved.push(f);
+    }
+  }
+  return { resolvedFindings: resolved, stillOpenFindings: stillOpen };
+}
+
+/**
+ * Stable identity for a finding. Used for diffing prior vs current
+ * across review rounds AND (by intention) shareable with the
+ * clud-bug-app inline-thread anchor hash so future cross-feature
+ * surfaces (e.g. "the auto-fix that resolved this thread also resolves
+ * this doc-file finding") align without re-computing.
+ *
+ * Exposed for tests + downstream callers that want to align their own
+ * finding storage on the same scheme.
+ */
+export function findingIdentity(f: {
+  file: string;
+  line: number;
+  severity: 'critical' | 'minor' | 'preexisting';
+  skillName: string;
+  summary: string;
+}): string {
+  // Truncate summary to 100 chars to absorb whitespace/punctuation
+  // drift between rounds without losing discrimination between
+  // genuinely-distinct findings (the SPEC §1.8.1 summary line is
+  // user-visible so it tends to be stable; 100 chars is enough for any
+  // realistic distinct summary while tolerating "fix the X" → "fix X"
+  // drift).
+  const summaryPart = f.summary.slice(0, 100);
+  return `${f.file}:${f.line}:${f.severity}:${f.skillName}:${summaryPart}`;
+}
+
+// ---------------------------------------------------------------------------
+// Parsing internals
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse one SPEC §1.8.1 bullet line into a {file, line, skill, summary}
+ * tuple. Returns null for any line that doesn't match the SPEC shape.
+ *
+ * Accepts both shapes:
+ *   `- **<file>:<line>** — <skill>: <summary>`
+ *   `- **<file>** — <skill>: <summary>`
+ *
+ * Also tolerates the multi-pass attribution prefix (D.2.5):
+ *   `- [Pass 1 — Role · model] **<file>:<line>** — <skill>: <summary>`
+ *
+ * Em-dash recognition: the SPEC pins U+2014 EM DASH between location
+ * and skill. Some downstream tools have been observed using `--` or
+ * regular hyphens; we accept both for resilience.
+ */
+function parseFindingBullet(line: string): Omit<ParsedFinding, 'severity'> | null {
+  // Strip the leading `- ` bullet marker.
+  if (!line.startsWith('- ')) return null;
+  let rest = line.slice(2);
+
+  // Strip optional `[Pass N — ...] ` attribution prefix (D.2.5).
+  if (rest.startsWith('[')) {
+    const closeIdx = rest.indexOf('] ');
+    if (closeIdx === -1) return null;
+    rest = rest.slice(closeIdx + 2);
+  }
+
+  // Expect `**<location>** ` next.
+  if (!rest.startsWith('**')) return null;
+  const locEnd = rest.indexOf('**', 2);
+  if (locEnd === -1) return null;
+  const location = rest.slice(2, locEnd);
+  rest = rest.slice(locEnd + 2);
+
+  // Strip the location separator. SPEC pins ` — ` (U+2014 surrounded by
+  // spaces). We accept hyphen-minus variants as a courtesy.
+  // The separator may be ` — `, ` -- `, or ` - `.
+  const sepMatch = rest.match(/^\s+(?:—|--|-)\s+/);
+  if (!sepMatch) return null;
+  rest = rest.slice(sepMatch[0].length);
+
+  // `<skill>: <summary>` — split on the first `: `.
+  const sepIdx = rest.indexOf(': ');
+  if (sepIdx === -1) return null;
+  const skillName = rest.slice(0, sepIdx).trim();
+  const summary = rest.slice(sepIdx + 2).trim();
+  if (skillName === '' || summary === '') return null;
+
+  // Split location into file + optional line. Walk RIGHTWARD from the
+  // last `:` so file names containing colons (Windows-style, rare) on
+  // the LHS don't confuse us.
+  const colonIdx = location.lastIndexOf(':');
+  let file = location;
+  let lineNum = 0;
+  if (colonIdx !== -1) {
+    const tail = location.slice(colonIdx + 1);
+    if (/^\d+$/.test(tail)) {
+      file = location.slice(0, colonIdx);
+      lineNum = Number(tail);
+    }
+  }
+
+  return { file, line: lineNum, skillName, summary };
+}

--- a/src/core/formal-review.ts
+++ b/src/core/formal-review.ts
@@ -1,0 +1,168 @@
+// SPEC §7.2.1 formal-review event selector.
+//
+// This is the PURE half of clud-bug-app's `lib/formal-review.ts` (the
+// Octokit-side `postFormalReview` IO wrapper stays App-side — it depends
+// on `getInstallationOctokit` + `@octokit/rest` which we don't want to
+// pull into core). The pure rule-table lives here so:
+//
+//   1. The npm workflow template's new post-step (added in v0.7.0-rc.3)
+//      can `import { selectReviewEvent } from 'clud-bug/core'` and post
+//      formal `pulls.createReview` calls under the workflow path — until
+//      this PR shipped, the workflow path NEVER satisfied the canonical
+//      ruleset's `required_approving_review_count: 1` floor because no
+//      APPROVE review was ever posted.
+//
+//   2. clud-bug-app (Phase 7 PR B) deletes its local copy and imports
+//      this version, gaining the §7.2.1 author_association extension
+//      (clud-bug-app's PR #40 shipped APPROVE without it, so the App
+//      currently auto-approves drive-by external-contributor PRs — a
+//      security bug closed by Phase 7 PR B's dep bump).
+//
+// Ported from clud-bug-app/lib/formal-review.ts (PR #40, MERGED 2026-06-10)
+// with the §7.2.1 `authorAssociation` extension new in Phase 7 PR A.
+
+/** GitHub's `pulls.createReview` `event` enum, narrowed to the three we use. */
+export type FormalReviewEvent = 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT';
+
+/**
+ * GitHub `author_association` on a PR. Verbatim union from the REST API
+ * (per https://docs.github.com/en/rest/pulls/pulls — `author_association`).
+ *
+ * The "external" tier for §7.2.1 auto-approve gating is:
+ *
+ *   { 'NONE', 'FIRST_TIME_CONTRIBUTOR', 'FIRST_TIMER', 'MANNEQUIN' }
+ *
+ * Everything else (OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR) is the
+ * "org-trusted" tier and eligible for auto-approve on a clean review.
+ *
+ * `FIRST_TIMER` is the legacy spelling (October 2018 era); GitHub
+ * currently emits `FIRST_TIME_CONTRIBUTOR` but some PR fixtures in
+ * downstream tests still carry the old token. We keep both so the
+ * external-contributor gate doesn't silently regress on the next
+ * REST-API rename.
+ */
+export type AuthorAssociation =
+  | 'OWNER'
+  | 'MEMBER'
+  | 'COLLABORATOR'
+  | 'CONTRIBUTOR'
+  | 'FIRST_TIME_CONTRIBUTOR'
+  | 'FIRST_TIMER'
+  | 'NONE'
+  | 'MANNEQUIN';
+
+/**
+ * Author-association values that route a clean-review APPROVE *down* to
+ * COMMENT per SPEC §7.2.1 precondition #3 ("PR author is an org member —
+ * NOT a first-time external contributor"). These authors still get a
+ * COMMENT review (so they SEE the bot's verdict) but the formal APPROVE
+ * vote stays withheld — a human reviewer must click Approve before the
+ * PR can merge under the canonical ruleset.
+ *
+ * Drive-by exploitation prevention: a malicious external contributor
+ * who opens a clean-looking PR cannot leverage clud-bug[bot]'s APPROVE
+ * vote to auto-merge.
+ */
+const EXTERNAL_ASSOCIATIONS: ReadonlySet<AuthorAssociation> = new Set<
+  AuthorAssociation
+>(['NONE', 'FIRST_TIME_CONTRIBUTOR', 'FIRST_TIMER', 'MANNEQUIN']);
+
+/**
+ * SPEC §7.2.1 + §7.2 rule table.
+ *
+ * Order matters — earlier rows short-circuit later ones:
+ *
+ * | Priority | Condition                                              | Event           |
+ * |----------|--------------------------------------------------------|-----------------|
+ * | 1        | PR author === clud-bug[bot]                            | 'skip'          |
+ * | 2        | authorAssociation ∈ EXTERNAL                           | 'COMMENT'       |
+ * | 3        | criticalCount > 0 AND strictMode=true                  | REQUEST_CHANGES |
+ * | 4        | criticalCount > 0 AND strictMode=false                 | COMMENT         |
+ * | 5        | minorCount > 0  (no critical)                          | COMMENT         |
+ * | 6        | 0 critical + 0 minor                                   | APPROVE         |
+ *
+ * The external-contributor row (Priority 2) sits BETWEEN self-PR-skip
+ * and the severity-driven rules: external contributors who open a
+ * critical-finding PR still get COMMENT (NOT REQUEST_CHANGES — we don't
+ * block their PR on a bot review; that's a human reviewer's call to
+ * make). External contributors who open a clean PR also get COMMENT
+ * (NOT APPROVE — the §7.2.1 precondition #3 gate).
+ *
+ * The 'skip' verdict tells the caller NOT to invoke `pulls.createReview`
+ * — GitHub returns 422 when a user reviews their own PR, so we
+ * short-circuit before the network round-trip. Self-PRs land during D.7
+ * migration fan-out (the App opens cross-repo update PRs under its own
+ * identity).
+ */
+export interface SelectReviewEventInput {
+  /** Count of `severity: critical` findings on the review. */
+  criticalCount: number;
+  /** Count of `severity: minor` findings on the review. */
+  minorCount: number;
+  /**
+   * `strictMode` flag read from `.clud-bug.json` at the PR's BASE ref.
+   * Older manifests may not carry this field — callers MUST pass
+   * `undefined` in that case so this function applies the safe default
+   * (false) rather than surprising users with REQUEST_CHANGES.
+   */
+  strictMode?: boolean;
+  /**
+   * GitHub login of the PR author. When it equals 'clud-bug[bot]' we
+   * skip the formal review entirely (GitHub disallows self-review with
+   * 422). This is the structural guard for D.7 migration fan-out PRs.
+   */
+  prAuthorLogin: string;
+  /**
+   * GitHub `author_association` on the PR. NEW in v0.7.0-rc.3 / SPEC
+   * §7.2.1: when this is in EXTERNAL_ASSOCIATIONS, a clean review gets
+   * COMMENT (not APPROVE) so external-contributor PRs require a human
+   * reviewer to satisfy the `required_approving_review_count: 1` floor.
+   *
+   * Callers that don't have this metadata (older webhook payloads,
+   * tests, etc.) should pass `'CONTRIBUTOR'` as the safe default — that
+   * tier is org-trusted and preserves pre-§7.2.1 behaviour.
+   */
+  authorAssociation: AuthorAssociation;
+}
+
+export function selectReviewEvent(
+  input: SelectReviewEventInput,
+): FormalReviewEvent | 'skip' {
+  // Priority 1: self-PR guard. GitHub returns 422 on a self-review;
+  // we short-circuit before the network round-trip. Self-PRs land
+  // during D.7 migration fan-out (the App opens cross-repo update PRs
+  // under its own identity).
+  if (input.prAuthorLogin === 'clud-bug[bot]') {
+    return 'skip';
+  }
+
+  // Priority 2: external-contributor gate (SPEC §7.2.1 precondition #3).
+  // External contributors NEVER get APPROVE (no auto-merge bypass via
+  // drive-by) and NEVER get REQUEST_CHANGES (we don't block their PR on
+  // a bot review — that escalation is a human reviewer's call). They
+  // always get an advisory COMMENT so they see the bot's verdict.
+  if (EXTERNAL_ASSOCIATIONS.has(input.authorAssociation)) {
+    return 'COMMENT';
+  }
+
+  // Priority 6 (note: priorities 3-5 fall through to here when there
+  // are no findings): clean review on an org-trusted author → APPROVE.
+  // APPROVE flips the `required_approving_review_count: 1` ruleset and
+  // lets auto-merge fire under the canonical SPEC §7.2 ruleset.
+  if (input.criticalCount === 0 && input.minorCount === 0) {
+    return 'APPROVE';
+  }
+
+  // Priority 3 + 4: critical finding → gate on strictMode. Default
+  // `strictMode === undefined` → false (advisory-only). REQUEST_CHANGES
+  // blocks the PR until the author dismisses or fixes; we only honor
+  // it when the repo opted in.
+  if (input.criticalCount > 0) {
+    return input.strictMode === true ? 'REQUEST_CHANGES' : 'COMMENT';
+  }
+
+  // Priority 5: minor-only or preexisting-only finding → advisory
+  // COMMENT. We never REQUEST_CHANGES on a minor — those are noted,
+  // not blocking.
+  return 'COMMENT';
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -116,6 +116,8 @@ export {
   WRITTEN_BY,
   SEVERITY_EMOJI as REVIEW_FILE_SEVERITY_EMOJI,
   type RenderReviewFileInput,
+  type RenderedFindingRef,
+  type CacheStats,
   type RenderMultiPassMarkdownInput,
   type MultiPassReview,
   type UnifiedFinding,
@@ -124,6 +126,31 @@ export {
   type ReviewPassMode,
   type MultiPassVerdict,
 } from './review-writeback.js';
+// SPEC §7.2.1 formal-review event selector. Pure rule-table half of
+// clud-bug-app's `lib/formal-review.ts`; the Octokit-side IO wrapper
+// (`postFormalReview`) stays App-side. v0.7.0-rc.3 adds the
+// `authorAssociation` extension so a clean review on an external
+// contributor's PR routes to COMMENT (not APPROVE) — the canonical
+// ruleset's `required_approving_review_count: 1` floor then requires
+// a human reviewer.
+export {
+  selectReviewEvent,
+  type FormalReviewEvent,
+  type AuthorAssociation,
+  type SelectReviewEventInput,
+} from './formal-review.js';
+// SPEC §1.8.1 Resolved / Still-open block helpers. `parsePriorReviewFile`
+// reads a prior `docs/reviews/PR-<n>.md`; `diffFindings` splits prior vs
+// current into resolved + still-open lists that `renderReviewFile`
+// emits as the §1.8.1 blocks. Identity scheme is shareable with future
+// inline-thread anchoring in clud-bug-app.
+export {
+  parsePriorReviewFile,
+  diffFindings,
+  findingIdentity,
+  type ParsedFinding,
+  type ParsedReview,
+} from './diff-findings.js';
 export {
   API_BASE,
   MAX_SKILLS,

--- a/src/core/review-writeback.ts
+++ b/src/core/review-writeback.ts
@@ -46,6 +46,34 @@ export const SEVERITY_EMOJI = {
   preexisting: '\u{1F7E3}', // U+1F7E3 PURPLE CIRCLE
 } as const;
 
+/**
+ * One parsed finding suitable for the SPEC §1.8.1 Resolved / Still-open
+ * blocks. Mirrors `ParsedFinding` from `./diff-findings.ts`; declared
+ * here as a structural interface (not re-imported) so callers without
+ * `diff-findings` in scope can still construct the input.
+ */
+export interface RenderedFindingRef {
+  file: string;
+  line: number;
+  severity: 'critical' | 'minor' | 'preexisting';
+  skillName: string;
+  summary: string;
+}
+
+/**
+ * SPEC §6.7.3 cache telemetry — per-invocation token counts from the
+ * Anthropic-family `usage` block. When present, the renderer emits a
+ * `<!-- cache: ... -->` HTML comment immediately below the
+ * `<!-- review-sha: ... -->` metadata line so downstream cost analysis
+ * tooling can audit cache behaviour from the committed doc-file.
+ */
+export interface CacheStats {
+  /** `cache_read_input_tokens` from the Anthropic usage block. */
+  cachedInputTokens: number;
+  /** `cache_creation_input_tokens` from the Anthropic usage block. */
+  cacheCreationInputTokens: number;
+}
+
 export interface RenderReviewFileInput {
   review: Review;
   prNumber: number;
@@ -53,6 +81,34 @@ export interface RenderReviewFileInput {
   headSha: string;
   /** GitHub PR URL — appended verbatim to the trailing rule. */
   prUrl: string;
+  /**
+   * Findings present in the prior `docs/reviews/PR-<n>.md` that are NOT
+   * present in this round's `review`. When non-empty, emits the SPEC
+   * §1.8.1 `**Resolved this round:**` block AFTER the severity buckets
+   * and BEFORE the trailing `---` separator. Omitted entirely when
+   * empty/undefined (SPEC §1.8.1: blocks MUST be omitted when empty).
+   *
+   * Produced by `diffFindings()` from `./diff-findings.ts`.
+   */
+  resolvedFindings?: RenderedFindingRef[];
+  /**
+   * Findings present in BOTH the prior `docs/reviews/PR-<n>.md` AND
+   * this round's `review` — the persistent ones. When non-empty, emits
+   * the SPEC §1.8.1 `**Still open:**` block AFTER `**Resolved this
+   * round:**` and before the trailing `---` separator. Omitted entirely
+   * when empty/undefined.
+   *
+   * Produced by `diffFindings()` from `./diff-findings.ts`.
+   */
+  stillOpenFindings?: RenderedFindingRef[];
+  /**
+   * SPEC §6.7.3 cache telemetry. When present, emits a
+   * `<!-- cache: <read> read · <created> created -->` HTML comment
+   * immediately below the `<!-- review-sha: ... -->` metadata line.
+   * Omitted entirely when undefined (this comment is OPTIONAL per the
+   * SPEC, but SHOULD be implemented for cost-analysis tooling).
+   */
+  cacheStats?: CacheStats;
 }
 
 /**
@@ -66,7 +122,15 @@ export interface RenderReviewFileInput {
  * the underlying finding data but differ in container.
  */
 export function renderReviewFile(input: RenderReviewFileInput): string {
-  const { review, prNumber, headSha, prUrl } = input;
+  const {
+    review,
+    prNumber,
+    headSha,
+    prUrl,
+    resolvedFindings,
+    stillOpenFindings,
+    cacheStats,
+  } = input;
   // Wire-shape Review carries findings in 3 severity arrays. Flatten to
   // internal `Finding[]` so the renderer's bucketing, count-derivation,
   // and per-skill aggregation can work uniformly.
@@ -83,6 +147,15 @@ export function renderReviewFile(input: RenderReviewFileInput): string {
   lines.push(`<!-- protocol-version: ${PROTOCOL_VERSION} -->`);
   lines.push(`<!-- written-by: ${WRITTEN_BY} -->`);
   lines.push(`<!-- review-sha: ${headSha} -->`);
+  // SPEC §6.7.3: cache telemetry comment goes immediately below the
+  // review-sha so a single grep can pull review-sha + cache stats out
+  // of a doc-file without re-parsing the whole block. Omitted entirely
+  // when cacheStats is undefined.
+  if (cacheStats !== undefined) {
+    lines.push(
+      `<!-- cache: ${cacheStats.cachedInputTokens} read · ${cacheStats.cacheCreationInputTokens} created -->`,
+    );
+  }
   lines.push('');
 
   // Summary line — SPEC §1.8.1 wording.
@@ -124,9 +197,31 @@ export function renderReviewFile(input: RenderReviewFileInput): string {
     lines.push('');
   }
 
-  // D.2.0 never emits "Resolved this round" / "Still open" — both lists
-  // are empty until D.2.5 (multi-pass tracking). SPEC §1.8.1 says these
-  // blocks MUST be omitted when empty.
+  // SPEC §1.8.1 Resolved this round / Still open blocks. Omitted
+  // entirely when the corresponding input list is empty/undefined.
+  //
+  // Bullet shape (one finding per line):
+  //   - `path/file.ts:42` — `critical-issues-only`: null-deref ... (was 🔴 Critical)
+  //
+  // The `(was <emoji> <Severity>)` suffix carries the SEVERITY at the
+  // time the finding was last seen so a downgrade across rounds is
+  // visible without diffing the two doc files. Note: backticks around
+  // file and skill render in markdown viewers as inline-code, which
+  // makes the file path scannable in the GitHub UI.
+  if (resolvedFindings !== undefined && resolvedFindings.length > 0) {
+    lines.push('**Resolved this round:**');
+    for (const f of resolvedFindings) {
+      lines.push(renderDiffFinding(f));
+    }
+    lines.push('');
+  }
+  if (stillOpenFindings !== undefined && stillOpenFindings.length > 0) {
+    lines.push('**Still open:**');
+    for (const f of stillOpenFindings) {
+      lines.push(renderDiffFinding(f));
+    }
+    lines.push('');
+  }
 
   lines.push('---');
   lines.push('');
@@ -146,6 +241,30 @@ function bucketBySeverity(findings: Finding[]): Record<
     minor: findings.filter((f) => f.severity === 'minor'),
     preexisting: findings.filter((f) => f.severity === 'preexisting'),
   };
+}
+
+/**
+ * Renders one finding for the SPEC §1.8.1 Resolved / Still-open blocks.
+ * Output shape:
+ *
+ *   - `path/file.ts:42` — `critical-issues-only`: null-deref ... (was 🔴 Critical)
+ *
+ * Line `0` is treated as "no anchor" (cross-cutting / missing) and the
+ * `:N` suffix is omitted. The severity label uses the SPEC §1.8.1
+ * emoji + label so a reader can see at a glance whether the finding
+ * was downgraded (different severity in current round) or merely
+ * resolved.
+ */
+function renderDiffFinding(f: RenderedFindingRef): string {
+  const location = f.line > 0 ? `${f.file}:${f.line}` : f.file;
+  const label =
+    f.severity === 'critical'
+      ? 'Critical'
+      : f.severity === 'minor'
+        ? 'Minor'
+        : 'Preexisting';
+  const emoji = SEVERITY_EMOJI[f.severity];
+  return `- \`${location}\` — \`${f.skillName}\`: ${f.summary} (was ${emoji} ${label})`;
 }
 
 function renderFinding(f: Finding, includeReasoning: boolean): string {

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -366,9 +366,52 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.2
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].
           # See workflow.yml.tmpl for design notes.
           bot-login: 'github-actions[bot]'
+
+      # v0.7.0-rc.3 — SPEC §7.2.1 formal-review event poster.
+      # See workflow.yml.tmpl for full design rationale; this step
+      # bridges the canonical-ruleset `required_approving_review_count: 1`
+      # floor on the npm workflow path. Best-effort: never fails the
+      # workflow (continue-on-error). Drive-by exploit guard: external
+      # contributors NEVER get APPROVE.
+      - name: Formal review — APPROVE / REQUEST_CHANGES / COMMENT
+        if: always() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -uo pipefail
+          STRICT_MODE=false
+          if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
+            if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
+              STRICT_MODE=true
+            fi
+          fi
+          export STRICT_MODE
+          VERDICT=$(printf '%s\n' "$STRUCTURED" \
+            | npx --yes clud-bug@{{CLUD_BUG_VERSION}} select-review-event --stdin \
+            | tail -n1)
+          VERDICT="${VERDICT:-skip}"
+          echo "::notice title=Clud Bug 🐛::Formal review verdict: $VERDICT (strictMode=$STRICT_MODE, author_assoc=$PR_AUTHOR_ASSOCIATION)"
+          if [ "$VERDICT" = "skip" ]; then
+            exit 0
+          fi
+          BODY=$(printf 'Automated formal review by clud-bug — see the summary comment for the substantive findings.\n\nVerdict: **%s**\n\n<!-- clud-bug-formal-review: workflow-path v0.7.0-rc.3 -->' "$VERDICT")
+          gh api -X POST "/repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            -f event="$VERDICT" \
+            -f commit_id="$HEAD_SHA" \
+            -f body="$BODY" \
+            > /dev/null \
+            || echo "::warning title=Clud Bug 🐛::Formal review POST failed (likely 422 self-PR or missing perms); degrading to comment-only."

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -366,9 +366,52 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.2
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].
           # See workflow.yml.tmpl for design notes.
           bot-login: 'github-actions[bot]'
+
+      # v0.7.0-rc.3 — SPEC §7.2.1 formal-review event poster.
+      # See workflow.yml.tmpl for full design rationale; this step
+      # bridges the canonical-ruleset `required_approving_review_count: 1`
+      # floor on the npm workflow path. Best-effort: never fails the
+      # workflow (continue-on-error). Drive-by exploit guard: external
+      # contributors NEVER get APPROVE.
+      - name: Formal review — APPROVE / REQUEST_CHANGES / COMMENT
+        if: always() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -uo pipefail
+          STRICT_MODE=false
+          if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
+            if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
+              STRICT_MODE=true
+            fi
+          fi
+          export STRICT_MODE
+          VERDICT=$(printf '%s\n' "$STRUCTURED" \
+            | npx --yes clud-bug@{{CLUD_BUG_VERSION}} select-review-event --stdin \
+            | tail -n1)
+          VERDICT="${VERDICT:-skip}"
+          echo "::notice title=Clud Bug 🐛::Formal review verdict: $VERDICT (strictMode=$STRICT_MODE, author_assoc=$PR_AUTHOR_ASSOCIATION)"
+          if [ "$VERDICT" = "skip" ]; then
+            exit 0
+          fi
+          BODY=$(printf 'Automated formal review by clud-bug — see the summary comment for the substantive findings.\n\nVerdict: **%s**\n\n<!-- clud-bug-formal-review: workflow-path v0.7.0-rc.3 -->' "$VERDICT")
+          gh api -X POST "/repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            -f event="$VERDICT" \
+            -f commit_id="$HEAD_SHA" \
+            -f body="$BODY" \
+            > /dev/null \
+            || echo "::warning title=Clud Bug 🐛::Formal review POST failed (likely 422 self-PR or missing perms); degrading to comment-only."

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -641,7 +641,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.2
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow
@@ -651,3 +651,98 @@ jobs:
           # never matches the new summary author → strict mode falls
           # open advisory for every install that opted in.
           bot-login: 'github-actions[bot]'
+
+      # v0.7.0-rc.3 — SPEC §7.2.1 formal-review event poster.
+      #
+      # Why this step exists: the canonical ruleset (SPEC §7.2) pins
+      # `required_approving_review_count: 1`. Before this step, the
+      # workflow path posted only a summary issue comment + a
+      # `clud-bug-review` check-run — neither of which counts as an
+      # approving review. So every PR on the workflow path required a
+      # human to click Approve, even when the bot's verdict was clean.
+      #
+      # This step bridges that gap: it pipes the same structured_output
+      # the render step consumed through `clud-bug select-review-event`
+      # (SPEC §7.2.1 rule table) and, on org-trusted authors, posts a
+      # formal `pulls.createReview` with `event=APPROVE` so the
+      # `required_approving_review_count: 1` floor flips automatically.
+      #
+      # Drive-by exploit guard: external contributors NEVER get APPROVE.
+      # The select-review-event verdict for any author in
+      # {NONE, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, MANNEQUIN} is forced
+      # to COMMENT — a human reviewer must explicitly Approve. See
+      # SPEC §7.2.1 precondition #3.
+      #
+      # Best-effort contract: this step MUST NEVER fail the workflow.
+      # `continue-on-error: true` ensures a malformed payload, network
+      # blip, or rate-limit on the formal-review API can't undo the
+      # already-posted summary comment. Worst case: no formal review is
+      # posted, falling back to today's comment-only behavior (= the
+      # pre-rc.3 status quo).
+      #
+      # Self-PR guard: when the PR author is `clud-bug[bot]` (D.7
+      # migration fan-out path that clud-bug-app authors), the verdict
+      # is "skip" — GitHub returns 422 on self-review, so we short-
+      # circuit before the network call.
+      - name: Formal review — APPROVE / REQUEST_CHANGES / COMMENT
+        if: always() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+          # SPEC §7.2.1 fields. The select-review-event command reads
+          # these from env (NOT stdin) so the workflow doesn't have to
+          # construct a nested JSON shape.
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -uo pipefail
+
+          # Resolve strictMode from the BASE ref's manifest — same
+          # discipline as strict-mode-gate (a PR can't opt itself out
+          # of strict mode by editing its own .clud-bug.json). Best-
+          # effort: any error here falls through to STRICT_MODE=false.
+          STRICT_MODE=false
+          if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
+            if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
+              STRICT_MODE=true
+            fi
+          fi
+          export STRICT_MODE
+
+          # Compute the verdict (one of: APPROVE / REQUEST_CHANGES /
+          # COMMENT / skip). The command degrades to "skip" on any
+          # caller-side error (malformed JSON, missing env), so we never
+          # need a fallback in shell.
+          VERDICT=$(printf '%s\n' "$STRUCTURED" \
+            | npx --yes clud-bug@{{CLUD_BUG_VERSION}} select-review-event --stdin \
+            | tail -n1)
+          VERDICT="${VERDICT:-skip}"
+
+          echo "::notice title=Clud Bug 🐛::Formal review verdict: $VERDICT (strictMode=$STRICT_MODE, author_assoc=$PR_AUTHOR_ASSOCIATION)"
+
+          if [ "$VERDICT" = "skip" ]; then
+            # Self-PR or caller-error case. No formal review posted;
+            # the summary comment + check-run remain the visible review
+            # surface. This is the pre-rc.3 status quo.
+            exit 0
+          fi
+
+          # Body is short + machine-pingable: human reviewers see the
+          # summary issue comment for the substantive review surface;
+          # the formal-review body is a cross-link.
+          BODY=$(printf 'Automated formal review by clud-bug — see the summary comment for the substantive findings.\n\nVerdict: **%s**\n\n<!-- clud-bug-formal-review: workflow-path v0.7.0-rc.3 -->' "$VERDICT")
+
+          # gh api fires `pulls.createReview` with the verdict event.
+          # commit_id pins the review to the exact SHA we reviewed so a
+          # later push doesn't auto-extend the approval scope.
+          gh api -X POST "/repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            -f event="$VERDICT" \
+            -f commit_id="$HEAD_SHA" \
+            -f body="$BODY" \
+            > /dev/null \
+            || echo "::warning title=Clud Bug 🐛::Formal review POST failed (likely 422 self-PR or missing perms); degrading to comment-only."

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -345,3 +345,152 @@ test('refresh --offline shows no-op when only baseline installed', async () => {
     assert.match(r.stdout, /sync with skills\.sh|collection updated/);
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
+
+// ---------------------------------------------------------------------------
+// v0.7.0-rc.3 — select-review-event subcommand for the workflow post-step.
+// SPEC §7.2.1 formal-review event selector. Robustness contract: NEVER
+// fails the workflow on caller-side problems — degrades to "skip" + 0.
+// ---------------------------------------------------------------------------
+
+function runSelectReviewEvent(input, env = {}) {
+  return run(process.cwd(), ['select-review-event', '--stdin'], { input, env });
+}
+
+test('select-review-event: clean review on org member → APPROVE', () => {
+  const payload = JSON.stringify({
+    critical_findings: [],
+    minor_findings: [],
+    preexisting_findings: [],
+  });
+  const r = runSelectReviewEvent(payload, {
+    PR_AUTHOR_LOGIN: 'octocat',
+    PR_AUTHOR_ASSOCIATION: 'MEMBER',
+    STRICT_MODE: 'false',
+  });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(r.stdout.trim(), 'APPROVE');
+});
+
+test('select-review-event: external contributor + clean review → COMMENT (NEVER APPROVE)', () => {
+  // The §7.2.1 drive-by-exploit guard. External contributors NEVER get
+  // APPROVE — auto-merge requires a human reviewer.
+  const payload = JSON.stringify({
+    critical_findings: [],
+    minor_findings: [],
+    preexisting_findings: [],
+  });
+  const r = runSelectReviewEvent(payload, {
+    PR_AUTHOR_LOGIN: 'drive-by',
+    PR_AUTHOR_ASSOCIATION: 'FIRST_TIME_CONTRIBUTOR',
+    STRICT_MODE: 'false',
+  });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(r.stdout.trim(), 'COMMENT');
+});
+
+test('select-review-event: critical + strictMode=true on org member → REQUEST_CHANGES', () => {
+  const payload = JSON.stringify({
+    critical_findings: [
+      { skill: 'race', file: 'a.ts', line: 1, summary: 'A' },
+    ],
+    minor_findings: [],
+    preexisting_findings: [],
+  });
+  const r = runSelectReviewEvent(payload, {
+    PR_AUTHOR_LOGIN: 'octocat',
+    PR_AUTHOR_ASSOCIATION: 'MEMBER',
+    STRICT_MODE: 'true',
+  });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(r.stdout.trim(), 'REQUEST_CHANGES');
+});
+
+test('select-review-event: self-PR (clud-bug[bot]) → skip', () => {
+  const payload = JSON.stringify({
+    critical_findings: [],
+    minor_findings: [],
+    preexisting_findings: [],
+  });
+  const r = runSelectReviewEvent(payload, {
+    PR_AUTHOR_LOGIN: 'clud-bug[bot]',
+    PR_AUTHOR_ASSOCIATION: 'MEMBER',
+    STRICT_MODE: 'false',
+  });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(r.stdout.trim(), 'skip');
+});
+
+test('select-review-event: empty stdin → skip + stderr note (workflow degrades)', () => {
+  const r = runSelectReviewEvent('', {
+    PR_AUTHOR_LOGIN: 'octocat',
+    PR_AUTHOR_ASSOCIATION: 'MEMBER',
+    STRICT_MODE: 'false',
+  });
+  // Must exit 0 — the workflow MUST NOT fail on missing review output.
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(r.stdout.trim(), 'skip');
+  assert.match(r.stderr, /stdin empty/);
+});
+
+test('select-review-event: malformed JSON → skip + stderr note (workflow degrades)', () => {
+  const r = runSelectReviewEvent('not valid json {{{', {
+    PR_AUTHOR_LOGIN: 'octocat',
+    PR_AUTHOR_ASSOCIATION: 'MEMBER',
+    STRICT_MODE: 'false',
+  });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(r.stdout.trim(), 'skip');
+  assert.match(r.stderr, /JSON parse failed/);
+});
+
+test('select-review-event: missing PR_AUTHOR_LOGIN → skip', () => {
+  // PR_AUTHOR_LOGIN is the structural guard — without it we can't safely
+  // run the self-PR check, so we skip rather than risk a self-review 422.
+  // Pass PR_AUTHOR_LOGIN='' explicitly so the inherited test-process env
+  // (whatever its value) can't satisfy the check.
+  const payload = JSON.stringify({ critical_findings: [], minor_findings: [] });
+  const r = runSelectReviewEvent(payload, {
+    PR_AUTHOR_LOGIN: '',
+    PR_AUTHOR_ASSOCIATION: 'MEMBER',
+    STRICT_MODE: 'false',
+  });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(r.stdout.trim(), 'skip');
+});
+
+test('select-review-event: missing PR_AUTHOR_ASSOCIATION → defaults to CONTRIBUTOR (org-trusted)', () => {
+  // Older webhook payloads / non-GH callers may not pass author_association.
+  // We default to CONTRIBUTOR so the §7.2.1-naive caller's behaviour is
+  // PRESERVED (would have APPROVED on a clean review), not silently
+  // degraded to COMMENT.
+  const payload = JSON.stringify({ critical_findings: [], minor_findings: [] });
+  const r = runSelectReviewEvent(payload, {
+    PR_AUTHOR_LOGIN: 'octocat',
+    PR_AUTHOR_ASSOCIATION: '',  // explicitly empty — inherited env can't pollute
+    STRICT_MODE: 'false',
+  });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(r.stdout.trim(), 'APPROVE');
+});
+
+test('select-review-event: minor-only on member → COMMENT', () => {
+  const payload = JSON.stringify({
+    critical_findings: [],
+    minor_findings: [{ skill: 'style', file: 'a.ts', line: 1, summary: 'A' }],
+    preexisting_findings: [],
+  });
+  const r = runSelectReviewEvent(payload, {
+    PR_AUTHOR_LOGIN: 'octocat',
+    PR_AUTHOR_ASSOCIATION: 'MEMBER',
+    STRICT_MODE: 'true',
+  });
+  assert.equal(r.status, 0, r.stderr);
+  // Strict mode does NOT escalate minors per SPEC §7.2.1.
+  assert.equal(r.stdout.trim(), 'COMMENT');
+});
+
+test('--help advertises select-review-event subcommand', () => {
+  const r = run(process.cwd(), ['--help']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /select-review-event/);
+});

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -458,6 +458,28 @@ test('select-review-event: missing PR_AUTHOR_LOGIN → skip', () => {
   assert.equal(r.stdout.trim(), 'skip');
 });
 
+test('select-review-event: unrecognized PR_AUTHOR_ASSOCIATION → COMMENT (fail-closed per §7.2.1)', () => {
+  // clud-bug-review #163 caught a fail-open default: a future REST-API
+  // rename of an external tier (e.g. GitHub introduces a new external
+  // token) would silently route a clean drive-by PR to APPROVE under
+  // the old logic. The §7.2.1 gate exists explicitly to defend against
+  // this — the fallback MUST treat unrecognized non-empty values as
+  // external → COMMENT, NEVER APPROVE. If the rename was for a still-
+  // trusted tier the cost is one extra human Approve click; if it was
+  // for a new external tier we've closed the auto-merge exploit.
+  const payload = JSON.stringify({ critical_findings: [], minor_findings: [] });
+  const r = runSelectReviewEvent(payload, {
+    PR_AUTHOR_LOGIN: 'octocat',
+    PR_AUTHOR_ASSOCIATION: 'FUTURE_GH_TIER_2027',  // a token we don't recognize
+    STRICT_MODE: 'false',
+  });
+  assert.equal(r.status, 0, r.stderr);
+  // Clean review on UNRECOGNIZED → COMMENT (fail-closed). NEVER APPROVE.
+  assert.equal(r.stdout.trim(), 'COMMENT');
+  // Operator-visible warning so the rename surface is detectable.
+  assert.match(r.stderr, /unrecognized PR_AUTHOR_ASSOCIATION/);
+});
+
 test('select-review-event: missing PR_AUTHOR_ASSOCIATION → defaults to CONTRIBUTOR (org-trusted)', () => {
   // Older webhook payloads / non-GH callers may not pass author_association.
   // We default to CONTRIBUTOR so the §7.2.1-naive caller's behaviour is

--- a/test/diff-findings.test.js
+++ b/test/diff-findings.test.js
@@ -1,0 +1,390 @@
+// Tests for src/core/diff-findings.ts — SPEC §1.8.1 Resolved / Still-open
+// block helpers. Covers:
+//   - parsePriorReviewFile robustness (null, empty, malformed, well-formed)
+//   - diffFindings split logic (null prior, empty current, identical, partial)
+//   - findingIdentity stability across rounds
+//   - severity-bucket change counts as resolved (different identity by design)
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  parsePriorReviewFile,
+  diffFindings,
+  findingIdentity,
+} from '../src/core/diff-findings.js';
+import {
+  parsePriorReviewFile as barrelParse,
+  diffFindings as barrelDiff,
+  findingIdentity as barrelIdentity,
+} from '../src/core/index.js';
+import { renderReviewFile } from '../src/core/review-writeback.js';
+
+// ---------------------------------------------------------------------------
+// parsePriorReviewFile — robustness
+// ---------------------------------------------------------------------------
+
+describe('parsePriorReviewFile: robustness', () => {
+  it('returns null on null input', () => {
+    expect(parsePriorReviewFile(null)).toBeNull();
+  });
+
+  it('returns null on undefined input', () => {
+    expect(parsePriorReviewFile(undefined)).toBeNull();
+  });
+
+  it('returns null on empty markdown', () => {
+    expect(parsePriorReviewFile('')).toBeNull();
+  });
+
+  it('returns null on whitespace-only markdown', () => {
+    expect(parsePriorReviewFile('   \n\n  \n')).toBeNull();
+  });
+
+  it('returns null on completely unrelated markdown (no severity sections)', () => {
+    expect(
+      parsePriorReviewFile('# Hello\n\nThis is not a review file.'),
+    ).toBeNull();
+  });
+
+  it('drops malformed bullet lines silently (no throw, no spurious findings)', () => {
+    // The "bullet" lines below are not valid SPEC §1.8.1 finding lines.
+    const md = [
+      '# clud-bug review — PR #1',
+      '',
+      '### \u{1F534} Critical',
+      '- this is not a bullet',
+      '- **no closing bold (missing)',
+      '- ** ** — — empty',
+      '',
+    ].join('\n');
+    expect(parsePriorReviewFile(md)).toBeNull();
+  });
+
+  it('parses a well-formed single-finding doc', () => {
+    const md = [
+      '# clud-bug review — PR #1',
+      '<!-- protocol-version: 0.1.0 -->',
+      '<!-- written-by: clud-bug[bot] -->',
+      '<!-- review-sha: abc -->',
+      '',
+      '**Summary:** 1 critical · 0 minor · 0 preexisting · 0 resolved-from-prior · 0 still-open',
+      '',
+      '**Findings:**',
+      '',
+      '### \u{1F534} Critical',
+      '- **src/auth.ts:42** — race-conditions: Race condition on token refresh',
+      '  Reasoning: Two async calls can interleave.',
+      '',
+      '---',
+      '',
+      '[Link to PR](https://github.com/foo/bar/pull/1)',
+    ].join('\n');
+    const parsed = parsePriorReviewFile(md);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.findings.length).toBe(1);
+    expect(parsed?.findings[0]).toEqual({
+      file: 'src/auth.ts',
+      line: 42,
+      severity: 'critical',
+      skillName: 'race-conditions',
+      summary: 'Race condition on token refresh',
+    });
+  });
+
+  it('parses a multi-bucket doc with correct severity tagging', () => {
+    const md = [
+      '### \u{1F534} Critical',
+      '- **a.ts:1** — race: A',
+      '- **b.ts:2** — race: B',
+      '',
+      '### \u{1F7E1} Minor',
+      '- **c.ts:3** — style: C',
+      '',
+      '### \u{1F7E3} Preexisting (informational)',
+      '- **d.ts:4** — types: D',
+      '',
+    ].join('\n');
+    const parsed = parsePriorReviewFile(md);
+    expect(parsed?.findings.length).toBe(4);
+    expect(parsed?.findings[0]?.severity).toBe('critical');
+    expect(parsed?.findings[1]?.severity).toBe('critical');
+    expect(parsed?.findings[2]?.severity).toBe('minor');
+    expect(parsed?.findings[3]?.severity).toBe('preexisting');
+  });
+
+  it('accepts cross-cutting findings without :line anchor', () => {
+    const md = [
+      '### \u{1F534} Critical',
+      '- **README.md** — docs: missing intro section',
+      '',
+    ].join('\n');
+    const parsed = parsePriorReviewFile(md);
+    expect(parsed?.findings.length).toBe(1);
+    expect(parsed?.findings[0]?.file).toBe('README.md');
+    expect(parsed?.findings[0]?.line).toBe(0);
+  });
+
+  it('accepts (unknown file) markers and preserves them verbatim', () => {
+    const md = [
+      '### \u{1F534} Critical',
+      '- **(unknown file)** — race: cross-cutting',
+      '',
+    ].join('\n');
+    const parsed = parsePriorReviewFile(md);
+    expect(parsed?.findings[0]?.file).toBe('(unknown file)');
+  });
+
+  it('ignores Resolved / Still-open blocks (does not double-count history)', () => {
+    const md = [
+      '### \u{1F534} Critical',
+      '- **a.ts:1** — race: A',
+      '',
+      '**Resolved this round:**',
+      '- `b.ts:2` — `race`: B (was 🔴 Critical)',
+      '',
+      '**Still open:**',
+      '- `c.ts:3` — `race`: C (was 🔴 Critical)',
+      '',
+    ].join('\n');
+    const parsed = parsePriorReviewFile(md);
+    // Only the in-bucket finding is captured; Resolved/Still-open
+    // entries are skipped because they describe PRIOR rounds.
+    expect(parsed?.findings.length).toBe(1);
+    expect(parsed?.findings[0]?.file).toBe('a.ts');
+  });
+
+  it('parses multi-pass attribution prefix and strips it from the bullet', () => {
+    const md = [
+      '### \u{1F534} Critical',
+      '- [Pass 1 — Beetle · sonnet] **a.ts:1** — race: A',
+      '',
+    ].join('\n');
+    const parsed = parsePriorReviewFile(md);
+    expect(parsed?.findings.length).toBe(1);
+    expect(parsed?.findings[0]?.file).toBe('a.ts');
+    expect(parsed?.findings[0]?.skillName).toBe('race');
+    expect(parsed?.findings[0]?.summary).toBe('A');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// diffFindings — split logic
+// ---------------------------------------------------------------------------
+
+describe('diffFindings: split logic', () => {
+  const priorWithThree = {
+    findings: [
+      { file: 'a.ts', line: 1, severity: 'critical', skillName: 'race', summary: 'A' },
+      { file: 'b.ts', line: 2, severity: 'critical', skillName: 'race', summary: 'B' },
+      { file: 'c.ts', line: 3, severity: 'minor', skillName: 'style', summary: 'C' },
+    ],
+  };
+
+  it('null prior → no resolved, no still-open', () => {
+    const result = diffFindings(null, {
+      critical_findings: [
+        { skill: 'race', file: 'a.ts', line: 1, summary: 'A' },
+      ],
+    });
+    expect(result.resolvedFindings).toEqual([]);
+    expect(result.stillOpenFindings).toEqual([]);
+  });
+
+  it('empty current → all prior become resolved', () => {
+    const result = diffFindings(priorWithThree, {
+      critical_findings: [],
+      minor_findings: [],
+      preexisting_findings: [],
+    });
+    expect(result.resolvedFindings.length).toBe(3);
+    expect(result.stillOpenFindings).toEqual([]);
+  });
+
+  it('completely empty current (no arrays at all) → all prior become resolved', () => {
+    const result = diffFindings(priorWithThree, {});
+    expect(result.resolvedFindings.length).toBe(3);
+    expect(result.stillOpenFindings).toEqual([]);
+  });
+
+  it('identical → no resolved, all still-open', () => {
+    const result = diffFindings(priorWithThree, {
+      critical_findings: [
+        { skill: 'race', file: 'a.ts', line: 1, summary: 'A' },
+        { skill: 'race', file: 'b.ts', line: 2, summary: 'B' },
+      ],
+      minor_findings: [{ skill: 'style', file: 'c.ts', line: 3, summary: 'C' }],
+    });
+    expect(result.resolvedFindings).toEqual([]);
+    expect(result.stillOpenFindings.length).toBe(3);
+  });
+
+  it('partial overlap → correct split', () => {
+    // a.ts:1 (resolved), b.ts:2 (still open), c.ts:3 (resolved)
+    const result = diffFindings(priorWithThree, {
+      critical_findings: [{ skill: 'race', file: 'b.ts', line: 2, summary: 'B' }],
+    });
+    expect(result.resolvedFindings.length).toBe(2);
+    expect(result.stillOpenFindings.length).toBe(1);
+    expect(result.stillOpenFindings[0]?.file).toBe('b.ts');
+    // Prior-order preserved in resolved (a.ts before c.ts).
+    expect(result.resolvedFindings[0]?.file).toBe('a.ts');
+    expect(result.resolvedFindings[1]?.file).toBe('c.ts');
+  });
+
+  it('severity-bucket change (critical → minor on the same line) counts as resolved + new', () => {
+    // Same file/line/skill/summary, severity changed → DIFFERENT identity.
+    // This is by design: a downgrade is a fix (full credit) + a new
+    // finding (the bot still has a concern). The renderer surfaces both
+    // in their respective buckets.
+    const prior = {
+      findings: [
+        {
+          file: 'a.ts',
+          line: 1,
+          severity: 'critical',
+          skillName: 'race',
+          summary: 'A',
+        },
+      ],
+    };
+    const result = diffFindings(prior, {
+      minor_findings: [{ skill: 'race', file: 'a.ts', line: 1, summary: 'A' }],
+    });
+    expect(result.resolvedFindings.length).toBe(1);
+    expect(result.resolvedFindings[0]?.severity).toBe('critical');
+    expect(result.stillOpenFindings).toEqual([]);
+  });
+
+  it('malformed prior markdown → parse returns null → diff is no-op', () => {
+    const prior = parsePriorReviewFile('not a review');
+    expect(prior).toBeNull();
+    const result = diffFindings(prior, {
+      critical_findings: [{ skill: 'race', file: 'a.ts', line: 1, summary: 'A' }],
+    });
+    expect(result.resolvedFindings).toEqual([]);
+    expect(result.stillOpenFindings).toEqual([]);
+  });
+
+  it('cross-cutting (line=0) findings diff correctly', () => {
+    const prior = {
+      findings: [
+        {
+          file: 'README.md',
+          line: 0,
+          severity: 'critical',
+          skillName: 'docs',
+          summary: 'missing intro',
+        },
+      ],
+    };
+    const result = diffFindings(prior, {
+      critical_findings: [
+        // Same file, no line (omitted), same skill + summary → identical id.
+        { skill: 'docs', file: 'README.md', summary: 'missing intro' },
+      ],
+    });
+    expect(result.resolvedFindings).toEqual([]);
+    expect(result.stillOpenFindings.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findingIdentity — stability
+// ---------------------------------------------------------------------------
+
+describe('findingIdentity: hash shape stability', () => {
+  it('produces identical id for identical fields', () => {
+    const a = {
+      file: 'a.ts',
+      line: 1,
+      severity: /** @type {const} */ ('critical'),
+      skillName: 'race',
+      summary: 'Race condition on token refresh',
+    };
+    const b = { ...a };
+    expect(findingIdentity(a)).toBe(findingIdentity(b));
+  });
+
+  it('produces different id when severity differs (downgrade is a different finding)', () => {
+    const a = {
+      file: 'a.ts',
+      line: 1,
+      severity: /** @type {const} */ ('critical'),
+      skillName: 'race',
+      summary: 'A',
+    };
+    const b = { ...a, severity: /** @type {const} */ ('minor') };
+    expect(findingIdentity(a)).not.toBe(findingIdentity(b));
+  });
+
+  it('truncates summary at 100 chars for identity', () => {
+    // Two summaries differing only past character 100 should hash to
+    // the same id — absorbs minor wording drift between rounds.
+    const baseHundred = 'x'.repeat(100);
+    const a = {
+      file: 'a.ts',
+      line: 1,
+      severity: /** @type {const} */ ('critical'),
+      skillName: 'race',
+      summary: `${baseHundred}-rest-A`,
+    };
+    const b = {
+      file: 'a.ts',
+      line: 1,
+      severity: /** @type {const} */ ('critical'),
+      skillName: 'race',
+      summary: `${baseHundred}-rest-B`,
+    };
+    expect(findingIdentity(a)).toBe(findingIdentity(b));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// barrel re-export equivalence
+// ---------------------------------------------------------------------------
+
+describe('barrel: clud-bug/core re-exports diff-findings helpers', () => {
+  it('parsePriorReviewFile is the same identity', () => {
+    expect(barrelParse).toBe(parsePriorReviewFile);
+  });
+  it('diffFindings is the same identity', () => {
+    expect(barrelDiff).toBe(diffFindings);
+  });
+  it('findingIdentity is the same identity', () => {
+    expect(barrelIdentity).toBe(findingIdentity);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Roundtrip: render → parse → diff (smoke test for parse against the
+// renderer's actual output shape). Catches drift between the two halves
+// if either is later changed in isolation.
+// ---------------------------------------------------------------------------
+
+describe('roundtrip: renderReviewFile output is parsable by parsePriorReviewFile', () => {
+  it('renderReviewFile → parsePriorReviewFile recovers the same findings', () => {
+    const md = renderReviewFile({
+      review: {
+        status_header: 'critical findings',
+        summary_counts: {
+          critical: 2, minor: 1, preexisting: 0, resolved_from_prior: 0, still_open: 0,
+        },
+        per_skill_scan: [],
+        critical_findings: [
+          { skill: 'race', file: 'a.ts', line: 1, summary: 'A' },
+          { skill: 'race', file: 'b.ts', line: 2, summary: 'B' },
+        ],
+        minor_findings: [{ skill: 'style', file: 'c.ts', line: 3, summary: 'C' }],
+        preexisting_findings: [],
+        skills_referenced: ['race', 'style'],
+        last_reviewed_sha: '0'.repeat(40),
+      },
+      prNumber: 1,
+      headSha: '1'.repeat(40),
+      prUrl: 'https://github.com/foo/bar/pull/1',
+    });
+    const parsed = parsePriorReviewFile(md);
+    expect(parsed?.findings.length).toBe(3);
+    expect(parsed?.findings.map((f) => f.file)).toEqual(['a.ts', 'b.ts', 'c.ts']);
+  });
+});

--- a/test/formal-review.test.js
+++ b/test/formal-review.test.js
@@ -1,0 +1,201 @@
+// Table-driven tests for SPEC §7.2.1 selectReviewEvent — the pure
+// formal-review event selector.
+//
+// Covers:
+//   - self-PR skip (D.7 migration fan-out path)
+//   - external-contributor gate (NEW in v0.7.0-rc.3 — drive-by exploit fix)
+//   - severity-driven event selection on org-trusted authors
+//   - strict-mode escalation matrix
+//
+// Equivalence with clud-bug-app/lib/formal-review.ts is implicit via the
+// shared rule shape; clud-bug-app's Phase 7 PR B will delete its local
+// copy and import this version.
+
+import { describe, expect, it } from 'vitest';
+
+import { selectReviewEvent } from '../src/core/formal-review.js';
+import { selectReviewEvent as barrelSelectReviewEvent } from '../src/core/index.js';
+
+describe('selectReviewEvent: self-PR guard (priority 1)', () => {
+  const base = {
+    criticalCount: 0,
+    minorCount: 0,
+    strictMode: false,
+    prAuthorLogin: 'clud-bug[bot]',
+    authorAssociation: /** @type {const} */ ('OWNER'),
+  };
+
+  it('skips on clud-bug[bot] author even with a clean review', () => {
+    expect(selectReviewEvent(base)).toBe('skip');
+  });
+
+  it('skips on clud-bug[bot] author even with critical + strict (self-skip wins)', () => {
+    expect(
+      selectReviewEvent({ ...base, criticalCount: 1, strictMode: true }),
+    ).toBe('skip');
+  });
+
+  it('skips on clud-bug[bot] author regardless of authorAssociation', () => {
+    expect(
+      selectReviewEvent({
+        ...base,
+        criticalCount: 0,
+        authorAssociation: 'MEMBER',
+      }),
+    ).toBe('skip');
+  });
+});
+
+describe('selectReviewEvent: external-contributor gate (priority 2, NEW §7.2.1)', () => {
+  const externalAssociations = /** @type {const} */ ([
+    'NONE',
+    'FIRST_TIME_CONTRIBUTOR',
+    'FIRST_TIMER',
+    'MANNEQUIN',
+  ]);
+
+  // The defining §7.2.1 invariant: external contributors NEVER get
+  // APPROVE on a clean review (drive-by exploit of auto-merge is the
+  // closed security bug).
+  for (const aa of externalAssociations) {
+    it(`${aa} + clean review → COMMENT (NEVER APPROVE)`, () => {
+      expect(
+        selectReviewEvent({
+          criticalCount: 0,
+          minorCount: 0,
+          strictMode: false,
+          prAuthorLogin: 'drive-by-user',
+          authorAssociation: aa,
+        }),
+      ).toBe('COMMENT');
+    });
+
+    it(`${aa} + critical + strictMode=true → COMMENT (NEVER REQUEST_CHANGES — don't block external)`, () => {
+      expect(
+        selectReviewEvent({
+          criticalCount: 1,
+          minorCount: 0,
+          strictMode: true,
+          prAuthorLogin: 'drive-by-user',
+          authorAssociation: aa,
+        }),
+      ).toBe('COMMENT');
+    });
+
+    it(`${aa} + critical + strictMode=false → COMMENT`, () => {
+      expect(
+        selectReviewEvent({
+          criticalCount: 2,
+          minorCount: 1,
+          strictMode: false,
+          prAuthorLogin: 'drive-by-user',
+          authorAssociation: aa,
+        }),
+      ).toBe('COMMENT');
+    });
+
+    it(`${aa} + minor-only → COMMENT`, () => {
+      expect(
+        selectReviewEvent({
+          criticalCount: 0,
+          minorCount: 3,
+          strictMode: false,
+          prAuthorLogin: 'drive-by-user',
+          authorAssociation: aa,
+        }),
+      ).toBe('COMMENT');
+    });
+  }
+});
+
+describe('selectReviewEvent: org-trusted authors (priority 3-6)', () => {
+  const trustedAssociations = /** @type {const} */ ([
+    'OWNER',
+    'MEMBER',
+    'COLLABORATOR',
+    'CONTRIBUTOR',
+  ]);
+
+  // The matrix: org-trusted × clean/critical/minor × strict on/off.
+  for (const aa of trustedAssociations) {
+    it(`${aa} + clean review → APPROVE`, () => {
+      expect(
+        selectReviewEvent({
+          criticalCount: 0,
+          minorCount: 0,
+          strictMode: false,
+          prAuthorLogin: 'trusted-user',
+          authorAssociation: aa,
+        }),
+      ).toBe('APPROVE');
+    });
+
+    it(`${aa} + critical + strictMode=true → REQUEST_CHANGES`, () => {
+      expect(
+        selectReviewEvent({
+          criticalCount: 1,
+          minorCount: 0,
+          strictMode: true,
+          prAuthorLogin: 'trusted-user',
+          authorAssociation: aa,
+        }),
+      ).toBe('REQUEST_CHANGES');
+    });
+
+    it(`${aa} + critical + strictMode=false → COMMENT (advisory only)`, () => {
+      expect(
+        selectReviewEvent({
+          criticalCount: 1,
+          minorCount: 0,
+          strictMode: false,
+          prAuthorLogin: 'trusted-user',
+          authorAssociation: aa,
+        }),
+      ).toBe('COMMENT');
+    });
+
+    it(`${aa} + critical + strictMode=undefined → COMMENT (safe default; older manifest)`, () => {
+      expect(
+        selectReviewEvent({
+          criticalCount: 1,
+          minorCount: 0,
+          strictMode: undefined,
+          prAuthorLogin: 'trusted-user',
+          authorAssociation: aa,
+        }),
+      ).toBe('COMMENT');
+    });
+
+    it(`${aa} + minor-only → COMMENT`, () => {
+      expect(
+        selectReviewEvent({
+          criticalCount: 0,
+          minorCount: 1,
+          strictMode: false,
+          prAuthorLogin: 'trusted-user',
+          authorAssociation: aa,
+        }),
+      ).toBe('COMMENT');
+    });
+
+    it(`${aa} + minor-only + strictMode=true → COMMENT (strict only escalates criticals)`, () => {
+      expect(
+        selectReviewEvent({
+          criticalCount: 0,
+          minorCount: 2,
+          strictMode: true,
+          prAuthorLogin: 'trusted-user',
+          authorAssociation: aa,
+        }),
+      ).toBe('COMMENT');
+    });
+  }
+});
+
+describe('selectReviewEvent: barrel re-export equivalence', () => {
+  it('clud-bug/core re-exports selectReviewEvent (same identity)', () => {
+    // Sanity check: the barrel and the module both export the same
+    // function. Catches "renamed to fooReviewEvent" drift early.
+    expect(barrelSelectReviewEvent).toBe(selectReviewEvent);
+  });
+});

--- a/test/release-discipline.test.js
+++ b/test/release-discipline.test.js
@@ -171,3 +171,49 @@ test('release discipline: Upload skill-usage artifact step must set include-hidd
     );
   }
 });
+
+test('release discipline: Formal review step is present in all 3 templates (v0.7.0-rc.3)', async () => {
+  // v0.7.0-rc.3 added the SPEC §7.2.1 formal-review event poster to
+  // bridge the canonical-ruleset `required_approving_review_count: 1`
+  // floor on the npm workflow path. Without this step, every workflow-
+  // path PR requires a human Approve click even when the bot is clean.
+  //
+  // Three properties enforced here:
+  //   1. The step exists in all 3 templates (workflow/-ts/-py)
+  //   2. `continue-on-error: true` — best-effort contract; the step
+  //      MUST NEVER fail the workflow on caller-side problems
+  //   3. The step invokes `clud-bug@<CLUD_BUG_VERSION>` (templated)
+  //      so any future version bump automatically picks up the new pin
+  const templates = [
+    'workflow.yml.tmpl',
+    'workflow-ts.yml.tmpl',
+    'workflow-py.yml.tmpl',
+  ];
+  for (const tmpl of templates) {
+    const content = await readFile(join(REPO_ROOT, 'templates', tmpl), 'utf8');
+    const idx = content.indexOf('Formal review — APPROVE / REQUEST_CHANGES / COMMENT');
+    assert.ok(
+      idx !== -1,
+      `${tmpl}: missing the v0.7.0-rc.3 'Formal review' post-step.
+       Background: SPEC §7.2.1 requires the canonical ruleset's
+       \`required_approving_review_count: 1\` floor to be auto-satisfied
+       by clud-bug[bot] on clean reviews. Without this step the npm
+       workflow path never posts a formal APPROVE — every PR requires
+       a human Approve click even when the bot's verdict is clean.
+       See docs/decisions-branches/release__v0.7.0-rc.3.md for design.`,
+    );
+    // The step block extends ~1500 chars below the step name. Confirm
+    // the best-effort guard and the npx invocation are present.
+    const stepBlock = content.slice(idx, idx + 2000);
+    assert.match(
+      stepBlock,
+      /continue-on-error:\s*true/,
+      `${tmpl}: 'Formal review' step is missing 'continue-on-error: true' — required for the best-effort contract.`,
+    );
+    assert.match(
+      stepBlock,
+      /npx --yes clud-bug@\{\{CLUD_BUG_VERSION\}\} select-review-event/,
+      `${tmpl}: 'Formal review' step must invoke \`npx --yes clud-bug@{{CLUD_BUG_VERSION}} select-review-event\`. Hard-coded versions defeat the template's release-discipline pin auto-bump.`,
+    );
+  }
+});

--- a/test/review-writeback.test.js
+++ b/test/review-writeback.test.js
@@ -386,6 +386,171 @@ test('renderMultiPassMarkdown: absent f.file → "(unknown file)" fallback (not 
   assert.ok(md.includes('(unknown file)'));
 });
 
+// ---------------------------------------------------------------------------
+// v0.7.0-rc.3 — SPEC §1.8.1 Resolved / Still-open blocks + §6.7.3 cache
+// telemetry. New optional inputs to renderReviewFile.
+// ---------------------------------------------------------------------------
+
+const RESOLVED_SAMPLE = [
+  {
+    file: 'src/foo.ts', line: 12, severity: 'critical',
+    skillName: 'critical-issues-only',
+    summary: 'null-deref on empty array',
+  },
+];
+const STILL_OPEN_SAMPLE = [
+  {
+    file: 'src/bar.ts', line: 84, severity: 'minor',
+    skillName: 'evidence-based-review',
+    summary: 'missing test for edge case',
+  },
+];
+
+test('renderReviewFile: Resolved this round block present when input non-empty', () => {
+  const md = renderReviewFile({
+    review: EMPTY_REVIEW, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,
+    resolvedFindings: RESOLVED_SAMPLE,
+  });
+  assert.ok(md.includes('**Resolved this round:**'));
+  // SPEC §1.8.1 bullet shape — backtick-wrapped file + skill, (was 🔴 Critical) suffix.
+  assert.ok(
+    md.includes(
+      '- `src/foo.ts:12` — `critical-issues-only`: null-deref on empty array (was 🔴 Critical)',
+    ),
+  );
+});
+
+test('renderReviewFile: Resolved block emitted AFTER severity buckets, BEFORE trailing ---', () => {
+  // Use a review with a finding so we have severity buckets to anchor on.
+  const md = renderReviewFile({
+    review: REVIEW_WITH_CRITICAL, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,
+    resolvedFindings: RESOLVED_SAMPLE,
+  });
+  const critIdx = md.indexOf('### 🔴 Critical');
+  const resolvedIdx = md.indexOf('**Resolved this round:**');
+  const dashIdx = md.indexOf('\n---\n');
+  assert.ok(critIdx >= 0);
+  assert.ok(resolvedIdx > critIdx);
+  assert.ok(dashIdx > resolvedIdx);
+});
+
+test('renderReviewFile: Resolved block omitted entirely on empty array', () => {
+  const md = renderReviewFile({
+    review: EMPTY_REVIEW, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,
+    resolvedFindings: [],
+  });
+  assert.ok(!md.includes('**Resolved this round:**'));
+});
+
+test('renderReviewFile: Resolved block omitted entirely when undefined', () => {
+  const md = renderReviewFile({
+    review: EMPTY_REVIEW, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,
+  });
+  assert.ok(!md.includes('**Resolved this round:**'));
+});
+
+test('renderReviewFile: Still open block present when input non-empty', () => {
+  const md = renderReviewFile({
+    review: EMPTY_REVIEW, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,
+    stillOpenFindings: STILL_OPEN_SAMPLE,
+  });
+  assert.ok(md.includes('**Still open:**'));
+  assert.ok(
+    md.includes(
+      '- `src/bar.ts:84` — `evidence-based-review`: missing test for edge case (was 🟡 Minor)',
+    ),
+  );
+});
+
+test('renderReviewFile: Still open block emitted AFTER Resolved this round when both present', () => {
+  const md = renderReviewFile({
+    review: EMPTY_REVIEW, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,
+    resolvedFindings: RESOLVED_SAMPLE,
+    stillOpenFindings: STILL_OPEN_SAMPLE,
+  });
+  const resolvedIdx = md.indexOf('**Resolved this round:**');
+  const stillIdx = md.indexOf('**Still open:**');
+  assert.ok(resolvedIdx >= 0);
+  assert.ok(stillIdx > resolvedIdx);
+});
+
+test('renderReviewFile: Still open block omitted entirely on empty array', () => {
+  const md = renderReviewFile({
+    review: EMPTY_REVIEW, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,
+    stillOpenFindings: [],
+  });
+  assert.ok(!md.includes('**Still open:**'));
+});
+
+test('renderReviewFile: cross-cutting finding (line=0) omits :line suffix in diff block', () => {
+  const md = renderReviewFile({
+    review: EMPTY_REVIEW, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,
+    resolvedFindings: [
+      {
+        file: 'README.md', line: 0, severity: 'critical',
+        skillName: 'docs-link-check', summary: 'broken anchor',
+      },
+    ],
+  });
+  // line=0 means cross-cutting; we omit the :N suffix.
+  assert.ok(md.includes('- `README.md` — `docs-link-check`: broken anchor (was 🔴 Critical)'));
+  assert.ok(!md.includes('README.md:0'));
+});
+
+test('renderReviewFile: severity emoji correct in (was X) suffix for all three buckets', () => {
+  const md = renderReviewFile({
+    review: EMPTY_REVIEW, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,
+    resolvedFindings: [
+      { file: 'a.ts', line: 1, severity: 'critical', skillName: 's', summary: 'A' },
+      { file: 'b.ts', line: 2, severity: 'minor', skillName: 's', summary: 'B' },
+      { file: 'c.ts', line: 3, severity: 'preexisting', skillName: 's', summary: 'C' },
+    ],
+  });
+  assert.ok(md.includes('(was 🔴 Critical)'));
+  assert.ok(md.includes('(was 🟡 Minor)'));
+  assert.ok(md.includes('(was 🟣 Preexisting)'));
+});
+
+test('renderReviewFile: SPEC §6.7.3 cache telemetry comment present when input provided', () => {
+  const md = renderReviewFile({
+    review: EMPTY_REVIEW, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,
+    cacheStats: { cachedInputTokens: 12800, cacheCreationInputTokens: 184 },
+  });
+  assert.ok(md.includes('<!-- cache: 12800 read · 184 created -->'));
+});
+
+test('renderReviewFile: cache comment appears immediately below review-sha (SPEC §6.7.3)', () => {
+  const md = renderReviewFile({
+    review: EMPTY_REVIEW, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,
+    cacheStats: { cachedInputTokens: 1000, cacheCreationInputTokens: 50 },
+  });
+  const shaIdx = md.indexOf('<!-- review-sha:');
+  const cacheIdx = md.indexOf('<!-- cache:');
+  assert.ok(shaIdx >= 0);
+  assert.ok(cacheIdx > shaIdx);
+  // Should be on the very next line — no other metadata between them.
+  const between = md.slice(shaIdx, cacheIdx);
+  // One newline + immediately the cache comment.
+  assert.match(between, /^<!-- review-sha: [0-9a-f]+ -->\n$/);
+});
+
+test('renderReviewFile: cache comment omitted entirely when cacheStats undefined', () => {
+  const md = renderReviewFile({
+    review: EMPTY_REVIEW, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,
+  });
+  assert.ok(!md.includes('<!-- cache:'));
+});
+
+test('renderReviewFile: cache comment with zero values still emitted (audit trail)', () => {
+  const md = renderReviewFile({
+    review: EMPTY_REVIEW, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,
+    cacheStats: { cachedInputTokens: 0, cacheCreationInputTokens: 0 },
+  });
+  // Even at 0 / 0 the comment lands — operators need to see "first review"
+  // (0/0 means no cache hit, cold start) vs absent (caller didn't pass stats).
+  assert.ok(md.includes('<!-- cache: 0 read · 0 created -->'));
+});
+
 test('renderMultiPassMarkdown: disagreed attribution adds Disputed note', () => {
   const disputedReview = {
     ...MULTI_PASS_REVIEW,


### PR DESCRIPTION
## Summary

Phase 7 PR A closes 5 SPEC v0.2.0 conformance gaps in clud-bug core and ships the workflow-path bridge for formal APPROVE reviews. After this lands, clud-bug-app's Phase 7 PR B will consume via dep bump + small wiring; the npm workflow path inherits via the new template post-step.

### Closed gaps

- **SPEC §7.2.1** (security): \`selectReviewEvent\` now gates APPROVE on \`authorAssociation\`. Drive-by external-contributor PRs route to COMMENT, NEVER APPROVE — closes the auto-merge exploit surface exposed in clud-bug-app PR #40.
- **SPEC §1.8.1** (visibility): \`renderReviewFile\` emits \`**Resolved this round:**\` + \`**Still open:**\` blocks (omitted when empty). New helpers \`parsePriorReviewFile\` + \`diffFindings\` produce the diff inputs.
- **SPEC §6.7.3** (telemetry): \`renderReviewFile\` emits \`<!-- cache: <read> read · <created> created -->\` immediately below \`<!-- review-sha: ... -->\` when caller passes \`cacheStats\`.
- **Workflow APPROVE bridge**: new \`clud-bug select-review-event --stdin\` CLI subcommand + workflow template post-step posts a formal \`pulls.createReview\` so the canonical ruleset's \`required_approving_review_count: 1\` floor is auto-satisfied on the npm workflow path. \`continue-on-error: true\` — best-effort, never fails the workflow.

### New core exports (from \`clud-bug/core\`)

- \`selectReviewEvent\` + \`AuthorAssociation\` + \`SelectReviewEventInput\` + \`FormalReviewEvent\` — SPEC §7.2.1 rule table
- \`parsePriorReviewFile\` + \`diffFindings\` + \`findingIdentity\` — SPEC §1.8.1 Resolved / Still-open block helpers
- \`ParsedFinding\` + \`ParsedReview\` + \`RenderedFindingRef\` + \`CacheStats\` — input/output types
- \`renderReviewFile\` extensions (back-compat): \`resolvedFindings?\`, \`stillOpenFindings?\`, \`cacheStats?\`

### Migration note for clud-bug-app (Phase 7 PR B)

1. Bump \`clud-bug\` dep to \`^0.7.0-rc.3\` (or matching tag).
2. Delete local \`lib/formal-review.ts\` \`selectReviewEvent\`; import from \`clud-bug/core\`.
3. Pass \`authorAssociation\` from the webhook payload at the call site (\`pull_request.author_association\`). Default \`'CONTRIBUTOR'\` preserves pre-§7.2.1 trusted-author semantics.
4. Wire \`parsePriorReviewFile\` + \`diffFindings\` into \`auto-resolve\` or the review-writeback path to surface the §1.8.1 Resolved / Still-open blocks.
5. Wire \`cacheStats\` (already captured for billing) into \`renderReviewFile\` calls.

### Sample SPEC §1.8.1 emitted blocks

\`\`\`markdown
**Resolved this round:**
- \`src/foo.ts:12\` — \`critical-issues-only\`: null-deref on empty array (was 🔴 Critical)

**Still open:**
- \`src/bar.ts:84\` — \`evidence-based-review\`: missing test for edge case (was 🟡 Minor)
\`\`\`

### LOC delta

+1940 / -9 across 14 files (core: +769 incl. new modules; tests: +951; templates: +187; docs/version: +33).

## Test plan
- [x] \`npm test\` — 565 tests pass (was 470 on rc.2; +95 new)
- [x] \`npm run build\` — zero errors
- [x] template rendering verified end-to-end (CLUD_BUG_VERSION → 0.7.0-rc.3 pin)
- [ ] \`clud-bug-review\` on this PR — CLEAN required

## USER ACTIONS (queued)
1. After merge: \`git tag v0.7.0-rc.3 <merge-sha> -m "v0.7.0-rc.3"\` + \`git push origin v0.7.0-rc.3\`
2. \`cd /Users/ludlow/clud-bug && npm publish --tag next\`
3. Phase 7 PR B on clud-bug-app: bump dep, delete local formal-review, wire author_association.

🤖 Generated with [Claude Code](https://claude.com/claude-code)