### PR TITLE
Wave 5a: D.2.X per-finding inline review threads in npm workflow (rc.7)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.6
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.7
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/decisions-branches/wave-5a-inline-threads.md
+++ b/docs/decisions-branches/wave-5a-inline-threads.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-27 17:38 - Wave 5a — D.2.X per-finding inline review threads in npm workflow (rc.7)
+
+**Reasoning:** OSS parity push: bring inline-thread feedback (D.2.X) from clud-bug-app to the npm workflow template path so self-hosted users get per-finding GitHub review threads instead of one bundled summary comment. The pure helpers + GraphQL constants land in clud-bug/core/inline-threads.ts (App can swap to import from core in a future Wave 5c). New CLI verb post-inline-threads --stdin shells out to gh api for the REST createReview + gh api graphql for thread-id lookup. Workflow templates get a new post-step after the existing render step.
+
+**Alternatives considered:** Move inline-thread logic into clud-bug-app (status quo, App-only): rejected because OSS users get strictly less. Plan locked feature-complete-before-Marketplace and OSS pitch promises 'best-in-class single-pass + inline threads + auto-resolve'., Use Redis-backed thread persistence in npm workflow (parallel to App): rejected. npm workflow is stateless; introducing Redis requires customers wire external infra. Stateless-via-GraphQL is the way — query GitHub reviewThreads on demand, re-derive findingId from the <!-- finding-id: ... --> marker we embed in each comment body., Combine D.2.X + D.2.6 in one rc.7 PR: rejected. Two sequential PRs (5a then 5b) keep each reviewable (~700 LOC) and let 5a soak on clud-bug-test before 5b builds on it.
+
+**Implications:**
+- Workflow templates now invoke a third CLI verb post-render (post-inline-threads). All 3 variants updated in lockstep. Test count 602 → 647 (+45).
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -9,8 +9,7 @@ clud-bug
 │   ├── workflow-ts.yml
 │   └── workflow.yml
 ├── .claude
-│   ├── skills
-│   └── worktrees
+│   └── skills
 ├── .github
 │   ├── actions
 │   ├── workflows

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -9,7 +9,8 @@ clud-bug
 │   ├── workflow-ts.yml
 │   └── workflow.yml
 ├── .claude
-│   └── skills
+│   ├── skills
+│   └── worktrees
 ├── .github
 │   ├── actions
 │   ├── workflows

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -61,6 +61,7 @@ clud-bug
 │   ├── edit-workflow.test.js
 │   ├── formal-review.test.js
 │   ├── init-with-skdd.test.js
+│   ├── inline-threads.test.js
 │   ├── prompt-builder.test.js
 │   ├── prompts.eval.test.js
 │   ├── prompts.test.js

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (47 decisions)
+## 2026-06 (48 decisions)
 
-- **2026-06-27** — Wave 4e.2 (rc.6) — extend SkillFrontmatter + appliesToAuthor helper *(feat/rc6-applies-to-author-filter)* — [decisions-branches/feat__rc6-applies-to-author-filter.md](decisions-branches/feat__rc6-applies-to-author-filter.md)
-- *... 45 more decisions ...*
+- **2026-06-27** — Wave 5a — D.2.X per-finding inline review threads in npm workflow (rc.7) *(wave-5a-inline-threads)* — [decisions-branches/wave-5a-inline-threads.md](decisions-branches/wave-5a-inline-threads.md)
+- *... 46 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.6",
+  "version": "0.7.0-rc.7",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -161,6 +161,15 @@ Commands:
                         STRICT_MODE ("true"/"false"). Empty/malformed stdin →
                         exits 0 with "skip" on stdout (no-op; workflow degrades
                         gracefully to the existing comment-only behavior).
