### PR TITLE
rc.6: applies_to.author filter (Wave 4e.2, SPEC v0.5.1 consumer)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.5
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.6
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/decisions-branches/feat__rc6-applies-to-author-filter.md
+++ b/docs/decisions-branches/feat__rc6-applies-to-author-filter.md
@@ -1,0 +1,15 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-27 16:16 - Wave 4e.2 (rc.6) — extend SkillFrontmatter + appliesToAuthor helper
+
+**Reasoning:** SPEC v0.5.1 §1.10.1 adds applies_to.author for skill filtering by PR author. rc.6 implements the consumer-side surface: SkillFrontmatter type extended with kind + voice_scope + applies_to.author (the Wave 4d reviewer-flagged silent-drops are now first-class), parseFrontmatter populates them, new exported appliesToAuthor helper mirrors appliesToPr signature for callers that need the strict-AND filter combination. Bumps 0.7.0-rc.5 → rc.6. strict-mode-gate pins in 3 workflow templates + action.yml header bumped to match.
+
+**Alternatives considered:** Validate kind/voice_scope strictly (throw on unknown values) — rejected: lenient surface (undefined on unknown) matches the parser's existing pattern + lets unknown future SPEC values degrade gracefully, Add separate appliesToVoiceAuthor / appliesToConventionsAuthor helpers — rejected: the SPEC field is kind-agnostic; one helper is the natural fit, Compose paths + author filtering inside a single appliesToBoth helper — rejected: separate helpers keep the AND composition explicit at the call site (consumer decides ordering + short-circuit)
+
+**Implications:**
+- appliesToAuthor reads raw skill content via regex (mirrors appliesToPr/readAppliesTo pattern); doesn't require pre-parsed frontmatter. Caller can use whichever path is convenient.
+- v0.5.0 consumers reading a v0.5.1 SKILL.md silently ignore applies_to.author (parser drops unknown keys); rc.6 is the first consumer that enforces the filter
+- 16 new tests: 5 for kind/voice_scope frontmatter surface, 3 for applies_to.author parse, 8 for appliesToAuthor helper (matching/non-matching/quoted/no-filter/no-frontmatter/empty-author/non-string-input)
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -9,8 +9,7 @@ clud-bug
 │   ├── workflow-ts.yml
 │   └── workflow.yml
 ├── .claude
-│   ├── skills
-│   └── worktrees
+│   └── skills
 ├── .github
 │   ├── actions
 │   ├── workflows

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -9,7 +9,8 @@ clud-bug
 │   ├── workflow-ts.yml
 │   └── workflow.yml
 ├── .claude
-│   └── skills
+│   ├── skills
+│   └── worktrees
 ├── .github
 │   ├── actions
 │   ├── workflows

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (46 decisions)
+## 2026-06 (47 decisions)
 
