### PR TITLE
chore(package): bin field — string → object shape

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "ai",
     "skills"
   ],
-  "bin": "bin/clud-bug.js",
+  "bin": {
+    "clud-bug": "bin/clud-bug.js"
+  },
   "files": [
     "bin",
     "data",


### PR DESCRIPTION
Closes the rc.4 publish warning. npm internally normalizes string-form bin to object-form during publish; bringing source in line so future publishes go through clean. No behavior change.