+  post-inline-threads   Post per-finding inline review threads (D.2.X). Reads a
+   --stdin               structured-output JSON payload from stdin, fetches the
+                        PR diff via \`gh api\`, posts one batched review with one
+                        comment per anchorable finding. Each comment body carries
+                        a hidden \`<!-- finding-id: <hash> --> \`marker so Wave 5b
+                        auto-resolve can re-match findings on subsequent pushes
+                        without persistent state. Required env vars: GH_TOKEN,
+                        REPO ("owner/name"), PR_NUMBER, HEAD_SHA. Output is a
+                        JSON status report \`{posted, skipped, preexisting, error?}\`.
 
 Options:
   --offline             Skip skills.sh; pin only the bundled baseline specimens.
@@ -219,6 +228,7 @@ async function main() {
     case 'render':  return runRender(args);
     case 'update-skill-usage': return runUpdateSkillUsage(args);
     case 'select-review-event': return runSelectReviewEvent(args);
+    case 'post-inline-threads': return runPostInlineThreads(args);
     default:
       process.stderr.write(`Unknown command: ${cmd || '(none)'}\n\n${HELP}`);
       process.exit(2);
@@ -500,6 +510,201 @@ async function runSelectReviewEvent(args) {
     authorAssociation,
   });
   process.stdout.write(event + '\n');
+}
+
+
+// Wave 5a / 0.7.0-rc.7: post per-finding inline review threads (D.2.X)
+// to the PR.  Replaces the legacy "one summary comment listing every
+// finding" UX with first-class GitHub review threads users can reply to
+// and (in Wave 5b) the bot can auto-resolve on fix-push.
+//
+// Pipeline:
+//   1. Read the structured review JSON from stdin (same shape the
+//      `render` and `update-skill-usage` verbs consume).
+//   2. Fetch the PR's per-file diff via `gh api repos/.../pulls/N/files`.
+//   3. Call `planInlineThreads(findings, diffFiles)` from
+//      `clud-bug/core/inline-threads` to partition into anchored
+//      `comments[]` + skipped + preexisting buckets.
+//   4. If any comments survive: POST one batched review via
+//      `gh api -X POST repos/.../pulls/N/reviews` with `event: COMMENT`.
+//      Each comment body carries a hidden `<!-- finding-id: <hash> -->`
+//      marker so Wave 5b auto-resolve can re-derive the same ids on
+//      subsequent pushes without a persistent store.
+//   5. Emit a JSON summary on stdout (`{posted, skipped, preexisting}`).
+//
+// Required env vars (the workflow template provides all of them):
+//   GH_TOKEN, REPO ("owner/name"), PR_NUMBER, HEAD_SHA
+//
+// Failure posture: any `gh api` failure is logged to stderr + emitted in
+// the stdout JSON as `error`, but the verb exits 0 so the surrounding
+// workflow step's `continue-on-error: true` is the single source of
+// failure semantics. Mirrors the `render` / `update-skill-usage` posture.
+async function runPostInlineThreads(args) {
+  const { planInlineThreads } = await import('../core/inline-threads.js');
+
+  if (!args.stdin) {
+    process.stderr.write(
+      'clud-bug post-inline-threads: --stdin is required.\n',
+    );
+    process.stdout.write(JSON.stringify({ posted: 0, skipped: [], preexisting: [], error: 'no-stdin' }) + '\n');
+    return;
+  }
+
+  let raw = '';
+  for await (const chunk of process.stdin) raw += chunk;
+  raw = raw.trim();
+  if (!raw) {
+    process.stderr.write(
+      'clud-bug post-inline-threads: stdin empty — no-op.\n',
+    );
+    process.stdout.write(JSON.stringify({ posted: 0, skipped: [], preexisting: [], error: 'empty-stdin' }) + '\n');
+    return;
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch (e) {
+    process.stderr.write(
+      `clud-bug post-inline-threads: JSON parse failed: ${e.message} — no-op.\n`,
+    );
+    process.stdout.write(JSON.stringify({ posted: 0, skipped: [], preexisting: [], error: 'parse-failed' }) + '\n');
+    return;
+  }
+  if (!payload || typeof payload !== 'object') {
+    process.stderr.write(
+      'clud-bug post-inline-threads: payload must be a JSON object — no-op.\n',
+    );
+    process.stdout.write(JSON.stringify({ posted: 0, skipped: [], preexisting: [], error: 'not-object' }) + '\n');
+    return;
+  }
+
+  // Pull findings from the structured_output shape — same field names as
+  // the SPEC §1.8.1 review schema the model emits.
+  const findings = [];
+  for (const f of Array.isArray(payload.critical_findings) ? payload.critical_findings : []) {
+    if (f && typeof f === 'object') {
+      findings.push({ ...f, severity: 'critical' });
+    }
+  }
+  for (const f of Array.isArray(payload.minor_findings) ? payload.minor_findings : []) {
+    if (f && typeof f === 'object') {
+      findings.push({ ...f, severity: 'minor' });
+    }
+  }
+  // `preexisting_findings` are intentionally not threaded (informational
+  // about prior code; not a reason to block this PR). `planInlineThreads`
+  // partitions them into the `preexisting` bucket if any are included, but
+  // the workflow path doesn't ship them — keep the payload focused.
+
+  if (findings.length === 0) {
+    process.stdout.write(JSON.stringify({ posted: 0, skipped: [], preexisting: [], reason: 'no-findings' }) + '\n');
+    return;
+  }
+
+  // Required env vars.
+  const repo = String(process.env.REPO ?? '').trim();
+  const prNumberRaw = String(process.env.PR_NUMBER ?? '').trim();
+  const headSha = String(process.env.HEAD_SHA ?? '').trim();
+  const prNumber = Number(prNumberRaw);
+  if (!repo || !repo.includes('/') || !Number.isInteger(prNumber) || prNumber <= 0 || !headSha) {
+    process.stderr.write(
+      `clud-bug post-inline-threads: REPO + PR_NUMBER + HEAD_SHA env vars required (got REPO=${repo}, PR_NUMBER=${prNumberRaw}, HEAD_SHA=${headSha ? '<set>' : '<unset>'}).\n`,
+    );
+    process.stdout.write(JSON.stringify({ posted: 0, skipped: [], preexisting: [], error: 'missing-env' }) + '\n');
+    return;
+  }
+
+  // Fetch the PR's diff. `gh api repos/.../pulls/N/files --paginate`
+  // returns a JSON array of {filename, patch, status, ...}. The single
+  // -slurp on multi-page output stitches all pages into one big array.
+  const filesResult = spawnSync(
+    'gh',
+    [
+      'api',
+      `repos/${repo}/pulls/${prNumber}/files`,
+      '--paginate',
+      '--slurp',
+    ],
+    { encoding: 'utf8' },
+  );
+  if (filesResult.status !== 0) {
+    process.stderr.write(
+      `clud-bug post-inline-threads: \`gh api .../files\` failed (exit ${filesResult.status}): ${(filesResult.stderr || '').slice(0, 500)}\n`,
+    );
+    process.stdout.write(JSON.stringify({ posted: 0, skipped: [], preexisting: [], error: 'diff-fetch-failed' }) + '\n');
+    return;
+  }
+
+  let diffFiles = [];
+  try {
+    // --slurp wraps each page in an outer array; flatten one level.
+    const pages = JSON.parse(filesResult.stdout);
+    if (Array.isArray(pages)) {
+      for (const page of pages) {
+        if (Array.isArray(page)) diffFiles.push(...page);
+      }
+    }
+  } catch (e) {
+    process.stderr.write(
+      `clud-bug post-inline-threads: diff JSON parse failed: ${e.message}\n`,
+    );
+    process.stdout.write(JSON.stringify({ posted: 0, skipped: [], preexisting: [], error: 'diff-parse-failed' }) + '\n');
+    return;
+  }
+
+  const plan = planInlineThreads(findings, diffFiles);
+  if (plan.comments.length === 0) {
+    // Everything fell through to summary-comment fallback (no anchor
+    // matches). Not a failure — emit the breakdown so the workflow log
+    // explains why no inline threads were posted.
+    process.stdout.write(JSON.stringify({
+      posted: 0,
+      skipped: plan.skipped.map((f) => ({ skill: f.skill, file: f.file, line: f.line, reason: 'not-anchorable' })),
+      preexisting: plan.preexisting.map((f) => ({ skill: f.skill })),
+      reason: 'no-anchorable-findings',
+    }) + '\n');
+    return;
+  }
+
+  // Post the review. gh accepts the body as a JSON file via --input — we
+  // pipe through stdin with `--input -`. Build the body as JSON-on-one-line
+  // so stdin is a single write that `gh` reads start-to-finish.
+  const reviewBody = JSON.stringify({
+    commit_id: headSha,
+    event: 'COMMENT',
+    body: `Clud-Bug posted ${plan.comments.length} inline finding${plan.comments.length === 1 ? '' : 's'}.`,
+    comments: plan.comments,
+  });
+
+  const postResult = spawnSync(
+    'gh',
+    [
+      'api',
+      '--method', 'POST',
+      `repos/${repo}/pulls/${prNumber}/reviews`,
+      '--input', '-',
+    ],
+    { encoding: 'utf8', input: reviewBody },
+  );
+  if (postResult.status !== 0) {
+    process.stderr.write(
+      `clud-bug post-inline-threads: \`gh api -X POST .../reviews\` failed (exit ${postResult.status}): ${(postResult.stderr || '').slice(0, 500)}\n`,
+    );
+    process.stdout.write(JSON.stringify({
+      posted: 0,
+      skipped: plan.skipped.map((f) => ({ skill: f.skill, file: f.file, line: f.line, reason: 'not-anchorable' })),
+      preexisting: plan.preexisting.map((f) => ({ skill: f.skill })),
+      error: 'review-post-failed',
+    }) + '\n');
+    return;
+  }
+
+  process.stdout.write(JSON.stringify({
+    posted: plan.comments.length,
+    skipped: plan.skipped.map((f) => ({ skill: f.skill, file: f.file, line: f.line, reason: 'not-anchorable' })),
+    preexisting: plan.preexisting.map((f) => ({ skill: f.skill })),
+  }) + '\n');
 }
 
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -151,6 +151,28 @@ export {
   type ParsedFinding,
   type ParsedReview,
 } from './diff-findings.js';