-- **2026-06-25** — Migrate clud-bug toolchain from TypeScript 5.5 to TypeScript 6.0 *(chore/ts6-migration-ignore-deprecations)* — [decisions-branches/chore__ts6-migration-ignore-deprecations.md](decisions-branches/chore__ts6-migration-ignore-deprecations.md)
-- *... 44 more decisions ...*
+- **2026-06-27** — Wave 4e.2 (rc.6) — extend SkillFrontmatter + appliesToAuthor helper *(feat/rc6-applies-to-author-filter)* — [decisions-branches/feat__rc6-applies-to-author-filter.md](decisions-branches/feat__rc6-applies-to-author-filter.md)
+- *... 45 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.5",
+  "version": "0.7.0-rc.6",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -172,6 +172,7 @@ export {
   readReviewMode,
   readAppliesTo,
   appliesToPr,
+  appliesToAuthor,
   partitionByReviewMode,
   extractPerSkillLine,
   selectReviewHeader,
@@ -191,4 +192,6 @@ export {
   type SkillFrontmatter,
   type SkillSource,
   type SkillReviewMode,
+  type SkillKind,
+  type VoiceScope,
 } from './skills.js';

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -285,6 +285,54 @@ export function appliesToPr(skillContent: unknown, prPaths: unknown): boolean {
   return false;
 }
 
+// v0.7.0-rc.6 (SPEC §1.10.1 v0.5.1+) — does this skill apply to a PR
+// opened by `prAuthor`? Reads `applies_to.author` from the raw SKILL.md
+// frontmatter. Returns:
+//   - `true` if `applies_to.author` is absent (no author filter set —
+//     skill loads regardless of author; v0.5.0 backward-compat default).
+//   - `true` if `applies_to.author === prAuthor` (case-sensitive match
+//     against the PR author's GitHub login).
+//   - `false` if `applies_to.author` is set to a different login.
+//
+// Designed to mirror `appliesToPr`'s signature (raw skill content +
+// runtime PR context) so consumers can call both filters in a single
+// loader pass. Skills with NO `applies_to` block at all also return
+// `true` (the existing v0.5.0 unconditional-load behavior).
+//
+// Strict-AND composition per SPEC §1.10.1: when a skill sets BOTH
+// `applies_to.author` AND `paths`/`extensions`, callers MUST call BOTH
+// filters and AND the results. This helper only checks the author leg;
+// the caller composes.
+export function appliesToAuthor(
+  skillContent: unknown,
+  prAuthor: unknown,
+): boolean {
+  if (typeof skillContent !== 'string') return true;
+  const fm = skillContent.match(/^---\n([\s\S]*?)\n---/);
+  if (!fm) return true;
+  const block = fm[1] as string;
+  // Look for `applies_to:` block; if absent, no author constraint.
+  const head = block.match(/^applies_to:\s*$/m);
+  if (!head) return true;
+  const startIdx = (head.index as number) + head[0].length;
+  const rest = block.slice(startIdx);
+  // The block ends at the next top-level key (line starting with a
+  // word char + `:`) OR end-of-block. Mirrors `readAppliesTo`.
+  const stop = rest.search(/^\w[\w-]*:/m);
+  const scoped = stop === -1 ? rest : rest.slice(0, stop);
+  // Match `  author: <value>` — single string scalar; strip optional
+  // quotes. `author: [a, b]` form is intentionally NOT supported
+  // (SPEC: "single GitHub login string, no list").
+  const authorMatch = scoped.match(/^\s{2}author:\s*(.+?)\s*$/m);
+  if (!authorMatch) return true;
+  const declared = (authorMatch[1] as string)
+    .trim()
+    .replace(/^["']|["']$/g, '');
+  if (!declared) return true; // empty value treated as unset
+  if (typeof prAuthor !== 'string' || !prAuthor) return false;
+  return declared === prAuthor;
+}
+
 // Minimal glob → regex: `**` → `.*`, `*` → `[^/]*`, `?` → `.`,
 // everything else escaped. Anchored full-string match.
 function globMatch(glob: string, path: string): boolean {
@@ -601,14 +649,39 @@ export type SkillReviewMode = 'shared' | 'dedicated';
  * `PromptSkillFrontmatter` is a narrower subset (name + description +
  * applies_to) so we keep the full shape here.
  */
+export type SkillKind = 'rule' | 'voice';
+export type VoiceScope = 'personal' | 'team' | 'org' | 'community';
+
 export interface SkillFrontmatter {
   name: string;
   description: string;
   source: SkillSource | string; // string fallback for forward-compat
   review_mode: SkillReviewMode;
+  /**
+   * SPEC §1.10.1 v0.5.0+ skill classification. OPTIONAL — absent =
+   * `kind: rule` (the v0.4.0 default). Surfaced on the parsed
+   * frontmatter (v0.7.0-rc.6+) so consumers can route on the field;
+   * v0.7.0-rc.5 and earlier silently dropped it.
+   */
+  kind?: SkillKind;
+  /**
+   * SPEC §1.10.1 v0.5.0+ voice scope. REQUIRED when `kind: voice`,
+   * absent otherwise. Surfaced on the parsed frontmatter (v0.7.0-rc.6+).
+   */
+  voice_scope?: VoiceScope;
   applies_to?: {
     paths?: string[];
     extensions?: string[];
+    /**
+     * SPEC §1.10.1 v0.5.1+ — single GitHub login string (no `@`
+     * prefix, no list). When present, the skill MUST only load when
+     * `pull_request.user.login === author`. Filters via strict AND
+     * with the sibling `paths` + `extensions` filters when all are
+     * present. v0.7.0-rc.5 and earlier silently dropped this field
+     * (treated skills as if it were absent — load unconditionally);
+     * v0.7.0-rc.6+ enforces the filter via `appliesToAuthor`.
+     */
+    author?: string;
   };
 }
 
@@ -691,8 +764,26 @@ export function parseFrontmatter(raw: string): SkillFrontmatter {
   const reviewMode: SkillReviewMode =
     out['review_mode'] === 'dedicated' ? 'dedicated' : 'shared';
 
+  // v0.7.0-rc.6 — surface SPEC §1.10.1 v0.5.0+ kind + voice_scope on
+  // the parsed frontmatter. v0.7.0-rc.5 silently dropped these fields
+  // (the Wave 4d reviewer-flagged silent-drop). Validation is lenient:
+  // unknown values are surfaced as undefined so downstream code sees a
+  // clean type rather than a malformed value. SPEC enforcement (e.g.,
+  // "voice_scope REQUIRED when kind: voice") is the caller's job.
+  const kindRaw = out['kind'];
+  const kind: SkillKind | undefined =
+    kindRaw === 'voice' ? 'voice' : kindRaw === 'rule' ? 'rule' : undefined;
+  const voiceScopeRaw = out['voice_scope'];
+  const voiceScope: VoiceScope | undefined =
+    voiceScopeRaw === 'personal' ||
+    voiceScopeRaw === 'team' ||
+    voiceScopeRaw === 'org' ||
+    voiceScopeRaw === 'community'
+      ? voiceScopeRaw
+      : undefined;
+
   const appliesToRaw = out['applies_to'] as
-    | { paths?: unknown; extensions?: unknown }
+    | { paths?: unknown; extensions?: unknown; author?: unknown }
     | undefined;
   let appliesTo: SkillFrontmatter['applies_to'] | undefined;
   if (appliesToRaw) {
@@ -702,9 +793,19 @@ export function parseFrontmatter(raw: string): SkillFrontmatter {
     const extensions = Array.isArray(appliesToRaw.extensions)
       ? appliesToRaw.extensions.map(String)
       : undefined;
+    // v0.7.0-rc.6 — SPEC §1.10.1 v0.5.1+ author filter. Single string
+    // only; reject lists + falsy values to keep the filter contract
+    // unambiguous (a future SPEC could broaden to lists if customer
+    // demand argues for it).
+    const authorRaw = appliesToRaw.author;
+    const author =
+      typeof authorRaw === 'string' && authorRaw.trim().length > 0
+        ? authorRaw.trim()
+        : undefined;
     appliesTo = {
       ...(paths !== undefined ? { paths } : {}),
       ...(extensions !== undefined ? { extensions } : {}),
+      ...(author !== undefined ? { author } : {}),
     };
   }
 
@@ -713,6 +814,8 @@ export function parseFrontmatter(raw: string): SkillFrontmatter {
     description,
     source,
     review_mode: reviewMode,
+    ...(kind !== undefined ? { kind } : {}),
+    ...(voiceScope !== undefined ? { voice_scope: voiceScope } : {}),
     ...(appliesTo !== undefined ? { applies_to: appliesTo } : {}),
   };
 }

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -330,7 +330,13 @@ export function appliesToAuthor(
     .replace(/^["']|["']$/g, '');
   if (!declared) return true; // empty value treated as unset
   if (typeof prAuthor !== 'string' || !prAuthor) return false;
-  return declared === prAuthor;
+  // GitHub logins are case-insensitive (GitHub rejects creating two
+  // accounts that differ only in case; `pull_request.user.login` is
+  // case-preserved but routing is not case-sensitive). Compare
+  // case-insensitively so a skill author writing `Thrillmot` still
+  // matches a webhook delivering `thrillmot` (or vice versa).
+  // Reviewer-flagged Important on PR #179.
+  return declared.toLowerCase() === prAuthor.toLowerCase();
 }
 
 // Minimal glob → regex: `**` → `.*`, `*` → `[^/]*`, `?` → `.`,
@@ -802,11 +808,19 @@ export function parseFrontmatter(raw: string): SkillFrontmatter {
       typeof authorRaw === 'string' && authorRaw.trim().length > 0
         ? authorRaw.trim()
         : undefined;
-    appliesTo = {
-      ...(paths !== undefined ? { paths } : {}),
-      ...(extensions !== undefined ? { extensions } : {}),
-      ...(author !== undefined ? { author } : {}),
-    };
+    // Reviewer-flagged Important on PR #179: an empty `applies_to:`
+    // block (no sub-keys) was emitting `applies_to: {}` on the
+    // returned frontmatter, which leaked into the prompt builder as
+    // JSON noise + semantically diverged from readAppliesTo's null
+    // return for the same input. Only construct appliesTo when at
+    // least one sub-field is present.
+    if (paths !== undefined || extensions !== undefined || author !== undefined) {
+      appliesTo = {
+        ...(paths !== undefined ? { paths } : {}),
+        ...(extensions !== undefined ? { extensions } : {}),
+        ...(author !== undefined ? { author } : {}),
+      };
+    }
   }
 
   return {

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -366,7 +366,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.5
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -366,7 +366,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.5
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -641,7 +641,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.5
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/skills-frontmatter.test.js
+++ b/test/skills-frontmatter.test.js
@@ -10,7 +10,7 @@
 import { test } from 'vitest';
 import { strict as assert } from 'node:assert';
 
-import { parseFrontmatter, stripFrontmatter } from '../src/core/skills.js';
+import { appliesToAuthor, parseFrontmatter, stripFrontmatter } from '../src/core/skills.js';
 
 // ---------------------------------------------------------------------------
 // Valid frontmatter
@@ -229,4 +229,181 @@ test('stripFrontmatter: handles CRLF line endings', () => {
   const raw = MINIMAL_VALID.replace(/\n/g, '\r\n');
   const body = stripFrontmatter(raw);
   assert.ok(body.includes('Body text here.'));
+});
+
+// ---------------------------------------------------------------------------
+// v0.7.0-rc.6 — SPEC v0.5.0+ kind + voice_scope surfaced on frontmatter
+// (Wave 4d reviewer-flagged silent-drop, now formalized in v0.5.1)
+// ---------------------------------------------------------------------------
+
+test('parseFrontmatter: kind: voice + voice_scope: org surfaced on parsed frontmatter', () => {
+  const raw = `---
+name: voice-acme
+description: Acme org voice for the bot.
+kind: voice
+voice_scope: org
+---
+Body.
+`;
+  const fm = parseFrontmatter(raw);
+  assert.equal(fm.kind, 'voice');
+  assert.equal(fm.voice_scope, 'org');
+});
+
+test('parseFrontmatter: kind: rule surfaced explicitly', () => {
+  const raw = `---
+name: my-rule
+description: A rule skill.
+kind: rule
+---
+Body.
+`;
+  const fm = parseFrontmatter(raw);
+  assert.equal(fm.kind, 'rule');
+});
+
+test('parseFrontmatter: unknown kind silently drops (defensive)', () => {
+  const raw = `---
+name: weird
+description: Weird kind.
+kind: enterprise
+---
+Body.
+`;
+  const fm = parseFrontmatter(raw);
+  assert.equal(fm.kind, undefined);
+});
+
+test('parseFrontmatter: unknown voice_scope silently drops', () => {
+  const raw = `---
+name: weird-voice
+description: Weird scope.
+kind: voice
+voice_scope: galaxy
+---
+Body.
+`;
+  const fm = parseFrontmatter(raw);
+  assert.equal(fm.kind, 'voice');
+  assert.equal(fm.voice_scope, undefined);
+});
+
+test('parseFrontmatter: absent kind + voice_scope → both undefined (v0.5.0 default)', () => {
+  const fm = parseFrontmatter(MINIMAL_VALID);
+  assert.equal(fm.kind, undefined);
+  assert.equal(fm.voice_scope, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// v0.7.0-rc.6 — SPEC v0.5.1 applies_to.author field
+// ---------------------------------------------------------------------------
+
+test('parseFrontmatter: applies_to.author surfaces a single login string', () => {
+  const raw = `---
+name: conventions-ludlow
+description: ludlow's review conventions.
+kind: rule
+applies_to:
+  author: ludlow
+---
+Body.
+`;
+  const fm = parseFrontmatter(raw);
+  assert.equal(fm.applies_to?.author, 'ludlow');
+});
+
+test('parseFrontmatter: applies_to.author with paths + author composes both', () => {
+  const raw = `---
+name: conventions-ludlow-ts
+description: ludlow's TS conventions.
+kind: rule
+applies_to:
+  paths: ["src/**"]
+  author: ludlow
+---
+Body.
+`;
+  const fm = parseFrontmatter(raw);
+  assert.deepEqual(fm.applies_to?.paths, ['src/**']);
+  assert.equal(fm.applies_to?.author, 'ludlow');
+});
+
+test('parseFrontmatter: empty author string drops (treated as absent)', () => {
+  const raw = `---
+name: empty-author
+description: Empty author.
+applies_to:
+  author: ""
+---
+Body.
+`;
+  const fm = parseFrontmatter(raw);
+  assert.equal(fm.applies_to?.author, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// v0.7.0-rc.6 — appliesToAuthor helper (SPEC §1.10.1 v0.5.1)
+// ---------------------------------------------------------------------------
+
+const AUTHOR_LUDLOW_SKILL = `---
+name: conventions-ludlow
+description: ludlow's review conventions.
+kind: rule
+applies_to:
+  author: ludlow
+---
+Body.
+`;
+
+const QUOTED_AUTHOR_SKILL = `---
+name: conventions-ludlow
+description: ludlow's review conventions.
+applies_to:
+  author: "ludlow"
+---
+Body.
+`;
+
+const NO_AUTHOR_SKILL = `---
+name: critical-issues-only
+description: No author filter.
+applies_to:
+  paths: ["src/**"]
+---
+Body.
+`;
+
+test('appliesToAuthor: matching author → true', () => {
+  assert.equal(appliesToAuthor(AUTHOR_LUDLOW_SKILL, 'ludlow'), true);
+});
+
+test('appliesToAuthor: non-matching author → false', () => {
+  assert.equal(appliesToAuthor(AUTHOR_LUDLOW_SKILL, 'alice'), false);
+});
+
+test('appliesToAuthor: case-sensitive (GitHub logins are not interchangeable case-wise)', () => {
+  assert.equal(appliesToAuthor(AUTHOR_LUDLOW_SKILL, 'Ludlow'), false);
+});
+
+test('appliesToAuthor: quoted author value strips quotes', () => {
+  assert.equal(appliesToAuthor(QUOTED_AUTHOR_SKILL, 'ludlow'), true);
+});
+
+test('appliesToAuthor: no applies_to.author → true regardless of PR author (backward-compat)', () => {
+  assert.equal(appliesToAuthor(NO_AUTHOR_SKILL, 'anyone'), true);
+  assert.equal(appliesToAuthor(NO_AUTHOR_SKILL, ''), true);
+});
+
+test('appliesToAuthor: no frontmatter → true (defensive, never throws)', () => {
+  assert.equal(appliesToAuthor('Plain markdown.', 'ludlow'), true);
+});
+
+test('appliesToAuthor: empty PR author + author filter set → false', () => {
+  assert.equal(appliesToAuthor(AUTHOR_LUDLOW_SKILL, ''), false);
+});
+
+test('appliesToAuthor: non-string skill content → true (defensive)', () => {
+  assert.equal(appliesToAuthor(undefined, 'ludlow'), true);
+  assert.equal(appliesToAuthor(null, 'ludlow'), true);
+  assert.equal(appliesToAuthor(42, 'ludlow'), true);
 });

--- a/test/skills-frontmatter.test.js
+++ b/test/skills-frontmatter.test.js
@@ -341,6 +341,24 @@ Body.
   assert.equal(fm.applies_to?.author, undefined);
 });
 
+test('parseFrontmatter: empty applies_to block (no sub-keys) → applies_to undefined', () => {
+  // Reviewer-flagged on PR #179: an `applies_to:` block with no
+  // sub-keys was emitting `applies_to: {}` on the parsed
+  // frontmatter, leaking into the prompt as JSON noise and
+  // diverging semantically from readAppliesTo's null return for
+  // the same input. The fix omits applies_to entirely when no
+  // sub-field is present.
+  const raw = `---
+name: no-filters
+description: Empty applies_to.
+applies_to:
+---
+Body.
+`;
+  const fm = parseFrontmatter(raw);
+  assert.equal(fm.applies_to, undefined);
+});
+
 // ---------------------------------------------------------------------------
 // v0.7.0-rc.6 — appliesToAuthor helper (SPEC §1.10.1 v0.5.1)
 // ---------------------------------------------------------------------------
@@ -381,8 +399,14 @@ test('appliesToAuthor: non-matching author → false', () => {
   assert.equal(appliesToAuthor(AUTHOR_LUDLOW_SKILL, 'alice'), false);
 });
 
-test('appliesToAuthor: case-sensitive (GitHub logins are not interchangeable case-wise)', () => {
-  assert.equal(appliesToAuthor(AUTHOR_LUDLOW_SKILL, 'Ludlow'), false);
+test('appliesToAuthor: case-insensitive (GitHub logins route case-insensitively)', () => {
+  // GitHub treats `Ludlow` and `ludlow` as the same user. Skill
+  // authors may capitalize differently from what the webhook
+  // delivers; matching MUST be case-insensitive so authoring style
+  // doesn't silently break filtering. Reviewer-flagged Important
+  // on PR #179.
+  assert.equal(appliesToAuthor(AUTHOR_LUDLOW_SKILL, 'Ludlow'), true);
+  assert.equal(appliesToAuthor(AUTHOR_LUDLOW_SKILL, 'LUDLOW'), true);
 });
 
 test('appliesToAuthor: quoted author value strips quotes', () => {


### PR DESCRIPTION
## Summary

Implements the consumer-side surface for SPEC v0.5.1 §1.10.1's new `applies_to.author` field. Extends `SkillFrontmatter` + `parseFrontmatter` to surface `kind` + `voice_scope` + `applies_to.author` (the Wave 4d reviewer-flagged silent-drops are now first-class). Adds new `appliesToAuthor` helper.

## Why

SPEC v0.5.1 added an OPTIONAL `applies_to.author: <gh-handle>` field so skills can filter loading by PR author. Primary use case: "review like me" personal-conventions skills (`.claude/skills/conventions-<gh-handle>/`) that fire only on a specific maintainer's PRs.

The chain: SPEC PR #16 merged on `thrillmade/protocol` → THIS rc.6 implements the consumer-side filter → Wave 4e.3 consumes via `clud-bug-app` bumping the dep.

## Core changes (`src/core/skills.ts`)

- `SkillFrontmatter` extended:
  - `kind?: 'rule' | 'voice'`
  - `voice_scope?: 'personal' | 'team' | 'org' | 'community'`
  - `applies_to.author?: string`
- `parseFrontmatter` populates the new fields with lenient validation (unknown → undefined)
- NEW exported `appliesToAuthor(skillContent, prAuthor): boolean` mirrors `appliesToPr` signature

Re-exported `SkillKind` + `VoiceScope` + `appliesToAuthor` from `src/core/index.ts`.

## Mechanical bumps

- `package.json` 0.7.0-rc.5 → 0.7.0-rc.6
- `strict-mode-gate@v0.7.0-rc.5` → `@v0.7.0-rc.6` in 3 workflow templates + the action.yml header docstring (release-discipline test enforces this)

## Backward-compat

Skills without `applies_to.author` load unconditionally (v0.5.0 behavior). v0.5.0 consumers reading a v0.5.1 SKILL.md silently ignore the field (parser drops unknown keys). rc.6 is the first consumer that enforces the filter — perfect strangler-fig migration: producers can add the field before consumers are upgraded.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 601/601 passing (+16 new)
  - 5 cases for `kind` + `voice_scope` frontmatter surface (incl. unknown-value drop)
  - 3 cases for `applies_to.author` parse (single + with paths + empty)
  - 8 cases for `appliesToAuthor` helper (matching, non-matching, case-sensitive, quoted, no-filter, no-frontmatter, empty-author, non-string-input)

## USER ACTION post-merge

1. Tag `v0.7.0-rc.6` on the merge commit
2. `npm publish --tag next`

Then Wave 4e.3 (clud-bug-app) consumes via `pnpm add clud-bug@next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)