### PR TITLE
feat(rc.4): configure-github + cache comment + resolved findings naming

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.3
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.4
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,91 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.7.0-rc.4] — 2026-06-17
+
+Marketplace prep — three SPEC-aligned core enhancements bundled for the
+v0.7.0 ship train. All three live in `src/core/` so the App's Phase 4
+re-import lands them in one wave; clud-bug-app consumption is a follow-up
+PR dispatched AFTER this version is tagged + published. See plan §Phase 6
+and tasks #224 + #227 + #228.
+
+### Added — `clud-bug configure-github <owner>/<repo>` (Phase 6 task #227)
+
+External users installing the App expect "best-practice branch protection"
+applied automatically. This CLI lets them opt in BEFORE the App's auto-setup
+runs server-side.
+
+- **`src/core/configure-github.ts`** — pure diff + idempotent-PATCH module.
+  Exports `applyCanonicalRuleset(octokit, params)` taking a structural
+  `OctokitLike` interface (no `@octokit/rest` runtime dep — App passes its
+  real instance; CLI passes a `gh api`-backed adapter). Returns
+  `{ changes: string[], alreadyCanonical: boolean, ruleset: 'canonical-v1' }`.
+  Hard idempotency contract: `apply(); apply()` converges and the second
+  call reports `alreadyCanonical: true` with zero PATCH side effects.
+- **`src/cli/configure-github.ts`** — `clud-bug configure-github
+  <owner>/<repo>` with `--dry-run` and `--branch <name>`. Auth ladder:
+  `GITHUB_TOKEN` env first, then `gh auth token`. Helpful exit-1 message
+  if neither produces a token.
+- **`data/canonical-v1.json`** — bundled copy of the protocol repo's
+  canonical-v1 ruleset (`thrillmade/protocol#rulesets/canonical-v1.json`),
+  so the CLI works offline. Loaded once per process by `loadCanonicalV1()`
+  with memoization.
+- Behavior on partial mismatch:
+  - `required_status_checks.contexts` are treated as a **superset** —
+    repos that legitimately require extra CI gates keep them.
+  - `required_approving_review_count` is a **floor** — never lowered.
+  - All other booleans converge exactly.
+
+### Added — SPEC §6.7.3 cache telemetry comment in review doc-files (task #224)
+
+`renderReviewFile()` now accepts an optional `cacheStats: { cachedInputTokens,
+cacheCreationInputTokens }` input. When present, emits a
+`<!-- cache: <read> read · <created> created -->` HTML comment immediately
+below `<!-- review-sha: ... -->` in the SPEC §1.8.1 doc-file. Absent input
+renders nothing (backwards-compat). Lights up post-hoc cost analysis on
+the committed doc-files — a single `grep '<!-- cache:'` over
+`docs/reviews/PR-*.md` produces the cache-hit-rate time series without
+re-walking workflow logs.
+
+### Added — SPEC §1.8.1 Resolved this round / Still open blocks (task #228)
+
+`renderReviewFile()` now accepts optional `resolvedFindings: Finding[]`
+and `stillOpenFindings: Finding[]` lists. When non-empty, emits the SPEC
+§1.8.1 named blocks (`**Resolved this round:**` and `**Still open:**`)
+AFTER the severity buckets and BEFORE the trailing `---` separator. Each
+bullet carries the (was 🔴 Critical / 🟡 Minor / 🟣 Preexisting) suffix so
+severity changes across rounds are visible without diffing the two doc
+files. Wired to `diffFindings()` from `./diff-findings.ts` (G7.t feedback —
+"1 resolved from prior" status line now backed by the named finding list).
+
+### Tests
+
+- `test/core/configure-github.test.js` — 19 new tests covering fresh repo
+  (404 protection), already-canonical no-op, partial mismatch (single-field
+  PATCH), superset preservation for required_status_checks.contexts,
+  raise-only floor for required_approving_review_count, dry-run skips
+  PATCH, idempotency contract, branch override, non-404 error propagation,
+  CLI wrapper missing-token / malformed-target / already-canonical /
+  dry-run / apply paths.
+- `test/review-writeback.test.js` — already covers the cache comment +
+  resolved/still-open block paths (v0.7.0-rc.3 infrastructure landed
+  alongside the parsePriorReviewFile + diffFindings port).
+
+### Version bumps
+
+- `package.json`: 0.7.0-rc.3 → 0.7.0-rc.4.
+- All 3 workflow templates + `.github/actions/strict-mode-gate/action.yml`:
+  `strict-mode-gate@v0.7.0-rc.3` → `@v0.7.0-rc.4` (release-discipline
+  guard enforces this).
+
+### Architectural lock
+
+Per Bug 9 / Phase 2-4 architecture: clud-bug npm is the **single source
+of truth**. clud-bug-app will consume the new `applyCanonicalRuleset` +
+`renderReviewFile` extensions via the `clud-bug@0.7.0-rc.4` import in a
+follow-up wave AFTER this version is tagged + published. No App-side
+changes ship in this PR.
+
 ## [0.6.34] — 2026-06-02
 
 ### Fixed — `clud-bug-review` emits `neutral` on transient Anthropic API errors (Concern 2 from tokenomics-agent v0.6.14 verification report)

--- a/data/canonical-v1.json
+++ b/data/canonical-v1.json
@@ -1,0 +1,37 @@
+{
+  "$comment": "Canonical branch protection ruleset for SkDD-conformant repos. Applied by `logmind init --configure-github`, `clud-bug init --configure-github`, and `reporulez`. Implements thrillmade/protocol SPEC §7. Schema-locked at v1; major bumps require coordinated tool releases.",
+  "version": "v1",
+  "spec_version": "0.1.2",
+  "branch_protection": {
+    "required_status_checks": {
+      "strict": true,
+      "contexts": [
+        "clud-bug-review",
+        "check-decisions",
+        "check-derived-docs",
+        "check-links",
+        "test"
+      ]
+    },
+    "required_pull_request_reviews": {
+      "required_approving_review_count": 1,
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false
+    },
+    "required_conversation_resolution": true,
+    "enforce_admins": false,
+    "allow_force_pushes": false,
+    "allow_deletions": false,
+    "required_linear_history": false,
+    "allow_auto_merge": true,
+    "delete_branch_on_merge": true,
+    "squash_merge_commit_title": "PR_TITLE",
+    "squash_merge_commit_message": "PR_BODY"
+  },
+  "$notes": {
+    "required_approving_review_count": "1 — auto-satisfied by clud-bug[bot]'s APPROVE vote on clean reviews for org-member PRs (per SPEC §7.2.1). External-contributor PRs still need a human reviewer because the bot's APPROVE on first-time contributors is policy-gated. Repo-owners MAY raise above 1; tools MUST NOT lower below 1.",
+    "enforce_admins": "false so maintainers can land hotfixes outside the gate; the dogfood discipline expects this only for genuine emergencies (clud-bug review still runs but doesn't block)",
+    "contexts": "the four logmind workflow check names + clud-bug-review + a generic 'tests' context. Repos may add more, but MUST keep these. If a context name is renamed in workflow YAML, update the ruleset.",
+    "required_conversation_resolution": "true is the dogfood-defining rule: clud-bug findings must be resolved before merge"
+  }
+}

--- a/docs/decisions-branches/feat__rc.4-configure-github-cache-resolved.md
+++ b/docs/decisions-branches/feat__rc.4-configure-github-cache-resolved.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-17 03:39 - v0.7.0-rc.4: configure-github + cache comment + resolved findings naming
+
+**Reasoning:** Three SPEC-aligned core enhancements bundled for the v0.7.0 Marketplace prep ship train. Phase 6 task #227 (configure-github applier), task #224 (SPEC §6.7.3 cache comment in review doc-file), and task #228 (SPEC §1.8.1 Resolved/Still-open blocks). All three live in src/core/ so clud-bug-app's Phase 4 re-import lands them in one wave; App-side consumption is a follow-up PR dispatched AFTER USER tags + publishes.
+
+**Alternatives considered:** Could have shipped each wave as a separate rc bump (rc.4 = configure-github, rc.5 = cache, rc.6 = resolved), but they all target the same Marketplace-prep milestone and the App consumer needs all three together to satisfy the Phase 6 acceptance gate. One rc bump minimizes the consumer wave count.
+
+**Implications:**
+- Next: USER tags v0.7.0-rc.4 + npm publish. clud-bug-app then bumps its clud-bug dep + threads renderReviewFile's new cacheStats + resolvedFindings/stillOpenFindings params from the existing review-orchestrator. configure-github gets wired into the App's repo-onboarding endpoint as a follow-up.
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -9,8 +9,7 @@ clud-bug
 │   ├── workflow-ts.yml
 │   └── workflow.yml
 ├── .claude
-│   ├── skills
-│   └── worktrees
+│   └── skills
 ├── .github
 │   ├── actions
 │   ├── workflows

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -18,6 +18,8 @@ clud-bug
 │   └── config.yml
 ├── bin
 │   └── clud-bug.js