+// Wave 5a — D.2.X per-finding inline review threads. Pure helpers
+// (anchor detection, comment rendering, plan partitioning) + the GraphQL
+// constants the CLI's `post-inline-threads` verb invokes via `gh api`.
+// `findingId` returns the SHA-256[:16] hash and is distinct from the
+// plain-string `findingIdentity` above (both serve different matchers).
+export {
+  findingId,
+  parseHeadLines,
+  findingAnchorable,
+  extractAnchorContext,
+  renderThreadBody,
+  extractFindingIdFromBody,
+  planInlineThreads,
+  REVIEW_THREADS_QUERY,
+  REVIEW_THREADS_STATE_QUERY,
+  RESOLVE_THREAD_MUTATION,
+  type Severity as InlineThreadSeverity,
+  type FindingForThread,
+  type DiffFile,
+  type InlineCommentPlan,
+  type PlanInlineThreadsResult,
+} from './inline-threads.js';
 // SPEC §7 canonical-ruleset applier. Pure diff + idempotent-PATCH logic;
 // CLI side wraps `gh api` in an Octokit-like adapter and the App passes
 // its real Octokit instance. Shipped in v0.7.0-rc.4 for Marketplace prep

--- a/src/core/inline-threads.ts
+++ b/src/core/inline-threads.ts
@@ -1,0 +1,393 @@
+// Wave 5a — D.2.X inline review threads (npm workflow parity, OSS port).
+//
+// This module holds the pure helpers + GraphQL operation strings that BOTH
+// the npm workflow path and the hosted clud-bug-app use to attach a
+// per-finding inline review thread to the PR (replacing the legacy
+// "one big summary comment listing every finding" UX).
+//
+// The split between npm and app:
+//   - npm path (this package's CLI verb `post-inline-threads`) is stateless:
+//     it shells out to `gh api` for the REST createReview + `gh api graphql`
+//     for the GraphQL thread-id lookup, then EXITS. No persistent record —
+//     Wave 5b's auto-resolve re-queries GitHub on the next push and re-derives
+//     finding IDs from the comment-body markers we embed here.
+//   - app path keeps its Redis-backed persistence for performance (cross-
+//     push thread correlation without re-querying GraphQL every time). The
+//     pure helpers below are designed so a future Wave 5c swap can have the
+//     App import from this module + drop its local duplicates.
+//
+// Designed to share `findingId` semantics with clud-bug-app's
+// `lib/inline-threads.ts:findingId` (SHA-256 of the canonical 5-tuple,
+// truncated to 16 hex chars) so threads posted by one consumer stay
+// matchable by the other after the App migrates.
+
+import { createHash } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type Severity = 'critical' | 'minor' | 'preexisting';
+
+/**
+ * Minimal shape this module needs from a review finding. Both the npm CLI
+ * and the App's `Finding` type satisfy this; the App also carries
+ * `reasoning` + nullable `file`/`line` which we tolerate via the optional
+ * fields below.
+ */
+export interface FindingForThread {
+  severity: Severity;
+  skill: string;
+  file?: string;
+  line?: number;
+  summary: string;
+  reasoning?: string;
+}
+
+/**
+ * Per-file unified-diff entry. Matches the shape returned by `gh api
+ * repos/{owner}/{repo}/pulls/{n}/files` (after JSON.parse) AND
+ * `octokit.rest.pulls.listFiles(...).data` so the App can pass either
+ * directly.
+ */
+export interface DiffFile {
+  filename: string;
+  patch?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Stable finding id — SHA-256 of the canonical 5-tuple, truncated to 16 hex.
+// ---------------------------------------------------------------------------
+
+/**
+ * Hashes the canonical `${file}:${line}:${severity}:${skill}:${summary[:100]}`
+ * tuple to 16 hex characters. Stable across consumers — the App computes
+ * the same hash for the same finding, so threads posted by one consumer
+ * stay matchable by the other.
+ *
+ * Summary is truncated to 100 chars BEFORE hashing so small wording tweaks
+ * on subsequent review passes don't generate a fresh id and orphan the
+ * prior thread.
+ *
+ * Distinct from `findingIdentity` in `./diff-findings` (which returns the
+ * plain unhashed string — used by the Resolved/Still-open block matcher).
+ * Both helpers coexist on purpose: the unhashed string is human-readable
+ * for in-prose matching; the hash is short + collision-safe for embedding
+ * in `<!-- finding-id: ... -->` comment-body markers.
+ */
+export function findingId(finding: {
+  file?: string;
+  line?: number;
+  severity: Severity;
+  skill: string;
+  summary: string;
+}): string {
+  const file = finding.file ?? '<no-file>';
+  const line = finding.line ?? 0;
+  const summary = finding.summary.slice(0, 100);
+  const payload = `${file}:${line}:${finding.severity}:${finding.skill}:${summary}`;
+  return createHash('sha256').update(payload).digest('hex').slice(0, 16);
+}
+
+// ---------------------------------------------------------------------------
+// Diff anchor detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the set of 1-indexed HEAD-side line numbers a unified-diff patch
+ * touches (added + context lines). GitHub only accepts inline review
+ * comments on lines that appear in the diff, so this gates whether a
+ * finding's `line` can become a thread.
+ *
+ * "Touched" = appears on the RIGHT side of the unified diff: added (`+`)
+ * lines OR unchanged context (` `) lines inside any hunk. Removed (`-`)
+ * lines are LEFT-side only and can't anchor inline comments.
+ *
+ * If `patch` is undefined (binary file, GitHub truncation) returns an empty
+ * set — the caller falls back to the summary comment for those findings.
+ */
+export function parseHeadLines(patch: string | undefined): Set<number> {
+  const lines = new Set<number>();
+  if (!patch) return lines;
+
+  // Hunk header: @@ -oldStart,oldLines +newStart,newLines @@
+  // newLines defaults to 1 when omitted.
+  const hunkHeaderRe = /^@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,(\d+))?\s+@@/;
+
+  let newLine = 0;
+  let inHunk = false;
+  for (const rawLine of patch.split('\n')) {
+    const m = rawLine.match(hunkHeaderRe);
+    if (m) {
+      newLine = Number.parseInt(m[1]!, 10);
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue;
+
+    if (rawLine.startsWith('+') && !rawLine.startsWith('+++')) {
+      lines.add(newLine);
+      newLine++;
+    } else if (rawLine.startsWith('-') && !rawLine.startsWith('---')) {
+      // LEFT-side only — does not advance the newLine counter.
+    } else if (rawLine.startsWith('\\')) {
+      // "\ No newline at end of file" — doesn't advance.
+    } else {
+      // Context line — counts as a HEAD-side line.
+      lines.add(newLine);
+      newLine++;
+    }
+  }
+
+  return lines;
+}
+
+/**
+ * Returns true when the finding's `(file, line)` can be anchored as an
+ * inline comment on the current diff. `diffFiles` is the per-file diff
+ * (as returned by `gh api repos/.../pulls/.../files`).
+ */
+export function findingAnchorable(
+  finding: { file?: string; line?: number },
+  diffFiles: ReadonlyArray<DiffFile>,
+): boolean {
+  if (!finding.file || !finding.line) return false;
+  const file = diffFiles.find((f) => f.filename === finding.file);
+  if (!file) return false;
+  return parseHeadLines(file.patch).has(finding.line);
+}
+
+// ---------------------------------------------------------------------------
+// Context extraction for the verifier (consumed in Wave 5b)
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the `{codeBefore, codeAfter, diffAtAnchor?}` triple Wave 5b's
+ * auto-resolve verifier consumes for a single finding, pulled out of the
+ * unified-diff hunk that touches the finding's line.
+ *
+ * Works entirely from the in-hand patch — no fresh API calls. The patch
+ * already encodes BEFORE (lines with `-` or context) and AFTER (lines with
+ * `+` or context) for every hunk the PR touches.
+ *
+ * Returns empty strings for `codeBefore`/`codeAfter` when the finding's
+ * file isn't in the diff at all. The verifier sees "unchanged" and
+ * typically returns NOT_ADDRESSED / UNCERTAIN, which is the correct
+ * behavior — an unchanged file isn't a fix.
+ */
+export function extractAnchorContext(
+  finding: { file?: string; line?: number },
+  diffFiles: ReadonlyArray<DiffFile>,
+): { codeBefore: string; codeAfter: string; diffAtAnchor?: string } {
+  if (!finding.file || !finding.line) {
+    return { codeBefore: '', codeAfter: '' };
+  }
+  const file = diffFiles.find((f) => f.filename === finding.file);
+  if (!file || !file.patch) {
+    return { codeBefore: '', codeAfter: '' };
+  }
+
+  // Locate the hunk whose new-side range contains finding.line.
+  const hunkHeaderRe = /^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@/;
+  const patchLines = file.patch.split('\n');
+  let currentHunkStart = -1;
+
+  for (let i = 0; i < patchLines.length; i++) {
+    const m = patchLines[i]!.match(hunkHeaderRe);
+    if (!m) continue;
+    const newStart = Number.parseInt(m[3]!, 10);
+    const newLen = m[4] !== undefined ? Number.parseInt(m[4]!, 10) : 1;
+    if (
+      finding.line >= newStart &&
+      finding.line < newStart + Math.max(newLen, 1)
+    ) {
+      currentHunkStart = i;
+      break;
+    }
+  }
+
+  if (currentHunkStart < 0) {
+    return { codeBefore: '', codeAfter: '' };
+  }
+
+  const before: string[] = [];
+  const after: string[] = [];
+  const hunkBody: string[] = [patchLines[currentHunkStart]!];
+
+  for (let i = currentHunkStart + 1; i < patchLines.length; i++) {
+    const line = patchLines[i]!;
+    if (line.match(hunkHeaderRe)) break;
+    hunkBody.push(line);
+
+    if (line.startsWith('+') && !line.startsWith('+++')) {
+      after.push(line.slice(1));
+    } else if (line.startsWith('-') && !line.startsWith('---')) {
+      before.push(line.slice(1));
+    } else if (line.startsWith('\\')) {
+      // No-newline marker — skip.
+    } else if (line.length > 0) {
+      // Context line — appears on both sides.
+      const stripped = line.startsWith(' ') ? line.slice(1) : line;
+      before.push(stripped);
+      after.push(stripped);
+    }
+  }
+
+  return {
+    codeBefore: before.join('\n'),
+    codeAfter: after.join('\n'),
+    diffAtAnchor: hunkBody.join('\n'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Comment body rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Body for a single inline-thread comment. Includes a hidden HTML marker
+ * carrying `findingId` so Wave 5b's auto-resolve can recover the canonical
+ * id from the thread's first comment body without persisting state.
+ */
+export function renderThreadBody(finding: FindingForThread): string {
+  const id = findingId(finding);
+  const severityBadge = finding.severity === 'critical' ? '🔴' : '🟡';
+  const header = `${severityBadge} \`${finding.skill}\``;
+  const body = finding.summary.trim();
+  const reasoning = finding.reasoning ? `\n\n${finding.reasoning.trim()}` : '';
+  return `<!-- finding-id: ${id} -->\n${header}\n\n${body}${reasoning}`;
+}
+
+/**
+ * Extracts the hashed `findingId` from a thread comment body that was
+ * rendered by `renderThreadBody`. Returns null when the marker is absent
+ * (a manual reply, or a comment posted by a different tool).
+ *
+ * Used by Wave 5b's auto-resolve to re-derive finding ids from existing
+ * GitHub threads on a stateless re-run.
+ */
+export function extractFindingIdFromBody(body: string): string | null {
+  const m = body.match(/<!--\s*finding-id:\s*([a-f0-9]{16})\s*-->/);
+  return m ? m[1]! : null;
+}
+
+// ---------------------------------------------------------------------------
+// Inline-thread posting plan
+// ---------------------------------------------------------------------------
+
+/**
+ * One entry in the createReview `comments[]` array. Matches GitHub's REST
+ * shape exactly so callers can JSON.stringify directly into a `gh api` body.
+ */
+export interface InlineCommentPlan {
+  path: string;
+  line: number;
+  side: 'RIGHT';
+  body: string;
+}
+
+export interface PlanInlineThreadsResult {
+  /** Comment entries for the createReview `comments[]` field. */
+  comments: InlineCommentPlan[];
+  /** Findings the diff couldn't anchor (file or line not in any hunk). */
+  skipped: FindingForThread[];
+  /** Findings filtered out because severity is 'preexisting' (informational only). */
+  preexisting: FindingForThread[];
+}
+
+/**
+ * Partitions a flat findings list into the `comments[]` body for
+ * `POST /repos/:owner/:repo/pulls/:n/reviews` + the findings the caller
+ * should surface elsewhere (summary comment for `skipped`; never for
+ * `preexisting`).
+ *
+ * Pure function — no I/O. The CLI verb uses this to compute the API body;
+ * the App can use it after Wave 5c migration to share the same partitioning.
+ */
+export function planInlineThreads(
+  findings: ReadonlyArray<FindingForThread>,
+  diffFiles: ReadonlyArray<DiffFile>,
+): PlanInlineThreadsResult {
+  const comments: InlineCommentPlan[] = [];
+  const skipped: FindingForThread[] = [];
+  const preexisting: FindingForThread[] = [];
+
+  for (const f of findings) {
+    if (f.severity === 'preexisting') {
+      preexisting.push(f);
+      continue;
+    }
+    if (!findingAnchorable(f, diffFiles)) {
+      skipped.push(f);
+      continue;
+    }
+    comments.push({
+      path: f.file!,
+      line: f.line!,
+      side: 'RIGHT',
+      body: renderThreadBody(f),
+    });
+  }
+
+  return { comments, skipped, preexisting };
+}
+
+// ---------------------------------------------------------------------------
+// GraphQL operations — pinned to module scope so callers (and tests) can
+// reference the same query strings as the App.
+// ---------------------------------------------------------------------------
+
+export const REVIEW_THREADS_QUERY = `
+  query ReviewThreads($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            comments(first: 1) {
+              nodes {
+                databaseId
+                path
+                line
+                originalLine
+                body
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const REVIEW_THREADS_STATE_QUERY = `
+  query ReviewThreadStates($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            comments(first: 1) {
+              nodes {
+                databaseId
+                body
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const RESOLVE_THREAD_MUTATION = `
+  mutation ResolveThread($threadId: ID!) {
+    resolveReviewThread(input: { threadId: $threadId }) {
+      thread {
+        isResolved
+      }
+    }
+  }
+`;

--- a/src/core/inline-threads.ts
+++ b/src/core/inline-threads.ts
@@ -267,7 +267,10 @@ export function renderThreadBody(finding: FindingForThread): string {
  * GitHub threads on a stateless re-run.
  */
 export function extractFindingIdFromBody(body: string): string | null {
-  const m = body.match(/<!--\s*finding-id:\s*([a-f0-9]{16})\s*-->/);
+  // Anchor to start-of-string so a user reply that quotes the marker can't be
+  // misattributed as bot-authored. `renderThreadBody` always places the marker
+  // on line 1 — anything else is suspect input.
+  const m = body.match(/^<!--\s*finding-id:\s*([a-f0-9]{16})\s*-->/);
   return m ? m[1]! : null;
 }
 
@@ -361,6 +364,11 @@ export const REVIEW_THREADS_QUERY = `
   }
 `;
 
+// Includes `body` (unlike the App's lighter state query, which omits it) so
+// Wave 5b's auto-resolve can re-derive the `findingId` from the
+// `<!-- finding-id: ... -->` marker on each thread's first comment WITHOUT
+// persisting state between fix-pushes. The npm workflow is stateless; the
+// body field is the substitute for Redis-backed thread-id correlation.
 export const REVIEW_THREADS_STATE_QUERY = `
   query ReviewThreadStates($owner: String!, $repo: String!, $pr: Int!) {
     repository(owner: $owner, name: $repo) {

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -283,6 +283,21 @@ jobs:
 
           $CALIBRATION"
 
+      # Wave 5a (D.2.X) — see workflow.yml.tmpl for design notes.
+      - name: Post inline review threads
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} post-inline-threads --stdin)
+          echo "::notice title=inline-threads::$RESULT"
+
       # v0.6.29 / Component 4 — see workflow.yml.tmpl for design notes.
       - name: Update skill-usage tracking
         if: success() && steps.clud-bug-review.outputs.structured_output != ''
@@ -366,7 +381,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.6
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v12
+# clud-bug-template-version: v13
 name: Clud Bug 🐛 Crawls Your Code
 
 on:

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -283,6 +283,21 @@ jobs:
 
           $CALIBRATION"
 
+      # Wave 5a (D.2.X) — see workflow.yml.tmpl for design notes.
+      - name: Post inline review threads
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} post-inline-threads --stdin)
+          echo "::notice title=inline-threads::$RESULT"
+
       # v0.6.29 / Component 4 — see workflow.yml.tmpl for design notes.
       - name: Update skill-usage tracking
         if: success() && steps.clud-bug-review.outputs.structured_output != ''
@@ -366,7 +381,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.6
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v12
+# clud-bug-template-version: v13
 name: Clud Bug 🐛 Crawls Your Code
 
 on:

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -503,6 +503,35 @@ jobs:
 
           $CALIBRATION"
 
+      # v0.7.0-rc.7 / Wave 5a (D.2.X): post per-finding inline review
+      # threads alongside the summary comment. Each thread is anchored
+      # to a file + line in the diff and is a first-class GitHub review
+      # thread users can reply to. Each thread body carries a hidden
+      # `<!-- finding-id: <hash> -->` marker so Wave 5b (rc.8) auto-
+      # resolve can re-match findings on subsequent fix-pushes without
+      # any persistent state.
+      #
+      # Posted IN ADDITION TO the summary comment above — they serve
+      # different UX needs: the summary is the at-a-glance digest; the
+      # inline threads are where conversation + resolution happens.
+      #
+      # `continue-on-error` so a partial GraphQL/REST failure doesn't
+      # fail the whole review; the verb itself swallows errors into its
+      # stdout JSON and exits 0.
+      - name: Post inline review threads
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} post-inline-threads --stdin)
+          echo "::notice title=inline-threads::$RESULT"
+
       # v0.6.29 / Component 4: pipe structured_output through
       # `clud-bug update-skill-usage` to compute the per-skill loads +
       # citations delta from this one review. Writes to the ephemeral
@@ -641,7 +670,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.6
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -516,3 +516,79 @@ test('--help advertises select-review-event subcommand', () => {
   assert.equal(r.status, 0);
   assert.match(r.stdout, /select-review-event/);
 });
+
+// ---------------------------------------------------------------------------
+// Wave 5a (v0.7.0-rc.7) — post-inline-threads subcommand for the workflow
+// post-step. Same robustness contract as select-review-event: NEVER fails
+// the workflow on caller-side problems — degrades to exit 0 + a JSON
+// status report on stdout. The shell-out paths (gh api) need an integration
+// harness; these tests cover the validation-and-no-op paths.
+// ---------------------------------------------------------------------------
+
+function runPostInlineThreads(input, env = {}) {
+  return run(process.cwd(), ['post-inline-threads', '--stdin'], { input, env });
+}
+
+test('post-inline-threads: empty stdin → no-op with error JSON, exits 0', () => {
+  const r = runPostInlineThreads('', {
+    REPO: 'acme/test',
+    PR_NUMBER: '1',
+    HEAD_SHA: 'a'.repeat(40),
+  });
+  assert.equal(r.status, 0, r.stderr);
+  const out = JSON.parse(r.stdout.trim());
+  assert.equal(out.posted, 0);
+  assert.equal(out.error, 'empty-stdin');
+});
+
+test('post-inline-threads: malformed JSON → no-op with error JSON, exits 0', () => {
+  const r = runPostInlineThreads('not valid json {{{', {
+    REPO: 'acme/test',
+    PR_NUMBER: '1',
+    HEAD_SHA: 'a'.repeat(40),
+  });
+  assert.equal(r.status, 0, r.stderr);
+  const out = JSON.parse(r.stdout.trim());
+  assert.equal(out.posted, 0);
+  assert.equal(out.error, 'parse-failed');
+});
+
+test('post-inline-threads: payload with no findings → no-op with reason=no-findings, exits 0', () => {
+  const payload = JSON.stringify({
+    critical_findings: [],
+    minor_findings: [],
+    preexisting_findings: [],
+  });
+  const r = runPostInlineThreads(payload, {
+    REPO: 'acme/test',
+    PR_NUMBER: '1',
+    HEAD_SHA: 'a'.repeat(40),
+  });
+  assert.equal(r.status, 0, r.stderr);
+  const out = JSON.parse(r.stdout.trim());
+  assert.equal(out.posted, 0);
+  assert.equal(out.reason, 'no-findings');
+});
+
+test('post-inline-threads: missing env vars → no-op with error=missing-env, exits 0', () => {
+  // Has findings but no REPO/PR_NUMBER/HEAD_SHA — must short-circuit before
+  // attempting any gh api call.
+  const payload = JSON.stringify({
+    critical_findings: [
+      { skill: 'critical-issues-only', file: 'src/foo.ts', line: 1, summary: 'bug' },
+    ],
+    minor_findings: [],
+    preexisting_findings: [],
+  });
+  const r = runPostInlineThreads(payload, {}); // empty env, no REPO/PR_NUMBER/HEAD_SHA
+  assert.equal(r.status, 0, r.stderr);
+  const out = JSON.parse(r.stdout.trim());
+  assert.equal(out.posted, 0);
+  assert.equal(out.error, 'missing-env');
+});
+
+test('--help advertises post-inline-threads subcommand', () => {
+  const r = run(process.cwd(), ['--help']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /post-inline-threads/);
+});

--- a/test/inline-threads.test.js
+++ b/test/inline-threads.test.js
@@ -308,6 +308,21 @@ describe('renderThreadBody + extractFindingIdFromBody', () => {
     expect(extractFindingIdFromBody('<!-- finding-id: deadbeef -->')).toBeNull(); // 8 chars, not 16
     expect(extractFindingIdFromBody('<!-- finding-id: deadbeefdeadbeefXX -->')).toBeNull(); // non-hex
   });
+
+  it('returns null when marker appears mid-body (anti-injection — user reply quoting the marker)', () => {
+    // A human replying to the inline thread might paste/quote the marker
+    // text. The extractor MUST NOT match it as bot-authored — `renderThreadBody`
+    // always places the canonical marker as the first line of the original
+    // comment, so anything mid-body is suspect input from a downstream reply.
+    const body =
+      '> The original finding id was <!-- finding-id: deadbeefdeadbeef -->\n\nI disagree with this finding.';
+    expect(extractFindingIdFromBody(body)).toBeNull();
+  });
+
+  it('extracts the marker when it is on the very first line (the canonical place)', () => {
+    const body = '<!-- finding-id: 0123456789abcdef -->\nrest of comment';
+    expect(extractFindingIdFromBody(body)).toBe('0123456789abcdef');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/inline-threads.test.js
+++ b/test/inline-threads.test.js
@@ -1,0 +1,418 @@
+// Tests for src/core/inline-threads.ts — Wave 5a (D.2.X) pure helpers
+// + GraphQL constants. The IO-bound `gh api` calls live in the CLI verb
+// `post-inline-threads`; this file covers the pure logic those calls
+// build on top of.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  findingId,
+  parseHeadLines,
+  findingAnchorable,
+  extractAnchorContext,
+  renderThreadBody,
+  extractFindingIdFromBody,
+  planInlineThreads,
+  REVIEW_THREADS_QUERY,
+  REVIEW_THREADS_STATE_QUERY,
+  RESOLVE_THREAD_MUTATION,
+} from '../src/core/inline-threads.js';
+import {
+  findingId as barrelFindingId,
+  planInlineThreads as barrelPlan,
+  REVIEW_THREADS_QUERY as barrelQuery,
+} from '../src/core/index.js';
+
+// ---------------------------------------------------------------------------
+// Barrel re-exports
+// ---------------------------------------------------------------------------
+
+describe('core barrel re-exports', () => {
+  it('exposes findingId, planInlineThreads, REVIEW_THREADS_QUERY via index.js', () => {
+    expect(typeof barrelFindingId).toBe('function');
+    expect(typeof barrelPlan).toBe('function');
+    expect(typeof barrelQuery).toBe('string');
+    // Same reference (the barrel re-exports, doesn't wrap).
+    expect(barrelFindingId).toBe(findingId);
+    expect(barrelQuery).toBe(REVIEW_THREADS_QUERY);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findingId — SHA-256 hash stability
+// ---------------------------------------------------------------------------
+
+describe('findingId', () => {
+  it('returns 16 hex characters', () => {
+    const id = findingId({
+      file: 'src/foo.ts',
+      line: 10,
+      severity: 'critical',
+      skill: 'critical-issues-only',
+      summary: 'NPE risk',
+    });
+    expect(id).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it('is stable for the same inputs', () => {
+    const args = {
+      file: 'src/foo.ts',
+      line: 10,
+      severity: 'critical',
+      skill: 'critical-issues-only',
+      summary: 'NPE risk',
+    };
+    expect(findingId(args)).toBe(findingId(args));
+  });
+
+  it('absorbs summary drift past the 100-char truncation boundary', () => {
+    const base = 'A'.repeat(100);
+    const a = findingId({
+      file: 'src/foo.ts',
+      line: 10,
+      severity: 'critical',
+      skill: 's1',
+      summary: base + ' tail one',
+    });
+    const b = findingId({
+      file: 'src/foo.ts',
+      line: 10,
+      severity: 'critical',
+      skill: 's1',
+      summary: base + ' totally different tail',
+    });
+    expect(a).toBe(b);
+  });
+
+  it('changes id when any tuple field changes within the first 100 chars', () => {
+    const base = {
+      file: 'src/foo.ts',
+      line: 10,
+      severity: 'critical',
+      skill: 's1',
+      summary: 'short summary',
+    };
+    expect(findingId(base)).not.toBe(findingId({ ...base, file: 'src/bar.ts' }));
+    expect(findingId(base)).not.toBe(findingId({ ...base, line: 11 }));
+    expect(findingId(base)).not.toBe(findingId({ ...base, severity: 'minor' }));
+    expect(findingId(base)).not.toBe(findingId({ ...base, skill: 's2' }));
+    expect(findingId(base)).not.toBe(findingId({ ...base, summary: 'different' }));
+  });
+
+  it('tolerates missing file/line (uses `<no-file>` + 0 placeholders)', () => {
+    const id = findingId({
+      severity: 'critical',
+      skill: 's',
+      summary: 'x',
+    });
+    expect(id).toMatch(/^[a-f0-9]{16}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseHeadLines — diff parsing
+// ---------------------------------------------------------------------------
+
+describe('parseHeadLines', () => {
+  it('returns empty set for undefined patch', () => {
+    expect(parseHeadLines(undefined)).toEqual(new Set());
+  });
+
+  it('returns empty set for empty patch', () => {
+    expect(parseHeadLines('')).toEqual(new Set());
+  });
+
+  it('extracts added lines from a simple hunk', () => {
+    const patch = `@@ -1,1 +1,2 @@
+ unchanged
++new line`;
+    expect(parseHeadLines(patch)).toEqual(new Set([1, 2]));
+  });
+
+  it('counts context lines as HEAD-side line numbers', () => {
+    const patch = `@@ -1,3 +1,3 @@
+ line1
+-removed
++added
+ line3`;
+    expect(parseHeadLines(patch)).toEqual(new Set([1, 2, 3]));
+  });
+
+  it('does not advance line counter on removed (-) lines', () => {
+    const patch = `@@ -10,3 +10,1 @@
+ keep
+-rm1
+-rm2`;
+    expect(parseHeadLines(patch)).toEqual(new Set([10]));
+  });
+
+  it('skips +++/--- file headers', () => {
+    const patch = `--- a/old.ts
++++ b/new.ts
+@@ -1,1 +1,1 @@
++real add`;
+    expect(parseHeadLines(patch)).toEqual(new Set([1]));
+  });
+
+  it('handles multiple hunks', () => {
+    const patch = `@@ -1,1 +1,1 @@
++a
+@@ -10,1 +20,1 @@
++b`;
+    expect(parseHeadLines(patch)).toEqual(new Set([1, 20]));
+  });
+
+  it('handles defaulted newLines count (single-line hunks)', () => {
+    const patch = `@@ -5 +5 @@
++only`;
+    expect(parseHeadLines(patch)).toEqual(new Set([5]));
+  });
+
+  it('skips the "\\ No newline at end of file" marker', () => {
+    const patch = `@@ -1,1 +1,1 @@
++x
+\\ No newline at end of file`;
+    expect(parseHeadLines(patch)).toEqual(new Set([1]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findingAnchorable — gate per-finding thread creation
+// ---------------------------------------------------------------------------
+
+describe('findingAnchorable', () => {
+  const diffFiles = [
+    {
+      filename: 'src/foo.ts',
+      patch: `@@ -1,1 +1,2 @@
+ ctx
++added`,
+    },
+    { filename: 'src/binary.bin' }, // no patch (binary or truncated)
+  ];
+
+  it('returns true when file + line are in the diff', () => {
+    expect(findingAnchorable({ file: 'src/foo.ts', line: 1 }, diffFiles)).toBe(true);
+    expect(findingAnchorable({ file: 'src/foo.ts', line: 2 }, diffFiles)).toBe(true);
+  });
+
+  it('returns false when line is outside the hunks', () => {
+    expect(findingAnchorable({ file: 'src/foo.ts', line: 99 }, diffFiles)).toBe(false);
+  });
+
+  it('returns false when file is not in the diff', () => {
+    expect(findingAnchorable({ file: 'src/bar.ts', line: 1 }, diffFiles)).toBe(false);
+  });
+
+  it('returns false for binary files (no patch)', () => {
+    expect(findingAnchorable({ file: 'src/binary.bin', line: 1 }, diffFiles)).toBe(false);
+  });
+
+  it('returns false when file or line is missing', () => {
+    expect(findingAnchorable({ line: 1 }, diffFiles)).toBe(false);
+    expect(findingAnchorable({ file: 'src/foo.ts' }, diffFiles)).toBe(false);
+    expect(findingAnchorable({}, diffFiles)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractAnchorContext — verifier context extraction
+// ---------------------------------------------------------------------------
+
+describe('extractAnchorContext', () => {
+  const diffFiles = [
+    {
+      filename: 'src/foo.ts',
+      patch: `@@ -5,3 +5,4 @@
+ ctx1
+-old1
++new1
++new2
+ ctx2`,
+    },
+  ];
+
+  it('returns codeBefore and codeAfter populated from the hunk', () => {
+    const ctx = extractAnchorContext({ file: 'src/foo.ts', line: 6 }, diffFiles);
+    expect(ctx.codeBefore).toContain('old1');
+    expect(ctx.codeAfter).toContain('new1');
+    expect(ctx.diffAtAnchor).toContain('@@');
+  });
+
+  it('returns empty strings when file is not in the diff', () => {
+    const ctx = extractAnchorContext({ file: 'src/bar.ts', line: 1 }, diffFiles);
+    expect(ctx).toEqual({ codeBefore: '', codeAfter: '' });
+  });
+
+  it('returns empty strings when file/line are missing', () => {
+    expect(extractAnchorContext({}, diffFiles)).toEqual({ codeBefore: '', codeAfter: '' });
+  });
+
+  it('returns empty strings when line is outside all hunks', () => {
+    const ctx = extractAnchorContext({ file: 'src/foo.ts', line: 99 }, diffFiles);
+    expect(ctx).toEqual({ codeBefore: '', codeAfter: '' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderThreadBody / extractFindingIdFromBody — marker roundtrip
+// ---------------------------------------------------------------------------
+
+describe('renderThreadBody + extractFindingIdFromBody', () => {
+  const finding = {
+    severity: 'critical',
+    skill: 'critical-issues-only',
+    file: 'src/foo.ts',
+    line: 42,
+    summary: 'NPE on null user',
+    reasoning: 'getUser() can return null when the cache misses.',
+  };
+
+  it('embeds the canonical finding-id marker as the first line', () => {
+    const body = renderThreadBody(finding);
+    expect(body.startsWith('<!-- finding-id: ')).toBe(true);
+    const extracted = extractFindingIdFromBody(body);
+    expect(extracted).toBe(findingId(finding));
+  });
+
+  it('renders critical severity with red circle badge', () => {
+    expect(renderThreadBody({ ...finding, severity: 'critical' })).toContain('🔴');
+  });
+
+  it('renders minor severity with yellow circle badge', () => {
+    expect(renderThreadBody({ ...finding, severity: 'minor' })).toContain('🟡');
+  });
+
+  it('includes skill name in backticks', () => {
+    expect(renderThreadBody(finding)).toContain('`critical-issues-only`');
+  });
+
+  it('includes summary + reasoning in the body', () => {
+    const body = renderThreadBody(finding);
+    expect(body).toContain('NPE on null user');
+    expect(body).toContain('getUser() can return null');
+  });
+
+  it('omits reasoning section when reasoning is undefined', () => {
+    const body = renderThreadBody({ ...finding, reasoning: undefined });
+    expect(body).toContain('NPE on null user');
+    expect(body).not.toContain('getUser()');
+  });
+
+  it('returns null when body has no finding-id marker', () => {
+    expect(extractFindingIdFromBody('just a regular comment')).toBeNull();
+    expect(extractFindingIdFromBody('<!-- some-other-marker: xxx -->')).toBeNull();
+  });
+
+  it('returns null when finding-id marker is malformed (wrong length)', () => {
+    expect(extractFindingIdFromBody('<!-- finding-id: deadbeef -->')).toBeNull(); // 8 chars, not 16
+    expect(extractFindingIdFromBody('<!-- finding-id: deadbeefdeadbeefXX -->')).toBeNull(); // non-hex
+  });
+});
+
+// ---------------------------------------------------------------------------
+// planInlineThreads — finding partition
+// ---------------------------------------------------------------------------
+
+describe('planInlineThreads', () => {
+  const diffFiles = [
+    {
+      filename: 'src/foo.ts',
+      patch: `@@ -1,1 +1,2 @@
+ ctx
++added`,
+    },
+  ];
+
+  it('returns empty comments for empty findings', () => {
+    const r = planInlineThreads([], diffFiles);
+    expect(r.comments).toEqual([]);
+    expect(r.skipped).toEqual([]);
+    expect(r.preexisting).toEqual([]);
+  });
+
+  it('anchors a critical finding into a comment entry', () => {
+    const finding = {
+      severity: 'critical',
+      skill: 's',
+      file: 'src/foo.ts',
+      line: 2,
+      summary: 'bug',
+    };
+    const r = planInlineThreads([finding], diffFiles);
+    expect(r.comments).toHaveLength(1);
+    expect(r.comments[0]).toMatchObject({
+      path: 'src/foo.ts',
+      line: 2,
+      side: 'RIGHT',
+    });
+    expect(r.comments[0].body).toContain('<!-- finding-id:');
+    expect(r.skipped).toEqual([]);
+    expect(r.preexisting).toEqual([]);
+  });
+
+  it('moves preexisting findings to their own bucket (never threaded)', () => {
+    const finding = {
+      severity: 'preexisting',
+      skill: 's',
+      file: 'src/foo.ts',
+      line: 2,
+      summary: 'old',
+    };
+    const r = planInlineThreads([finding], diffFiles);
+    expect(r.comments).toEqual([]);
+    expect(r.preexisting).toHaveLength(1);
+  });
+
+  it('moves non-anchorable findings to skipped', () => {
+    const finding = {
+      severity: 'critical',
+      skill: 's',
+      file: 'src/bar.ts', // not in diff
+      line: 1,
+      summary: 'bug',
+    };
+    const r = planInlineThreads([finding], diffFiles);
+    expect(r.comments).toEqual([]);
+    expect(r.skipped).toHaveLength(1);
+  });
+
+  it('mixed batch: anchors what it can, partitions the rest', () => {
+    const findings = [
+      { severity: 'critical', skill: 'a', file: 'src/foo.ts', line: 2, summary: 'in' },
+      { severity: 'minor', skill: 'b', file: 'src/foo.ts', line: 99, summary: 'out-of-hunk' },
+      { severity: 'preexisting', skill: 'c', file: 'src/foo.ts', line: 1, summary: 'pre' },
+    ];
+    const r = planInlineThreads(findings, diffFiles);
+    expect(r.comments).toHaveLength(1);
+    expect(r.skipped).toHaveLength(1);
+    expect(r.preexisting).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GraphQL constants — shape sanity (regex spot-checks, not full parse)
+// ---------------------------------------------------------------------------
+
+describe('GraphQL operation strings', () => {
+  it('REVIEW_THREADS_QUERY queries reviewThreads with id + isResolved + comments', () => {
+    expect(REVIEW_THREADS_QUERY).toMatch(/query ReviewThreads/);
+    expect(REVIEW_THREADS_QUERY).toMatch(/reviewThreads\(first: 100\)/);
+    expect(REVIEW_THREADS_QUERY).toMatch(/isResolved/);
+    expect(REVIEW_THREADS_QUERY).toMatch(/databaseId/);
+    expect(REVIEW_THREADS_QUERY).toMatch(/originalLine/);
+  });
+
+  it('REVIEW_THREADS_STATE_QUERY queries the lighter state shape', () => {
+    expect(REVIEW_THREADS_STATE_QUERY).toMatch(/query ReviewThreadStates/);
+    expect(REVIEW_THREADS_STATE_QUERY).toMatch(/isResolved/);
+    // State query embeds body so Wave 5b can re-derive finding-id from the marker.
+    expect(REVIEW_THREADS_STATE_QUERY).toMatch(/body/);
+  });
+
+  it('RESOLVE_THREAD_MUTATION calls resolveReviewThread with threadId', () => {
+    expect(RESOLVE_THREAD_MUTATION).toMatch(/mutation ResolveThread/);
+    expect(RESOLVE_THREAD_MUTATION).toMatch(/resolveReviewThread/);
+    expect(RESOLVE_THREAD_MUTATION).toMatch(/\$threadId: ID!/);
+  });
+});

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -60,7 +60,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // Workflow refreshed
     const wf = await readFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'utf8');
     assert.match(wf, /allowedTools/);
-    assert.match(wf, /^# clud-bug-template-version: v12/);
+    assert.match(wf, /^# clud-bug-template-version: v13/);
     // Baseline rewritten with current shipped content
     const baseline = await readFile(join(dir, '.claude/skills/critical-issues-only/SKILL.md'), 'utf8');
     assert.match(baseline, /critical-issues-only/);
@@ -75,7 +75,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // The refreshed workflow records a from/to version note.
     const wfChange = r.changed.find((c) => c.label === 'review workflow');
     assert.equal(wfChange.from, 'v0');
-    assert.equal(wfChange.to, 'v12');
+    assert.equal(wfChange.to, 'v13');
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
## Summary

OSS parity push, part 1 of 2. Brings per-finding inline review threads (D.2.X) from the hosted clud-bug-app to the npm `clud-bug` workflow template path so self-hosted users get first-class GitHub review threads anchored to file+line, instead of one bundled summary comment listing every finding.

## What's in this PR

- **New `src/core/inline-threads.ts`** (393 LOC): pure helpers + GraphQL constants
  - `findingId(finding)` — SHA-256[:16] hash of the canonical 5-tuple (matches App's `lib/inline-threads.ts:findingId` so threads stay matchable after a future Wave 5c App-side swap)
  - `parseHeadLines(patch)`, `findingAnchorable(finding, diffFiles)`, `extractAnchorContext(finding, diffFiles)` — diff-anchor detection
  - `renderThreadBody(finding)` — embeds `<!-- finding-id: <hash> -->` marker so Wave 5b (rc.8) auto-resolve can re-match without persistent state
  - `extractFindingIdFromBody(body)` — inverse of the marker embed
  - `planInlineThreads(findings, diffFiles)` — partitions a flat findings list into the createReview `comments[]` body + skipped + preexisting buckets
  - GraphQL constants: `REVIEW_THREADS_QUERY`, `REVIEW_THREADS_STATE_QUERY`, `RESOLVE_THREAD_MUTATION` (module-scoped, exported for Wave 5b)
- **New CLI verb `clud-bug post-inline-threads --stdin`** in `src/cli/main.ts`: reads the structured review JSON from stdin, fetches the PR diff via `gh api repos/.../pulls/N/files --paginate`, calls `planInlineThreads`, and if any findings are anchorable, posts ONE batched review via `gh api -X POST .../reviews` with `event: COMMENT`. Emits a JSON status report on stdout. Required env vars: `GH_TOKEN`, `REPO`, `PR_NUMBER`, `HEAD_SHA`.
- **Workflow templates** (`workflow.yml.tmpl`, `workflow-ts.yml.tmpl`, `workflow-py.yml.tmpl`): new "Post inline review threads" post-step inserted after "Render + post structured review". `continue-on-error: true` matches the existing post-step posture.
- **Version pin updates**: `package.json` 0.7.0-rc.6 → 0.7.0-rc.7, all 3 workflow template `strict-mode-gate@v0.7.0-rc.6` → `@v0.7.0-rc.7`, action.yml header docstring.
- **Tests**: 45 new (40 in `test/inline-threads.test.js` covering all pure helpers + GraphQL constant shape, 5 in `test/cli.test.js` covering the validation-and-no-op paths of the new CLI verb). 602 → 647 total, all green.

## Design highlights

- **Stateless adapter** (the only meaningful difference vs the App-side impl): App uses Redis to persist `THREAD:{install}:{repo}:{pr}:{finding_id}` across pushes. npm workflow is stateless — re-queries GitHub `reviewThreads` on demand in Wave 5b, re-deriving `findingId` from the `<!-- finding-id: ... -->` marker we embed in comment bodies here.
- **Failure posture**: CLI verb fail-closed to exit 0 + `{posted: 0, error: ...}` JSON on stdout. Surrounding workflow step's `continue-on-error: true` is the single source of failure semantics. Mirrors existing `render` / `select-review-event` verbs.
- **Shared core, two consumers**: pure helpers in `src/core/inline-threads.ts` mirror the App's `lib/inline-threads.ts` algorithm so a future Wave 5c can swap the App to import from core + delete duplicates (~600 LOC deletion on the App side).

## Out of scope

- Auto-resolve on fix-push (D.2.6) — that's Wave 5b, builds on this PR's threads
- App-side swap to consume `clud-bug/core/inline-threads.ts` — queued as optional Wave 5c
- Multi-pass (D.2.5) + auto-fix push (D.2.7) — explicitly App-only premium

## Test plan

- [x] `npm run build` clean
- [x] `npm test` → 647/647 passing (was 602; +45 new)
- [ ] Bot review (clud-bug-review paused on this repo per Phase 5.3 — local code-reviewer agent stands in)
- [ ] Smoke verify on `clud-bug-test` AFTER tag + publish (USER ACTION queued as task #259)

🤖 Generated with [Claude Code](https://claude.com/claude-code)