### PR TITLE
chore: bump dependabot-auto-merge caller pin to 6e1f9df (major-bump support)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,7 @@
 name: Dependabot auto-merge
 
-# Auto-approve + squash-merge Dependabot patch/minor PRs once required CI passes.
-# Major bumps are left for human review. See §8.1 for org-level rationale.
+# Auto-approve + squash-merge Dependabot PRs once required CI passes.
+# Patch/minor/major all eligible — CI gates breakage. See §8.1 for org-level rationale.
 #
 # Calls the reusable workflow at thrillmade/.github.
 
@@ -16,6 +16,6 @@ permissions:
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
-    # Pinned to thrillmade/.github commit e4dfd7e for supply-chain immutability (per clud-bug-review on PR #144). Bump via dependabot or manual edit.
-    uses: thrillmade/.github/.github/workflows/dependabot-auto-merge.yml@e4dfd7ea66a4917ea85b7880c0e700628ced409f
+    # Pinned to thrillmade/.github commit 6e1f9df for supply-chain immutability (per clud-bug-review on PR #144). Bump via dependabot or manual edit.
+    uses: thrillmade/.github/.github/workflows/dependabot-auto-merge.yml@6e1f9dfd2695396d5ae2b14af9a84ca132784a94
     secrets: inherit

--- a/docs/decisions-branches/chore__bump-dabm-pin-6e1f9df.md
+++ b/docs/decisions-branches/chore__bump-dabm-pin-6e1f9df.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-10 11:12 - Bump dependabot-auto-merge caller pin to 6e1f9df
+
+**Reasoning:** Picks up thrillmade/.github PR #3 which drops the major-bump early-stop step. CI gates breakage; trust the bots.
+
+**Alternatives considered:** Stay on e4dfd7e and continue blocking major bumps from auto-merge — rejected, contradicts org direction 2026-06-10
+
+**Implications:**
+- Major dependabot bumps in this repo will now auto-merge on required-CI pass like patch/minor already do
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (37 decisions)
+## 2026-06 (38 decisions)
 
-- **2026-06-09** — v0.7.0-rc.2: fix clud-bug-review #158 critical + 2 minor on first pass *(release/v0.7.0-rc.2)* — [decisions-branches/release__v0.7.0-rc.2.md](decisions-branches/release__v0.7.0-rc.2.md)
-- *... 35 more decisions ...*
+- **2026-06-10** — Bump dependabot-auto-merge caller pin to 6e1f9df *(chore/bump-dabm-pin-6e1f9df)* — [decisions-branches/chore__bump-dabm-pin-6e1f9df.md](decisions-branches/chore__bump-dabm-pin-6e1f9df.md)
+- *... 36 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)


### PR DESCRIPTION
Bumps the reusable workflow pin to pick up the change from PR #3 on `thrillmade/.github` (drops the major-bump early-stop step). After merge, major dependabot bumps in this repo will auto-merge on CI pass like patch/minor already do.