+├── data
+│   └── canonical-v1.json
 ├── docs
 │   ├── decisions-branches
 │   ├── reviews
@@ -47,6 +49,7 @@ clud-bug
 │   ├── workflow-ts.yml.tmpl
 │   └── workflow.yml.tmpl
 ├── test
+│   ├── core
 │   ├── golden
 │   ├── agents-md.test.js
 │   ├── audit.test.js

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -9,7 +9,8 @@ clud-bug
 │   ├── workflow-ts.yml
 │   └── workflow.yml
 ├── .claude
-│   └── skills
+│   ├── skills
+│   └── worktrees
 ├── .github
 │   ├── actions
 │   ├── workflows

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (42 decisions)
+## 2026-06 (43 decisions)
 
-- **2026-06-10** — v0.7.0-rc.3: fix-closed unrecognized PR_AUTHOR_ASSOCIATION to NONE (clud-bug-review #163 fix) *(release/v0.7.0-rc.3)* — [decisions-branches/release__v0.7.0-rc.3.md](decisions-branches/release__v0.7.0-rc.3.md)
-- *... 40 more decisions ...*
+- **2026-06-17** — v0.7.0-rc.4: configure-github + cache comment + resolved findings naming *(feat/rc.4-configure-github-cache-resolved)* — [decisions-branches/feat__rc.4-configure-github-cache-resolved.md](decisions-branches/feat__rc.4-configure-github-cache-resolved.md)
+- *... 41 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.1",
+  "version": "0.7.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clud-bug",
-      "version": "0.7.0-rc.1",
+      "version": "0.7.0-rc.3",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.3",
+  "version": "0.7.0-rc.4",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",
@@ -23,6 +23,7 @@
   "bin": "bin/clud-bug.js",
   "files": [
     "bin",
+    "data",
     "dist",
     "src",
     "templates",

--- a/src/cli/configure-github.ts
+++ b/src/cli/configure-github.ts
@@ -117,56 +117,55 @@ export async function runConfigureGithub(
     );
   }
 
+  // Single-call orchestration: the CLI previously called
+  // applyCanonicalRuleset twice in apply mode (dry-run first to display the
+  // planned changes, then a real call to apply). That two-read pattern
+  // opened a TOCTOU window — concurrent changes between the two reads
+  // could make the displayed list diverge from the actually-applied list,
+  // and the dry-run cost a redundant API round-trip every time. Drop the
+  // preview-first read: pass `dryRun` straight through. The function's
+  // idempotency contract (returns `alreadyCanonical: true` + empty changes
+  // on a no-op) means we don't need a separate "look before you leap"
+  // call. Users who want preview semantics run `--dry-run` first as a
+  // distinct invocation — idiomatic CLI behavior. Surfaced by PR #166
+  // reviewer (CTO follow-up 2026-06-17).
   const octokit = octokitFactory(token);
-  let dryResult: ApplyResult;
+  let result: ApplyResult;
   try {
-    dryResult = await applyCanonicalRuleset(octokit, {
+    result = await applyCanonicalRuleset(octokit, {
       owner,
       repo,
       branch,
-      dryRun: true,
+      dryRun,
     });
   } catch (err) {
     stderr(
-      `clud-bug configure-github: failed to read current state: ${stringifyError(err)}\n`,
+      `clud-bug configure-github: ${dryRun ? 'failed to read current state' : 'PATCH failed'}: ${stringifyError(err)}\n`,
     );
     return 1;
   }
 
-  if (dryResult.alreadyCanonical) {
+  if (result.alreadyCanonical) {
     if (!quiet) stdout('  No changes — repo already matches canonical-v1.\n');
     stdout(`ok configure-github: ${owner}/${repo} already canonical-v1\n`);
     return 0;
   }
 
   if (!quiet) {
-    stdout(`  Planned changes (${dryResult.changes.length}):\n`);
-    for (const c of dryResult.changes) stdout(`    - ${c}\n`);
+    const verb = dryRun ? 'Planned' : 'Applied';
+    stdout(`  ${verb} changes (${result.changes.length}):\n`);
+    for (const c of result.changes) stdout(`    - ${c}\n`);
   }
 
   if (dryRun) {
     stdout(
-      `ok configure-github: dry-run on ${owner}/${repo} — ${dryResult.changes.length} change${dryResult.changes.length === 1 ? '' : 's'} pending\n`,
+      `ok configure-github: dry-run on ${owner}/${repo} — ${result.changes.length} change${result.changes.length === 1 ? '' : 's'} pending\n`,
     );
     return 0;
   }
 
-  let applyResult: ApplyResult;
-  try {
-    applyResult = await applyCanonicalRuleset(octokit, {
-      owner,
-      repo,
-      branch,
-    });
-  } catch (err) {
-    stderr(
-      `clud-bug configure-github: PATCH failed: ${stringifyError(err)}\n`,
-    );
-    return 1;
-  }
-
   stdout(
-    `ok configure-github: ${owner}/${repo} converged to canonical-v1 (${applyResult.changes.length} change${applyResult.changes.length === 1 ? '' : 's'})\n`,
+    `ok configure-github: ${owner}/${repo} converged to canonical-v1 (${result.changes.length} change${result.changes.length === 1 ? '' : 's'})\n`,
   );
   return 0;
 }

--- a/src/cli/configure-github.ts
+++ b/src/cli/configure-github.ts
@@ -1,0 +1,296 @@
+// `clud-bug configure-github` CLI command — applies the SPEC §7 canonical
+// branch protection ruleset to a target repo.
+//
+// External users installing the App expect "best practice branch protection"
+// applied automatically. This command lets them opt in offline + dry-run
+// safely BEFORE the App's auto-setup runs server-side. Same core logic
+// powers both paths (the App imports `applyCanonicalRuleset` from
+// clud-bug/core; this CLI passes a `gh api`-wrapping adapter so users
+// don't need `@octokit/rest` on their machine).
+//
+// Usage:
+//
+//   clud-bug configure-github <owner>/<repo>
+//   clud-bug configure-github <owner>/<repo> --dry-run
+//   clud-bug configure-github <owner>/<repo> --branch develop
+//
+// Auth ladder:
+//
+//   1. `GITHUB_TOKEN` env var (CI-friendly, no `gh` install required)
+//   2. `gh auth token` (developer workstation default)
+//
+// If neither produces a token, exits 1 with a recovery message.
+
+import { spawn, spawnSync } from 'node:child_process';
+import {
+  applyCanonicalRuleset,
+  loadCanonicalV1,
+  type OctokitLike,
+  type ApplyResult,
+} from '../core/configure-github.js';
+
+export interface RunConfigureGithubOptions {
+  /** "owner/repo" target — required. */
+  target?: string | null;
+  /** Target branch (default `main`). */
+  branch?: string;
+  /** Render diff only; skip PATCH calls. */
+  dryRun?: boolean;
+  /** Suppress progress chatter; emit only the final `ok` summary. */
+  quiet?: boolean;
+  /** Resolver for the GitHub token (tests pass a stub). */
+  resolveToken?: () => Promise<string | null>;
+  /** Octokit factory (tests inject a fake; defaults to the gh-adapter). */
+  octokitFactory?: (token: string) => OctokitLike;
+  /** Stdout writer (tests capture). */
+  stdout?: (msg: string) => void;
+  /** Stderr writer (tests capture). */
+  stderr?: (msg: string) => void;
+}
+
+const HELP = `clud-bug configure-github — apply SPEC §7 canonical branch protection.
+
+Usage:
+  clud-bug configure-github <owner>/<repo> [options]
+
+Options:
+  --dry-run         Compute diff and print it, but do NOT call PATCH endpoints.
+  --branch <name>   Target branch (default: main).
+  --quiet,-q        Suppress progress chatter; emit only the final summary.
+  --help,-h         Show this help.
+
+Auth (resolved in order):
+  1. GITHUB_TOKEN env var (CI-friendly)
+  2. \`gh auth token\` (developer workstation)
+
+Exit codes:
+  0  success or already-canonical
+  1  auth missing, PATCH error, or unrecoverable transport failure
+  2  CLI usage error (missing target, bad flag)
+`;
+
+/**
+ * Entry point — wired into `clud-bug.js` dispatch. Returns a Node-style
+ * exit code so the dispatcher can `process.exit()` deterministically. We
+ * don't call `process.exit` ourselves so tests can drive the function
+ * without taking down the harness.
+ */
+export async function runConfigureGithub(
+  options: RunConfigureGithubOptions,
+): Promise<number> {
+  const {
+    target,
+    branch = 'main',
+    dryRun = false,
+    quiet = false,
+    resolveToken = defaultResolveToken,
+    octokitFactory = ghCliOctokit,
+    stdout = (msg) => process.stdout.write(msg),
+    stderr = (msg) => process.stderr.write(msg),
+  } = options;
+
+  if (!target) {
+    stderr(HELP);
+    return 2;
+  }
+  const match = /^([^/]+)\/([^/]+)$/.exec(target);
+  if (!match) {
+    stderr(
+      `clud-bug configure-github: target must be in owner/repo form, got "${target}".\n`,
+    );
+    return 2;
+  }
+  const [, owner, repo] = match as unknown as [unknown, string, string];
+
+  const token = await resolveToken();
+  if (!token) {
+    stderr(
+      'clud-bug configure-github: no GitHub token found.\n' +
+        '  Set GITHUB_TOKEN, or install + auth gh: brew install gh && gh auth login\n',
+    );
+    return 1;
+  }
+
+  if (!quiet) {
+    stdout(
+      `\u{1F41B} configure-github: applying canonical-v1 ruleset to ${owner}/${repo} (branch=${branch})\n`,
+    );
+  }
+
+  const octokit = octokitFactory(token);
+  let dryResult: ApplyResult;
+  try {
+    dryResult = await applyCanonicalRuleset(octokit, {
+      owner,
+      repo,
+      branch,
+      dryRun: true,
+    });
+  } catch (err) {
+    stderr(
+      `clud-bug configure-github: failed to read current state: ${stringifyError(err)}\n`,
+    );
+    return 1;
+  }
+
+  if (dryResult.alreadyCanonical) {
+    if (!quiet) stdout('  No changes — repo already matches canonical-v1.\n');
+    stdout(`ok configure-github: ${owner}/${repo} already canonical-v1\n`);
+    return 0;
+  }
+
+  if (!quiet) {
+    stdout(`  Planned changes (${dryResult.changes.length}):\n`);
+    for (const c of dryResult.changes) stdout(`    - ${c}\n`);
+  }
+
+  if (dryRun) {
+    stdout(
+      `ok configure-github: dry-run on ${owner}/${repo} — ${dryResult.changes.length} change${dryResult.changes.length === 1 ? '' : 's'} pending\n`,
+    );
+    return 0;
+  }
+
+  let applyResult: ApplyResult;
+  try {
+    applyResult = await applyCanonicalRuleset(octokit, {
+      owner,
+      repo,
+      branch,
+    });
+  } catch (err) {
+    stderr(
+      `clud-bug configure-github: PATCH failed: ${stringifyError(err)}\n`,
+    );
+    return 1;
+  }
+
+  stdout(
+    `ok configure-github: ${owner}/${repo} converged to canonical-v1 (${applyResult.changes.length} change${applyResult.changes.length === 1 ? '' : 's'})\n`,
+  );
+  return 0;
+}
+
+/**
+ * Auth ladder: env var first, then `gh auth token`. Surfaces a token
+ * string on success or `null` if neither source has one (caller prints
+ * the recovery hint).
+ */
+async function defaultResolveToken(): Promise<string | null> {
+  const fromEnv = process.env.GITHUB_TOKEN?.trim();
+  if (fromEnv) return fromEnv;
+  const result = spawnSync('gh', ['auth', 'token'], { encoding: 'utf8' });
+  if (result.status === 0) {
+    const tok = result.stdout.trim();
+    if (tok) return tok;
+  }
+  return null;
+}
+
+/**
+ * Builds an `OctokitLike` instance backed by `gh api` shell-outs. This
+ * lets us satisfy the structural interface without pulling in
+ * `@octokit/rest` as a runtime dep (~200KB). The App passes its real
+ * Octokit instance instead.
+ */
+export function ghCliOctokit(token: string): OctokitLike {
+  // We pass GITHUB_TOKEN through the spawn env so gh's API surface picks
+  // it up consistently whether the user supplied env or gh auth.
+  const env = { ...process.env, GITHUB_TOKEN: token };
+
+  function ghApi<T>(
+    method: 'GET' | 'PUT' | 'PATCH' | 'POST',
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const args: string[] = ['api', '-X', method];
+      if (body !== undefined) {
+        args.push('--input', '-');
+      }
+      args.push(path);
+      // Add an Accept header so 404s return the structured error, not a
+      // friendlier shell hint. The wrapping err.message detection in
+      // `isBranchNotProtected` keys on the structured form.
+      args.push('-H', 'Accept: application/vnd.github+json');
+      const child = spawn('gh', args, {
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout!.on('data', (d: Buffer) => {
+        stdout += d.toString();
+      });
+      child.stderr!.on('data', (d: Buffer) => {
+        stderr += d.toString();
+      });
+      child.on('error', reject);
+      child.on('close', (code) => {
+        if (code !== 0) {
+          const httpMatch = /HTTP (\d{3})/.exec(stderr);
+          const status = httpMatch ? Number(httpMatch[1]) : undefined;
+          const err = new Error(
+            (stderr.trim() || stdout.trim() || `gh api exited ${code}`).slice(
+              0,
+              500,
+            ),
+          ) as Error & { status?: number };
+          if (status !== undefined) err.status = status;
+          reject(err);
+          return;
+        }
+        try {
+          resolve(stdout ? (JSON.parse(stdout) as T) : ({} as T));
+        } catch (parseErr) {
+          reject(parseErr);
+        }
+      });
+      if (body !== undefined) {
+        child.stdin!.end(JSON.stringify(body));
+      } else {
+        child.stdin!.end();
+      }
+    });
+  }
+
+  return {
+    repos: {
+      async getBranchProtection({ owner, repo, branch }) {
+        const data = await ghApi<unknown>(
+          'GET',
+          `/repos/${owner}/${repo}/branches/${branch}/protection`,
+        );
+        return { data: data as Awaited<ReturnType<OctokitLike['repos']['getBranchProtection']>>['data'] };
+      },
+      async updateBranchProtection({ owner, repo, branch, ...rest }) {
+        return ghApi(
+          'PUT',
+          `/repos/${owner}/${repo}/branches/${branch}/protection`,
+          rest,
+        );
+      },
+      async get({ owner, repo }) {
+        const data = await ghApi<unknown>(
+          'GET',
+          `/repos/${owner}/${repo}`,
+        );
+        return { data: data as Awaited<ReturnType<OctokitLike['repos']['get']>>['data'] };
+      },
+      async update({ owner, repo, ...rest }) {
+        return ghApi('PATCH', `/repos/${owner}/${repo}`, rest);
+      },
+    },
+  };
+}
+
+function stringifyError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/**
+ * Re-exported so callers can preload the ruleset (e.g. for a `--show-ruleset`
+ * flag in future). Currently exists for parity with the App's pattern.
+ */
+export { loadCanonicalV1 };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -99,3 +99,9 @@ export {
   type UpdateSkippedRecord,
   type RunUpdateResult,
 } from './update.js';
+
+export {
+  runConfigureGithub,
+  ghCliOctokit,
+  type RunConfigureGithubOptions,
+} from './configure-github.js';

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -62,6 +62,10 @@ function parseArgs(argv) {
     // users get the same one-command bootstrap as Python-first users
     // (logmind v0.6.8's --with-skdd is the symmetric counterpart).
     withSkdd: false,
+    // v0.7.0-rc.4: `clud-bug configure-github` flags.
+    // --dry-run prints the diff but skips PATCH; --branch overrides "main".
+    dryRun: false,
+    branch: null,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -84,6 +88,8 @@ function parseArgs(argv) {
     else if (a === '--health') args.health = true;
     else if (a === '--no-artifacts') args.artifacts = false;
     else if (a === '--with-skdd') args.withSkdd = true;
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--branch') args.branch = argv[++i];
     else args._.push(a);
   }
   return args;
@@ -105,6 +111,12 @@ Commands:
                         Use --since / --changed-in / --scope to narrow.
   update                Re-render workflows + refresh baseline specimens to the latest shipped
                         templates. Custom and skills.sh-installed specimens left alone.
+  configure-github <owner>/<repo>
+                        Apply the SPEC §7 canonical branch protection ruleset to a repo.
+                        Auth: GITHUB_TOKEN env first, then \`gh auth token\`. Use
+                        --dry-run to print the diff without PATCH-ing; --branch to
+                        target a non-main branch. Idempotent — already-canonical
+                        repos exit 0 with no changes.
   edit-workflow         Helper for editing .github/workflows/clud-bug-*.yml in an isolated
                         PR (the action refuses to review PRs that modify its own workflow).
   usage                 Read recent clud-bug-review run JSON + normalize cost per LOC.
@@ -163,6 +175,9 @@ Options:
                         required_conversation_resolution on the default
                         branch (init only). Use for repos that manage
                         branch protection via ruleset or org policy.
+  --dry-run             Print the canonical-v1 diff without PATCH-ing
+                        (configure-github only).
+  --branch <name>       Target branch for configure-github (default: main).
   --repo <owner/name>   Restrict \`usage\` to a single repo. Default: all repos
                         with clud-bug-review.yml in the gh user's auth scope.
   --pr <N>              Restrict \`usage\` to a single PR.
@@ -198,6 +213,7 @@ async function main() {
     case 'audit':   return runAudit(args);
     case 'update':  return runUpdateCmd(args);
     case 'edit-workflow': return runEditWorkflow(args);
+    case 'configure-github': return runConfigureGithubCmd(args);
     case 'usage':   return runUsage(args);
     case 'eval':    return runEval();
     case 'render':  return runRender(args);
@@ -1138,6 +1154,24 @@ async function runUpdateCmd(_args) {
   log('');
   log('Commit + push to apply the refreshed kit on the next PR.');
   ok(`updated: @v${ourVersion}, ${result.changed.length} changed, ${result.unchanged.length} unchanged${skipped.length ? `, ${skipped.length} skipped` : ''}`);
+}
+
+// v0.7.0-rc.4 — `clud-bug configure-github <owner>/<repo>`. Pulls in the
+// SPEC §7 canonical ruleset applier from src/cli/configure-github.ts;
+// thin wrapper here just maps CLI args into the typed entry point. The
+// command is idempotent — re-runs on a converged repo exit 0 with no
+// PATCH calls. See `src/core/configure-github.ts` for the diff + rule
+// table.
+async function runConfigureGithubCmd(args) {
+  const { runConfigureGithub } = await import('./configure-github.js');
+  const target = args._[1] ?? null;
+  const code = await runConfigureGithub({
+    target,
+    branch: args.branch || 'main',
+    dryRun: Boolean(args.dryRun),
+    quiet: QUIET,
+  });
+  if (code !== 0) process.exit(code);
 }
 
 async function runAudit(args) {

--- a/src/core/configure-github.ts
+++ b/src/core/configure-github.ts
@@ -1,0 +1,497 @@
+// SPEC §7 canonical-ruleset applier — pure core half of `configure-github`.
+//
+// External users installing the App expect "best practice branch protection"
+// applied automatically. This module diffs the current GitHub state against
+// the canonical ruleset (bundled at `data/canonical-v1.json`) and emits the
+// minimal set of PATCH calls to converge.
+//
+// Architectural shape mirrors `formal-review.ts` and `review-writeback.ts`:
+// the pure rule-table + diff logic lives in core (no Octokit dep at compile
+// time — clud-bug-app already has `@octokit/rest` and passes its instance;
+// the CLI side wraps `gh api` in a tiny adapter that satisfies the same
+// structural interface). Core stays npm-side single-source-of-truth per the
+// Bug 9 / Phase 2-4 architectural lock.
+//
+// Idempotent contract (HARD GUARANTEE):
+//
+//   const a = await applyCanonicalRuleset(octokit, params);
+//   const b = await applyCanonicalRuleset(octokit, params);
+//   // b.alreadyCanonical === true; b.changes.length === 0
+//
+// A second `apply()` call against a freshly-converged repo MUST produce
+// `alreadyCanonical: true` with `changes: []` and zero PATCH calls. This
+// lets external automation (CI, dispatch loops, dashboard probes) call
+// `apply()` defensively without rate-limiting itself out of the API.
+//
+// SPEC pins honored here:
+//   - canonical-v1.json schema (frozen at v1; major bumps require coordinated
+//     tool releases per the `$comment` field).
+//   - `required_status_checks.contexts` are TREATED AS A SUPERSET: if the
+//     repo already requires MORE contexts than the canonical list, we leave
+//     them alone (a repo that runs additional CI gates legitimately needs
+//     them in the required set). We only ADD the canonical contexts that
+//     are missing.
+//   - `required_approving_review_count`: canonical floor is 1. If the repo
+//     already requires MORE than 1, we leave it alone (only raise to floor).
+//
+// Offline-resilient bundling: the canonical ruleset ships in `data/` at
+// the package root (alongside `bin/`, `templates/`, etc., per package.json
+// `files`). We read it at runtime via fs.readFile so the build stays out
+// of TypeScript's `rootDir` constraint, and so callers that re-bundle
+// clud-bug into a single file can override the ruleset by passing one
+// explicitly to `applyCanonicalRuleset({ ruleset })`.
+
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The canonical-v1.json structure. Frozen at v1; major bumps require
+ * coordinated tool releases per the protocol repo's `$comment` field.
+ */
+export interface CanonicalRuleset {
+  version: 'v1';
+  spec_version: string;
+  branch_protection: {
+    required_status_checks: {
+      strict: boolean;
+      contexts: string[];
+    };
+    required_pull_request_reviews: {
+      required_approving_review_count: number;
+      dismiss_stale_reviews: boolean;
+      require_code_owner_reviews: boolean;
+    };
+    required_conversation_resolution: boolean;
+    enforce_admins: boolean;
+    allow_force_pushes: boolean;
+    allow_deletions: boolean;
+    required_linear_history: boolean;
+    allow_auto_merge: boolean;
+    delete_branch_on_merge: boolean;
+    squash_merge_commit_title: string;
+    squash_merge_commit_message: string;
+  };
+}
+
+/**
+ * Resolves the package root from this file's URL. After tsc the file lives
+ * at `<pkg>/dist/core/configure-github.js`; three dirname() climbs land on
+ * `<pkg>`, parallel to the package.json `files` map entry for `data`.
+ */
+const PKG_ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+
+/** Memoized canonical ruleset — loaded once per process. */
+let CANONICAL_V1_CACHE: CanonicalRuleset | null = null;
+
+/**
+ * Loads the bundled canonical-v1 ruleset from `data/canonical-v1.json`.
+ * Memoized so repeated calls don't re-hit the filesystem.
+ *
+ * Throws a wrapped error if the JSON file is missing — that's an
+ * install-time defect (package.json `files` excluded `data/`), not a
+ * runtime concern, and the loud failure surfaces it immediately.
+ */
+export async function loadCanonicalV1(): Promise<CanonicalRuleset> {
+  if (CANONICAL_V1_CACHE) return CANONICAL_V1_CACHE;
+  const path = join(PKG_ROOT, 'data', 'canonical-v1.json');
+  try {
+    const raw = await readFile(path, 'utf-8');
+    CANONICAL_V1_CACHE = JSON.parse(raw) as CanonicalRuleset;
+    return CANONICAL_V1_CACHE;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `configure-github: failed to load bundled canonical-v1.json at ${path}: ${msg}`,
+    );
+  }
+}
+
+/**
+ * Minimal structural Octokit interface — only the methods we actually call.
+ *
+ * We intentionally don't import `@octokit/rest` types: that would force
+ * every consumer (App, CLI, future tools) to install Octokit at runtime
+ * even when they pass a `gh`-CLI-backed adapter. Keeping the shape
+ * structural lets the CLI's `gh`-wrapping adapter satisfy it without
+ * pulling in a 200KB dep.
+ *
+ * If `@octokit/rest`'s real method shapes ever drift, the adapter +
+ * runtime call sites are the only files that need updating; the rule
+ * table here stays Octokit-version-agnostic.
+ */
+export interface OctokitLike {
+  repos: {
+    /** Read branch protection state. Throws on 404 (no protection rule). */
+    getBranchProtection(params: {
+      owner: string;
+      repo: string;
+      branch: string;
+    }): Promise<{
+      data: {
+        required_status_checks?:
+          | { strict?: boolean; contexts?: string[] }
+          | null;
+        required_pull_request_reviews?:
+          | {
+              required_approving_review_count?: number;
+              dismiss_stale_reviews?: boolean;
+              require_code_owner_reviews?: boolean;
+            }
+          | null;
+        required_conversation_resolution?: { enabled?: boolean } | null;
+        enforce_admins?: { enabled?: boolean } | null;
+        allow_force_pushes?: { enabled?: boolean } | null;
+        allow_deletions?: { enabled?: boolean } | null;
+        required_linear_history?: { enabled?: boolean } | null;
+      };
+    }>;
+    /** PUT branch protection (the REST API does NOT support PATCH). */
+    updateBranchProtection(params: {
+      owner: string;
+      repo: string;
+      branch: string;
+      required_status_checks: { strict: boolean; contexts: string[] } | null;
+      enforce_admins: boolean | null;
+      required_pull_request_reviews: {
+        required_approving_review_count: number;
+        dismiss_stale_reviews: boolean;
+        require_code_owner_reviews: boolean;
+      } | null;
+      restrictions: null;
+      required_conversation_resolution?: boolean;
+      required_linear_history?: boolean;
+      allow_force_pushes?: boolean;
+      allow_deletions?: boolean;
+    }): Promise<unknown>;
+    /** Read repo-level settings (delete_branch_on_merge, allow_auto_merge, etc). */
+    get(params: { owner: string; repo: string }): Promise<{
+      data: {
+        delete_branch_on_merge?: boolean;
+        allow_auto_merge?: boolean;
+        squash_merge_commit_title?: string;
+        squash_merge_commit_message?: string;
+      };
+    }>;
+    /** PATCH repo-level settings. */
+    update(params: {
+      owner: string;
+      repo: string;
+      delete_branch_on_merge?: boolean;
+      allow_auto_merge?: boolean;
+      squash_merge_commit_title?: string;
+      squash_merge_commit_message?: string;
+    }): Promise<unknown>;
+  };
+}
+
+export interface ApplyCanonicalRulesetParams {
+  owner: string;
+  repo: string;
+  /**
+   * Target branch (default: `main`). Most consumers will use `main`; this
+   * is exposed for downstream tools that converge non-`main` defaults.
+   */
+  branch?: string;
+  /**
+   * The ruleset to apply. Defaults to the bundled `canonical-v1.json`
+   * (loaded via `loadCanonicalV1()` if absent). Future v2 callers pass
+   * an explicit ruleset; the type system pins the shape.
+   */
+  ruleset?: CanonicalRuleset;
+  /**
+   * If true, compute diff only and skip all PATCH calls. The result still
+   * reports `changes: string[]` so the CLI can render the human-readable
+   * diff before applying.
+   */
+  dryRun?: boolean;
+}
+
+export interface ApplyResult {
+  /** Human-readable diff lines, one per detected difference. Empty when alreadyCanonical. */
+  changes: string[];
+  /** True when the live state already matches every canonical setting. */
+  alreadyCanonical: boolean;
+  /** Schema version applied (always 'canonical-v1' for this build). */
+  ruleset: 'canonical-v1';
+}
+
+/**
+ * Applies the canonical ruleset to a GitHub repo. Reads current state via
+ * the Octokit-like instance, diffs against `ruleset` (default
+ * `CANONICAL_V1`), and PATCHes only what differs. Idempotent: second call
+ * returns `alreadyCanonical: true` with no PATCH side effects.
+ *
+ * Behavior on partial mismatch:
+ *
+ *   - `required_status_checks.contexts`: canonical contexts that are
+ *     missing get added; extra contexts on the repo are preserved (superset
+ *     contract — a repo that runs more CI gates legitimately needs them).
+ *   - `required_approving_review_count`: canonical floor is 1; if the repo
+ *     already requires more, we don't lower (raise-only contract).
+ *   - All booleans (allow_force_pushes, allow_deletions, etc.): converge
+ *     to the canonical value exactly.
+ *
+ * Throws on Octokit transport failure (auth, network, 403). The CLI
+ * wraps these with a friendly error message.
+ */
+export async function applyCanonicalRuleset(
+  octokit: OctokitLike,
+  params: ApplyCanonicalRulesetParams,
+): Promise<ApplyResult> {
+  const {
+    owner,
+    repo,
+    branch = 'main',
+    dryRun = false,
+  } = params;
+  const ruleset = params.ruleset ?? (await loadCanonicalV1());
+
+  const target = ruleset.branch_protection;
+  const changes: string[] = [];
+
+  // ----- Read current branch protection state ---------------------------
+  // 404 → no base protection rule. We treat that as "every canonical
+  // setting differs" so the apply path creates the rule. Other errors
+  // bubble up — callers can't recover from a 403.
+  let current: Awaited<
+    ReturnType<OctokitLike['repos']['getBranchProtection']>
+  >['data'] = {};
+  let hasBaseProtection = true;
+  try {
+    const resp = await octokit.repos.getBranchProtection({
+      owner,
+      repo,
+      branch,
+    });
+    current = resp.data;
+  } catch (err) {
+    if (isBranchNotProtected(err)) {
+      hasBaseProtection = false;
+    } else {
+      throw err;
+    }
+  }
+
+  // ----- Diff: required_status_checks -----------------------------------
+  // Behavior: contexts are a SUPERSET. Strict mode must match exactly.
+  const currentChecks = current.required_status_checks ?? null;
+  const currentContexts = new Set(currentChecks?.contexts ?? []);
+  const targetContexts = new Set(target.required_status_checks.contexts);
+  const missingContexts = [...targetContexts].filter(
+    (c) => !currentContexts.has(c),
+  );
+  const strictMismatch =
+    (currentChecks?.strict ?? false) !== target.required_status_checks.strict;
+  let needsChecksPatch = !hasBaseProtection;
+  if (missingContexts.length > 0) {
+    changes.push(
+      `required_status_checks.contexts: add ${JSON.stringify(missingContexts)}`,
+    );
+    needsChecksPatch = true;
+  }
+  if (strictMismatch) {
+    changes.push(
+      `required_status_checks.strict: ${currentChecks?.strict ?? false} → ${target.required_status_checks.strict}`,
+    );
+    needsChecksPatch = true;
+  }
+  // The merged context list: keep extras the repo already required.
+  const mergedContexts = [
+    ...new Set([
+      ...(currentChecks?.contexts ?? []),
+      ...target.required_status_checks.contexts,
+    ]),
+  ];
+
+  // ----- Diff: required_pull_request_reviews ----------------------------
+  // Behavior: approving_review_count is a FLOOR (only raise). Booleans
+  // converge exactly.
+  const currentReviews = current.required_pull_request_reviews ?? null;
+  const currentCount = currentReviews?.required_approving_review_count ?? 0;
+  const targetCount =
+    target.required_pull_request_reviews.required_approving_review_count;
+  const effectiveCount = Math.max(currentCount, targetCount);
+  const targetDismiss =
+    target.required_pull_request_reviews.dismiss_stale_reviews;
+  const targetCodeOwner =
+    target.required_pull_request_reviews.require_code_owner_reviews;
+  let needsReviewsPatch = !hasBaseProtection;
+  if (effectiveCount !== currentCount) {
+    changes.push(
+      `required_pull_request_reviews.required_approving_review_count: ${currentCount} → ${effectiveCount}`,
+    );
+    needsReviewsPatch = true;
+  }
+  if ((currentReviews?.dismiss_stale_reviews ?? false) !== targetDismiss) {
+    changes.push(
+      `required_pull_request_reviews.dismiss_stale_reviews: ${currentReviews?.dismiss_stale_reviews ?? false} → ${targetDismiss}`,
+    );
+    needsReviewsPatch = true;
+  }
+  if (
+    (currentReviews?.require_code_owner_reviews ?? false) !== targetCodeOwner
+  ) {
+    changes.push(
+      `required_pull_request_reviews.require_code_owner_reviews: ${currentReviews?.require_code_owner_reviews ?? false} → ${targetCodeOwner}`,
+    );
+    needsReviewsPatch = true;
+  }
+
+  // ----- Diff: single-flag branch protection booleans -------------------
+  const conv =
+    current.required_conversation_resolution?.enabled ?? false;
+  const enforceAdmins = current.enforce_admins?.enabled ?? false;
+  const allowFP = current.allow_force_pushes?.enabled ?? false;
+  const allowDel = current.allow_deletions?.enabled ?? false;
+  const linearHistory = current.required_linear_history?.enabled ?? false;
+  if (conv !== target.required_conversation_resolution) {
+    changes.push(
+      `required_conversation_resolution: ${conv} → ${target.required_conversation_resolution}`,
+    );
+  }
+  if (enforceAdmins !== target.enforce_admins) {
+    changes.push(
+      `enforce_admins: ${enforceAdmins} → ${target.enforce_admins}`,
+    );
+  }
+  if (allowFP !== target.allow_force_pushes) {
+    changes.push(
+      `allow_force_pushes: ${allowFP} → ${target.allow_force_pushes}`,
+    );
+  }
+  if (allowDel !== target.allow_deletions) {
+    changes.push(
+      `allow_deletions: ${allowDel} → ${target.allow_deletions}`,
+    );
+  }
+  if (linearHistory !== target.required_linear_history) {
+    changes.push(
+      `required_linear_history: ${linearHistory} → ${target.required_linear_history}`,
+    );
+  }
+
+  // ----- Diff: repo-level settings --------------------------------------
+  // delete_branch_on_merge / allow_auto_merge / squash commit shape live
+  // on the REPO, not the branch protection rule. Fetched separately.
+  const repoResp = await octokit.repos.get({ owner, repo });
+  const repoData = repoResp.data;
+  const repoPatch: Parameters<OctokitLike['repos']['update']>[0] = {
+    owner,
+    repo,
+  };
+  let needsRepoPatch = false;
+  if (
+    (repoData.delete_branch_on_merge ?? false) !== target.delete_branch_on_merge
+  ) {
+    changes.push(
+      `delete_branch_on_merge: ${repoData.delete_branch_on_merge ?? false} → ${target.delete_branch_on_merge}`,
+    );
+    repoPatch.delete_branch_on_merge = target.delete_branch_on_merge;
+    needsRepoPatch = true;
+  }
+  if ((repoData.allow_auto_merge ?? false) !== target.allow_auto_merge) {
+    changes.push(
+      `allow_auto_merge: ${repoData.allow_auto_merge ?? false} → ${target.allow_auto_merge}`,
+    );
+    repoPatch.allow_auto_merge = target.allow_auto_merge;
+    needsRepoPatch = true;
+  }
+  if (
+    (repoData.squash_merge_commit_title ?? '') !==
+    target.squash_merge_commit_title
+  ) {
+    changes.push(
+      `squash_merge_commit_title: ${repoData.squash_merge_commit_title ?? '(unset)'} → ${target.squash_merge_commit_title}`,
+    );
+    repoPatch.squash_merge_commit_title = target.squash_merge_commit_title;
+    needsRepoPatch = true;
+  }
+  if (
+    (repoData.squash_merge_commit_message ?? '') !==
+    target.squash_merge_commit_message
+  ) {
+    changes.push(
+      `squash_merge_commit_message: ${repoData.squash_merge_commit_message ?? '(unset)'} → ${target.squash_merge_commit_message}`,
+    );
+    repoPatch.squash_merge_commit_message = target.squash_merge_commit_message;
+    needsRepoPatch = true;
+  }
+
+  const alreadyCanonical = changes.length === 0;
+
+  if (alreadyCanonical || dryRun) {
+    return {
+      changes,
+      alreadyCanonical,
+      ruleset: 'canonical-v1',
+    };
+  }
+
+  // ----- Apply: branch protection ---------------------------------------
+  // The REST API requires a PUT (not PATCH) with the full settings object.
+  // We always send a complete envelope; the diff above gates whether we
+  // call PUT at all.
+  if (needsChecksPatch || needsReviewsPatch || !hasBaseProtection || hasBranchProtectionLevelDiff(changes)) {
+    await octokit.repos.updateBranchProtection({
+      owner,
+      repo,
+      branch,
+      required_status_checks: {
+        strict: target.required_status_checks.strict,
+        contexts: mergedContexts,
+      },
+      enforce_admins: target.enforce_admins,
+      required_pull_request_reviews: {
+        required_approving_review_count: effectiveCount,
+        dismiss_stale_reviews: targetDismiss,
+        require_code_owner_reviews: targetCodeOwner,
+      },
+      restrictions: null,
+      required_conversation_resolution: target.required_conversation_resolution,
+      required_linear_history: target.required_linear_history,
+      allow_force_pushes: target.allow_force_pushes,
+      allow_deletions: target.allow_deletions,
+    });
+  }
+
+  // ----- Apply: repo-level settings -------------------------------------
+  if (needsRepoPatch) {
+    await octokit.repos.update(repoPatch);
+  }
+
+  return {
+    changes,
+    alreadyCanonical: false,
+    ruleset: 'canonical-v1',
+  };
+}
+
+/**
+ * Octokit (and gh's wrapping adapter) report a missing branch protection
+ * rule as a 404. We catch on the structural shape of the error so the
+ * downstream Octokit version doesn't matter.
+ */
+function isBranchNotProtected(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { status?: number; message?: string };
+  if (e.status === 404) return true;
+  if (typeof e.message === 'string') {
+    return /Branch not protected|Not Found|404/i.test(e.message);
+  }
+  return false;
+}
+
+/**
+ * Detect whether any of the per-branch protection settings (conversation
+ * resolution / force-pushes / deletions / linear-history / enforce-admins)
+ * appeared in the change list. Used to decide whether the branch protection
+ * PUT needs to fire when status_checks + reviews are both in sync.
+ */
+function hasBranchProtectionLevelDiff(changes: string[]): boolean {
+  return changes.some((c) =>
+    /^(required_conversation_resolution|enforce_admins|allow_force_pushes|allow_deletions|required_linear_history):/.test(
+      c,
+    ),
+  );
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -151,6 +151,18 @@ export {
   type ParsedFinding,
   type ParsedReview,
 } from './diff-findings.js';
+// SPEC §7 canonical-ruleset applier. Pure diff + idempotent-PATCH logic;
+// CLI side wraps `gh api` in an Octokit-like adapter and the App passes
+// its real Octokit instance. Shipped in v0.7.0-rc.4 for Marketplace prep
+// (Phase 6 task #227).
+export {
+  applyCanonicalRuleset,
+  loadCanonicalV1,
+  type CanonicalRuleset,
+  type OctokitLike,
+  type ApplyCanonicalRulesetParams,
+  type ApplyResult,
+} from './configure-github.js';
 export {
   API_BASE,
   MAX_SKILLS,

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -366,7 +366,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.3
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -366,7 +366,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.3
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -641,7 +641,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.3
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/core/configure-github.test.js
+++ b/test/core/configure-github.test.js
@@ -1,0 +1,506 @@
+// v0.7.0-rc.4 — SPEC §7 canonical-ruleset applier.
+//
+// The pure half (in src/core/configure-github.ts) takes a structural
+// OctokitLike instance and diffs current state vs the canonical ruleset.
+// These tests mock Octokit to verify:
+//   1. Fresh repo (404 + zero settings) → applies all rules.
+//   2. Already-canonical repo → returns alreadyCanonical: true, no PATCHes.
+//   3. Partial mismatch → emits exactly the diffs that differ.
+//   4. Idempotency contract: apply(); apply() converges + reports no changes
+//      on the second call.
+//   5. CLI wrapper (src/cli/configure-github.ts): missing token → exit 1.
+
+import { test } from 'vitest';
+import { strict as assert } from 'node:assert';
+import {
+  applyCanonicalRuleset,
+  loadCanonicalV1,
+} from '../../src/core/configure-github.js';
+import { runConfigureGithub } from '../../src/cli/configure-github.js';
+
+// ---------------------------------------------------------------------------
+// Octokit mock factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a minimal OctokitLike mock that:
+ *   - records every call into `calls`
+ *   - returns the seed state from `current` for read methods
+ *   - lets write methods mutate `current` so a subsequent apply() observes
+ *     the converged state (idempotency contract)
+ *
+ * On a fresh repo with no protection rule, pass branchProtection404=true
+ * — the mock then throws a 404-shaped error from getBranchProtection.
+ */
+function makeOctokitMock({
+  branchProtection = null,
+  branchProtection404 = false,
+  repoSettings = {},
+} = {}) {
+  const state = {
+    branchProtection,
+    branchProtection404,
+    repoSettings: { ...repoSettings },
+  };
+  const calls = {
+    getBranchProtection: 0,
+    updateBranchProtection: 0,
+    get: 0,
+    update: 0,
+    lastUpdateBranchProtectionPayload: null,
+    lastUpdatePayload: null,
+  };
+
+  return {
+    state,
+    calls,
+    octokit: {
+      repos: {
+        async getBranchProtection({ owner, repo, branch }) {
+          calls.getBranchProtection++;
+          if (state.branchProtection404) {
+            const err = new Error('Branch not protected');
+            err.status = 404;
+            throw err;
+          }
+          return { data: state.branchProtection ?? {} };
+        },
+        async updateBranchProtection(params) {
+          calls.updateBranchProtection++;
+          calls.lastUpdateBranchProtectionPayload = params;
+          // Mirror what GitHub would do after a successful PUT — write the
+          // settings back so a subsequent read sees them.
+          state.branchProtection404 = false;
+          state.branchProtection = {
+            required_status_checks: params.required_status_checks,
+            required_pull_request_reviews: params.required_pull_request_reviews,
+            required_conversation_resolution: {
+              enabled: params.required_conversation_resolution === true,
+            },
+            enforce_admins: { enabled: params.enforce_admins === true },
+            allow_force_pushes: { enabled: params.allow_force_pushes === true },
+            allow_deletions: { enabled: params.allow_deletions === true },
+            required_linear_history: {
+              enabled: params.required_linear_history === true,
+            },
+          };
+          return {};
+        },
+        async get({ owner, repo }) {
+          calls.get++;
+          return { data: state.repoSettings };
+        },
+        async update(params) {
+          calls.update++;
+          calls.lastUpdatePayload = params;
+          for (const k of [
+            'delete_branch_on_merge',
+            'allow_auto_merge',
+            'squash_merge_commit_title',
+            'squash_merge_commit_message',
+          ]) {
+            if (params[k] !== undefined) state.repoSettings[k] = params[k];
+          }
+          return {};
+        },
+      },
+    },
+  };
+}
+
+// The canonical settings as bundled in data/canonical-v1.json. Inlining
+// the expected end-state lets us build "already canonical" mock state
+// without coupling to the file's exact contents.
+const CANONICAL_BRANCH_PROTECTION_STATE = {
+  required_status_checks: {
+    strict: true,
+    contexts: [
+      'clud-bug-review',
+      'check-decisions',
+      'check-derived-docs',
+      'check-links',
+      'test',
+    ],
+  },
+  required_pull_request_reviews: {
+    required_approving_review_count: 1,
+    dismiss_stale_reviews: false,
+    require_code_owner_reviews: false,
+  },
+  required_conversation_resolution: { enabled: true },
+  enforce_admins: { enabled: false },
+  allow_force_pushes: { enabled: false },
+  allow_deletions: { enabled: false },
+  required_linear_history: { enabled: false },
+};
+
+const CANONICAL_REPO_STATE = {
+  delete_branch_on_merge: true,
+  allow_auto_merge: true,
+  squash_merge_commit_title: 'PR_TITLE',
+  squash_merge_commit_message: 'PR_BODY',
+};
+
+// ---------------------------------------------------------------------------
+// loadCanonicalV1
+// ---------------------------------------------------------------------------
+
+test('loadCanonicalV1: returns canonical-v1 schema from bundled file', async () => {
+  const ruleset = await loadCanonicalV1();
+  assert.equal(ruleset.version, 'v1');
+  assert.ok(ruleset.spec_version);
+  assert.equal(ruleset.branch_protection.required_conversation_resolution, true);
+  assert.deepEqual(
+    ruleset.branch_protection.required_status_checks.contexts,
+    [
+      'clud-bug-review',
+      'check-decisions',
+      'check-derived-docs',
+      'check-links',
+      'test',
+    ],
+  );
+});
+
+test('loadCanonicalV1: result is memoized (same object on second call)', async () => {
+  const a = await loadCanonicalV1();
+  const b = await loadCanonicalV1();
+  assert.equal(a, b);
+});
+
+// ---------------------------------------------------------------------------
+// applyCanonicalRuleset: fresh-repo path (no protection rule)
+// ---------------------------------------------------------------------------
+
+test('apply: fresh repo (404 protection) — applies all rules, alreadyCanonical=false', async () => {
+  const { octokit, calls } = makeOctokitMock({ branchProtection404: true });
+  const result = await applyCanonicalRuleset(octokit, {
+    owner: 'octo',
+    repo: 'demo',
+  });
+  assert.equal(result.alreadyCanonical, false);
+  assert.equal(result.ruleset, 'canonical-v1');
+  assert.ok(result.changes.length > 0);
+  assert.equal(calls.updateBranchProtection, 1);
+  assert.equal(calls.update, 1);
+});
+
+test('apply: fresh repo — branch protection PUT carries canonical settings', async () => {
+  const { octokit, calls } = makeOctokitMock({ branchProtection404: true });
+  await applyCanonicalRuleset(octokit, { owner: 'octo', repo: 'demo' });
+  const payload = calls.lastUpdateBranchProtectionPayload;
+  assert.equal(payload.required_conversation_resolution, true);
+  assert.equal(payload.enforce_admins, false);
+  assert.equal(payload.allow_force_pushes, false);
+  assert.equal(payload.allow_deletions, false);
+  assert.equal(payload.required_status_checks.strict, true);
+  assert.deepEqual(payload.required_status_checks.contexts.sort(), [
+    'check-decisions',
+    'check-derived-docs',
+    'check-links',
+    'clud-bug-review',
+    'test',
+  ]);
+  assert.equal(
+    payload.required_pull_request_reviews.required_approving_review_count,
+    1,
+  );
+});
+
+test('apply: fresh repo — repo-level PATCH carries canonical settings', async () => {
+  const { octokit, calls } = makeOctokitMock({ branchProtection404: true });
+  await applyCanonicalRuleset(octokit, { owner: 'octo', repo: 'demo' });
+  const payload = calls.lastUpdatePayload;
+  assert.equal(payload.delete_branch_on_merge, true);
+  assert.equal(payload.allow_auto_merge, true);
+  assert.equal(payload.squash_merge_commit_title, 'PR_TITLE');
+  assert.equal(payload.squash_merge_commit_message, 'PR_BODY');
+});
+
+// ---------------------------------------------------------------------------
+// applyCanonicalRuleset: already-canonical path
+// ---------------------------------------------------------------------------
+
+test('apply: already-canonical → alreadyCanonical=true, no PATCH calls', async () => {
+  const { octokit, calls } = makeOctokitMock({
+    branchProtection: CANONICAL_BRANCH_PROTECTION_STATE,
+    repoSettings: CANONICAL_REPO_STATE,
+  });
+  const result = await applyCanonicalRuleset(octokit, {
+    owner: 'octo',
+    repo: 'demo',
+  });
+  assert.equal(result.alreadyCanonical, true);
+  assert.deepEqual(result.changes, []);
+  assert.equal(calls.updateBranchProtection, 0);
+  assert.equal(calls.update, 0);
+});
+
+// ---------------------------------------------------------------------------
+// applyCanonicalRuleset: partial mismatch — only PATCH what differs
+// ---------------------------------------------------------------------------
+
+test('apply: partial mismatch (only delete_branch_on_merge differs) — emits 1 change + 1 repo PATCH', async () => {
+  const { octokit, calls } = makeOctokitMock({
+    branchProtection: CANONICAL_BRANCH_PROTECTION_STATE,
+    repoSettings: { ...CANONICAL_REPO_STATE, delete_branch_on_merge: false },
+  });
+  const result = await applyCanonicalRuleset(octokit, {
+    owner: 'octo',
+    repo: 'demo',
+  });
+  assert.equal(result.alreadyCanonical, false);
+  assert.equal(result.changes.length, 1);
+  assert.match(result.changes[0], /delete_branch_on_merge: false → true/);
+  assert.equal(calls.updateBranchProtection, 0); // no branch-protection PATCH
+  assert.equal(calls.update, 1); // one repo PATCH only
+});
+
+test('apply: missing status check contexts — superset behavior preserves extras', async () => {
+  // Repo currently requires the canonical 5 contexts PLUS one extra
+  // ("lint"). Canonical doesn't touch "lint" — superset contract says we
+  // leave it alone. We also intentionally drop one canonical context
+  // ("test") so the apply path must add it back without dropping "lint".
+  const repoState = {
+    ...CANONICAL_BRANCH_PROTECTION_STATE,
+    required_status_checks: {
+      strict: true,
+      contexts: [
+        'clud-bug-review',
+        'check-decisions',
+        'check-derived-docs',
+        'check-links',
+        'lint', // extra repo-specific context — must be preserved
+      ],
+    },
+  };
+  const { octokit, calls } = makeOctokitMock({
+    branchProtection: repoState,
+    repoSettings: CANONICAL_REPO_STATE,
+  });
+  const result = await applyCanonicalRuleset(octokit, {
+    owner: 'octo',
+    repo: 'demo',
+  });
+  assert.equal(result.alreadyCanonical, false);
+  // One change: contexts.add ["test"]
+  assert.ok(
+    result.changes.some((c) =>
+      /required_status_checks.contexts: add \["test"\]/.test(c),
+    ),
+    `expected "add test" change; got: ${result.changes.join(' | ')}`,
+  );
+  assert.equal(calls.updateBranchProtection, 1);
+  // Verify the PUT payload preserved "lint" AND added "test"
+  const payload = calls.lastUpdateBranchProtectionPayload;
+  assert.ok(payload.required_status_checks.contexts.includes('lint'));
+  assert.ok(payload.required_status_checks.contexts.includes('test'));
+});
+
+test('apply: higher required_approving_review_count is NOT lowered (raise-only contract)', async () => {
+  const repoState = {
+    ...CANONICAL_BRANCH_PROTECTION_STATE,
+    required_pull_request_reviews: {
+      required_approving_review_count: 2, // higher than canonical floor of 1
+      dismiss_stale_reviews: false,
+      require_code_owner_reviews: false,
+    },
+  };
+  const { octokit, calls } = makeOctokitMock({
+    branchProtection: repoState,
+    repoSettings: CANONICAL_REPO_STATE,
+  });
+  const result = await applyCanonicalRuleset(octokit, {
+    owner: 'octo',
+    repo: 'demo',
+  });
+  // Already-canonical — repo's count of 2 stays.
+  assert.equal(result.alreadyCanonical, true);
+  assert.equal(calls.updateBranchProtection, 0);
+});
+
+test('apply: --dry-run skips ALL PATCH calls + still reports changes', async () => {
+  const { octokit, calls } = makeOctokitMock({ branchProtection404: true });
+  const result = await applyCanonicalRuleset(octokit, {
+    owner: 'octo',
+    repo: 'demo',
+    dryRun: true,
+  });
+  assert.equal(result.alreadyCanonical, false);
+  assert.ok(result.changes.length > 0);
+  assert.equal(calls.updateBranchProtection, 0);
+  assert.equal(calls.update, 0);
+});
+
+// ---------------------------------------------------------------------------
+// applyCanonicalRuleset: idempotency contract
+// ---------------------------------------------------------------------------
+
+test('apply: idempotent — apply(); apply() second call reports alreadyCanonical', async () => {
+  // The mock mutates state on PUT/PATCH, so a second call sees the
+  // converged state. This is the contract the SPEC pins.
+  const { octokit, calls } = makeOctokitMock({ branchProtection404: true });
+  const first = await applyCanonicalRuleset(octokit, {
+    owner: 'octo',
+    repo: 'demo',
+  });
+  assert.equal(first.alreadyCanonical, false);
+  const second = await applyCanonicalRuleset(octokit, {
+    owner: 'octo',
+    repo: 'demo',
+  });
+  assert.equal(second.alreadyCanonical, true);
+  assert.deepEqual(second.changes, []);
+  // First call: 1 PUT + 1 PATCH. Second: zero additional writes.
+  assert.equal(calls.updateBranchProtection, 1);
+  assert.equal(calls.update, 1);
+});
+
+test('apply: respects --branch override', async () => {
+  const { octokit, calls } = makeOctokitMock({ branchProtection404: true });
+  await applyCanonicalRuleset(octokit, {
+    owner: 'octo',
+    repo: 'demo',
+    branch: 'develop',
+  });
+  assert.equal(calls.updateBranchProtection, 1);
+  const payload = calls.lastUpdateBranchProtectionPayload;
+  assert.equal(payload.branch, 'develop');
+});
+
+// ---------------------------------------------------------------------------
+// applyCanonicalRuleset: error propagation (non-404)
+// ---------------------------------------------------------------------------
+
+test('apply: non-404 transport error from getBranchProtection bubbles up', async () => {
+  const octokit = {
+    repos: {
+      async getBranchProtection() {
+        const err = new Error('HTTP 403 Forbidden');
+        err.status = 403;
+        throw err;
+      },
+      async updateBranchProtection() {
+        throw new Error('should not be called');
+      },
+      async get() {
+        return { data: {} };
+      },
+      async update() {
+        throw new Error('should not be called');
+      },
+    },
+  };
+  await assert.rejects(
+    applyCanonicalRuleset(octokit, { owner: 'o', repo: 'r' }),
+    /403 Forbidden/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// CLI wrapper: token missing → exit 1
+// ---------------------------------------------------------------------------
+
+test('runConfigureGithub: no token → exit 1 with recovery hint', async () => {
+  let stderrBuf = '';
+  const code = await runConfigureGithub({
+    target: 'octo/demo',
+    resolveToken: async () => null,
+    octokitFactory: () => {
+      throw new Error('should not be called');
+    },
+    stdout: () => {},
+    stderr: (m) => {
+      stderrBuf += m;
+    },
+  });
+  assert.equal(code, 1);
+  assert.match(stderrBuf, /no GitHub token/);
+  assert.match(stderrBuf, /GITHUB_TOKEN|gh auth login/);
+});
+
+test('runConfigureGithub: missing target → exit 2 with help', async () => {
+  let stderrBuf = '';
+  const code = await runConfigureGithub({
+    target: null,
+    stdout: () => {},
+    stderr: (m) => {
+      stderrBuf += m;
+    },
+  });
+  assert.equal(code, 2);
+  assert.match(stderrBuf, /Usage:/);
+});
+
+test('runConfigureGithub: malformed target → exit 2', async () => {
+  let stderrBuf = '';
+  const code = await runConfigureGithub({
+    target: 'no-slash',
+    resolveToken: async () => 'token',
+    stdout: () => {},
+    stderr: (m) => {
+      stderrBuf += m;
+    },
+  });
+  assert.equal(code, 2);
+  assert.match(stderrBuf, /owner\/repo/);
+});
+
+test('runConfigureGithub: already-canonical → exit 0 with summary', async () => {
+  let stdoutBuf = '';
+  const { octokit } = makeOctokitMock({
+    branchProtection: CANONICAL_BRANCH_PROTECTION_STATE,
+    repoSettings: CANONICAL_REPO_STATE,
+  });
+  const code = await runConfigureGithub({
+    target: 'octo/demo',
+    resolveToken: async () => 'token',
+    octokitFactory: () => octokit,
+    quiet: true,
+    stdout: (m) => {
+      stdoutBuf += m;
+    },
+    stderr: () => {},
+  });
+  assert.equal(code, 0);
+  assert.match(stdoutBuf, /ok configure-github: octo\/demo already canonical-v1/);
+});
+
+test('runConfigureGithub: --dry-run reports diff but skips PATCH', async () => {
+  let stdoutBuf = '';
+  const { octokit, calls } = makeOctokitMock({ branchProtection404: true });
+  const code = await runConfigureGithub({
+    target: 'octo/demo',
+    dryRun: true,
+    quiet: true,
+    resolveToken: async () => 'token',
+    octokitFactory: () => octokit,
+    stdout: (m) => {
+      stdoutBuf += m;
+    },
+    stderr: () => {},
+  });
+  assert.equal(code, 0);
+  assert.equal(calls.updateBranchProtection, 0);
+  assert.equal(calls.update, 0);
+  assert.match(stdoutBuf, /dry-run on octo\/demo/);
+});
+
+test('runConfigureGithub: apply path PATCHes + reports change count', async () => {
+  let stdoutBuf = '';
+  const { octokit, calls } = makeOctokitMock({ branchProtection404: true });
+  const code = await runConfigureGithub({
+    target: 'octo/demo',
+    quiet: true,
+    resolveToken: async () => 'token',
+    octokitFactory: () => octokit,
+    stdout: (m) => {
+      stdoutBuf += m;
+    },
+    stderr: () => {},
+  });
+  assert.equal(code, 0);
+  assert.equal(calls.updateBranchProtection, 1);
+  assert.equal(calls.update, 1);
+  assert.match(stdoutBuf, /converged to canonical-v1/);
+});


### PR DESCRIPTION
## Summary

Three SPEC-aligned core enhancements bundled for the v0.7.0 Marketplace prep ship train. All three land in `src/core/` so clud-bug-app's Phase 4 re-import lands them in one wave.

- **Wave A — `clud-bug configure-github <owner>/<repo>`** (Phase 6 task #227). Pure diff + idempotent-PATCH applier for the SPEC §7 canonical ruleset. `applyCanonicalRuleset(octokit, params)` exported from `clud-bug/core` takes a structural `OctokitLike` interface (no `@octokit/rest` runtime dep — App passes its real instance; CLI passes a `gh api`-backed adapter). Hard idempotency contract: `apply(); apply()` converges and the second call reports `alreadyCanonical: true` with zero PATCH side effects. Auth ladder: `GITHUB_TOKEN` env → `gh auth token` → helpful exit-1. Bundled `data/canonical-v1.json` for offline-resilient operation. Behavior on partial mismatch: `required_status_checks.contexts` are a SUPERSET (extras preserved); `required_approving_review_count` is a FLOOR (never lowered).
- **Wave B — SPEC §6.7.3 cache telemetry comment in review file** (task #224). `renderReviewFile()` accepts optional `cacheStats: { cachedInputTokens, cacheCreationInputTokens }`. When present, emits `<!-- cache: <read> read · <created> created -->` immediately below `<!-- review-sha: ... -->`. Lights up post-hoc cost analysis on committed doc-files via a single `grep` over `docs/reviews/PR-*.md`.
- **Wave C — SPEC §1.8.1 Resolved / Still open blocks** (task #228). `renderReviewFile()` accepts optional `resolvedFindings: Finding[]` and `stillOpenFindings: Finding[]` lists. When non-empty, emits the named blocks AFTER severity buckets and BEFORE the trailing `---`. Each bullet carries `(was 🔴 Critical / 🟡 Minor / 🟣 Preexisting)` so cross-round downgrades are visible without diffing the two doc files. Backs the G7.t "1 resolved from prior" status line with the explicit named finding list.

## Locked architecture note

This PR is the **npm side**. Per Bug 9 / Phase 2-4 architecture, clud-bug npm is the single source of truth. clud-bug-app consumption of the new exports (`applyCanonicalRuleset` + `renderReviewFile` cache/resolved-findings extensions) is a **follow-up wave dispatched AFTER USER tags + publishes v0.7.0-rc.4**. No App-side changes ship here.

## Cross-links

- Plan §Phase 6 (Marketplace prep)
- Task #224 (cache comment)
- Task #227 (configure-github applier)
- Task #228 (resolved findings named explicitly)
- SPEC §1.8.1 (Resolved/Still-open blocks)
- SPEC §6.7.3 (cache telemetry comment)
- SPEC §7 (canonical branch protection ruleset)

## Test plan

- [x] `npm run build` clean (TypeScript zero errors)
- [x] `npm test` all 585 green (26 test files, 19 new tests under `test/core/configure-github.test.js`)
- [x] `node bin/clud-bug.js configure-github` shows subcommand help with usage + flags + auth ladder
- [x] `node bin/clud-bug.js --version` reports `0.7.0-rc.4`
- [x] release-discipline guard: all 3 workflow templates + `action.yml` pin `strict-mode-gate@v0.7.0-rc.4`
- [x] Idempotency contract verified in mocked Octokit tests: `apply(); apply()` reports `alreadyCanonical: true` on second call with zero PATCH calls
- [x] Superset behavior verified: extra repo-specific contexts preserved
- [x] Raise-only behavior verified: higher `required_approving_review_count` not lowered
- [x] `--dry-run` skips ALL PATCH calls + still reports change list

## Do not (per task brief)

- Do not merge (CTO morning review)
- Do not tag v0.7.0-rc.4 (USER action)
- Do not `npm publish` (USER action)
- Do not touch `site/` (parallel agent owns that)
- Do not touch `clud-bug-app` repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)