### PR TITLE
fix(ci): unblock main — drop stale workflow refs + fix time-dependent test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,12 @@ jobs:
         # upstream by the logmind tool — file shellcheck issues against
         # thrillmade/logmind, not here.
         run: |
+          # PR #170 (2026-06-17 stop-the-bleed) deleted clud-bug-review.yml +
+          # claude-code-review.yml — they consumed ANTHROPIC_API_KEY directly
+          # and double-billed alongside the hosted App's AI Gateway path. Removed
+          # from this lint list. clud-bug-audit.yml is on consumer repos only;
+          # never lived in clud-bug itself.
           for wf in .github/workflows/ci.yml \
-                    .github/workflows/clud-bug-review.yml \
-                    .github/workflows/clud-bug-audit.yml \
-                    .github/workflows/clud-bug-self-update.yml \
-                    .github/workflows/claude-code-review.yml; do
-            [ -f "$wf" ] && ./actionlint "$wf"
+                    .github/workflows/clud-bug-self-update.yml; do
+            if [ -f "$wf" ]; then ./actionlint "$wf"; fi
           done

--- a/docs/decisions-branches/chore__ci-actionlint-drop-deleted-workflow-refs.md
+++ b/docs/decisions-branches/chore__ci-actionlint-drop-deleted-workflow-refs.md
@@ -1,0 +1,14 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-25 19:46 - Unblock main CI: drop stale workflow references from actionlint job + relative timestamp in usage fixture
+
+**Reasoning:** Two independent CI failures had silently accumulated on main. (1) ci.yml's actionlint job still hardcoded clud-bug-review.yml + claude-code-review.yml in its lint list 8 days after PR #170 deleted those workflows; under `set -e`, `[ -f missing-file ]` returns 1 and fails the script. (2) test/usage.test.js fixture's hardcoded createdAt '2026-05-25T00:00:00Z' drifted out of the rollup's 30-day current window as the calendar advanced, inverting the 'no prior window' test semantics. Each alone blocks every PR; both must land before the 3 open dependabot PRs (#162/#167/#173) can merge.
+
+**Alternatives considered:** Two separate PRs honoring the locked workflow-isolation rule (deadlocked: each PR would inherit the OTHER failure from main and land CI-red, forcing admin bypass), Convert actionlint job to a glob-based loop (every .github/workflows/*.yml) — wider but auto-self-healing for future workflow deletions; deferred because mixing template-rendered (.ci-rendered/*.yml) with owned workflows needs more thought
+
+**Implications:**
+- Time-stable test fixtures need relative timestamps when any rollup window logic depends on Date.now(). Will add a CONTRIBUTING note or lint to catch literal ISO dates in test fixtures over time
+- Workflow lint lists should be glob-discovered, not hardcoded; revisit in next workflow refactor wave
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (43 decisions)
+## 2026-06 (44 decisions)
 
-- **2026-06-17** — v0.7.0-rc.4: configure-github + cache comment + resolved findings naming *(feat/rc.4-configure-github-cache-resolved)* — [decisions-branches/feat__rc.4-configure-github-cache-resolved.md](decisions-branches/feat__rc.4-configure-github-cache-resolved.md)
-- *... 41 more decisions ...*
+- **2026-06-25** — Unblock main CI: drop stale workflow references from actionlint job + relative timestamp in usage fixture *(chore/ci-actionlint-drop-deleted-workflow-refs)* — [decisions-branches/chore__ci-actionlint-drop-deleted-workflow-refs.md](decisions-branches/chore__ci-actionlint-drop-deleted-workflow-refs.md)
+- *... 42 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/test/usage.test.js
+++ b/test/usage.test.js
@@ -202,11 +202,20 @@ test('extractTokensFromLog: log without token fields returns ok:false (job error
 
 // --- rollup ---
 
+// Default fixture createdAt is "7 days ago" relative to test-run time —
+// keeps the fixture inside the rollup's 30-day current window even as the
+// system clock advances. Previously a hardcoded literal (2026-05-25) drifted
+// outside the window once the calendar moved on, inverting the "no prior
+// window" test semantics. The relative form is stable across clock motion.
+const DEFAULT_FIXTURE_CREATED_AT = new Date(
+  Date.now() - 7 * 24 * 60 * 60 * 1000,
+).toISOString();
+
 function fixture(repo, pr, modifier = {}) {
   return {
     repo,
     pr,
-    createdAt: modifier.createdAt || '2026-05-25T00:00:00Z',
+    createdAt: modifier.createdAt || DEFAULT_FIXTURE_CREATED_AT,
     model: modifier.model || 'claude-sonnet-4-6',
     tokens: { input_tokens: 1000, output_tokens: 500, cache_read_input_tokens: 9000, cache_creation_input_tokens: 0 },
     additions: modifier.additions ?? 100,


### PR DESCRIPTION
Bundles two independent CI fixes that are both required to unblock main. Per CTO direction on this PR specifically: the locked "workflow files in their own PR" rule's rationale (Anthropic action validation 401 on `clud-bug-review.yml`) doesn't apply on clud-bug — that workflow was deleted in PR #170 stop-the-bleed. `ci.yml` has no validation gate, so combining the two fixes is safe and necessary (each PR individually would inherit the OTHER failure from main and land red).

## What's broken on main

**1. actionlint job (`.github/workflows/ci.yml`)** — PR #170 deleted `clud-bug-review.yml` + `claude-code-review.yml` but the actionlint loop's hardcoded file list wasn't updated. Under `set -e`, `[ -f missing-file ]` returns 1 and fails the script.

Fix: drop the deleted references from the list + convert `[ -f X ] && Y` → `if [ -f X ]; then Y; fi` for robust handling of future deletions.

**2. usage test (`test/usage.test.js:307`)** — fixture's default `createdAt` was hardcoded `'2026-05-25T00:00:00Z'`. When the suite was authored, that was inside the rollup's 30-day current window. As the calendar advanced, the date slipped into the 30-60-day previous window, inverting the "no prior window" test semantics.

Fix: default `createdAt` to `Date.now() - 7d` so the fixture stays in the current window regardless of when the suite runs.

## Unblocks

- 3 open dependabot PRs: #162 (typescript 5→6), #167 (vitest 2→4), #173 (@types/node 22→26)