### PR TITLE
Wave 5b: D.2.6 auto-resolve on fix-push (clud-bug rc.8)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.7
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.8
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/decisions-branches/wave-5b-auto-resolve.md
+++ b/docs/decisions-branches/wave-5b-auto-resolve.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-27 22:36 - Wave 5b — D.2.6 auto-resolve on fix-push in npm workflow (rc.8)
+
+**Reasoning:** OSS parity push, part 2 of 2 (after Wave 5a inline threads). On fix-push, the workflow asks the Anthropic Messages API per bot-authored unresolved inline thread whether the new commit addressed the original finding. ADDRESSED → resolve thread + post marker reply; UNCERTAIN/NOT_ADDRESSED → leave open (escalate critical UNCERTAIN to REQUEST_CHANGES intent). Pure rule tables + prompt + response-parser in clud-bug/core; IO (Anthropic fetch + GraphQL mutations) in CLI verb. Stateless via existing finding-id markers — no Redis.
+
+**Alternatives considered:** Use @anthropic-ai/sdk runtime dep — rejected; direct fetch() to Messages API keeps the package dep-light (only zod stays). ~30 LOC vs adding a transitive dep tree., Port App's heuristic fallback + aggregateMultiPassVerdicts — rejected for OSS MVP. Heuristic adds 80 LOC + a reFlaggedThreadIds correlation step for no customer ask. Multi-pass is App-only (D.2.5). Future Wave 5c can add either if needed., Make verifier model configurable via .clud-bug.json — rejected. Hardcoded to claude-sonnet-4-6 with CLUD_BUG_VERIFIER_MODEL env override for power users. Config-knob proliferation defer until customer asks.
+
+**Implications:**
+- Workflow ships a new post-step gated on synchronize events. CLI verb fail-closed: verifier errors → UNCERTAIN, all unexpected paths emit {error: ...} JSON + exit 0, surrounding continue-on-error: true is the single failure gate. Cost shape: ~$0.005/thread/fix-push × N threads. Smoke surface ready on clud-bug-test (workflow installed at rc.7 from Wave 5a; bump to rc.8 after publish).
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -9,8 +9,7 @@ clud-bug
 │   ├── workflow-ts.yml
 │   └── workflow.yml
 ├── .claude
-│   ├── skills
-│   └── worktrees
+│   └── skills
 ├── .github
 │   ├── actions
 │   ├── workflows

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -9,7 +9,8 @@ clud-bug
 │   ├── workflow-ts.yml
 │   └── workflow.yml
 ├── .claude
-│   └── skills
+│   ├── skills
+│   └── worktrees
 ├── .github
 │   ├── actions
 │   ├── workflows

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (48 decisions)
+## 2026-06 (49 decisions)
 
-- **2026-06-27** — Wave 5a — D.2.X per-finding inline review threads in npm workflow (rc.7) *(wave-5a-inline-threads)* — [decisions-branches/wave-5a-inline-threads.md](decisions-branches/wave-5a-inline-threads.md)
-- *... 46 more decisions ...*
+- **2026-06-27** — Wave 5b — D.2.6 auto-resolve on fix-push in npm workflow (rc.8) *(wave-5b-auto-resolve)* — [decisions-branches/wave-5b-auto-resolve.md](decisions-branches/wave-5b-auto-resolve.md)
+- *... 47 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.7",
+  "version": "0.7.0-rc.8",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -777,8 +777,16 @@ async function runResolveThreads(_args) {
     autoResolveConfig = readAutoResolveConfigFromCludBug(cfg, (msg) => {
       process.stderr.write(`clud-bug resolve-threads: config warning: ${msg}\n`);
     });
-  } catch {
-    // Missing or unparseable .clud-bug.json — use defaults.
+  } catch (err) {
+    // Missing OR unparseable .clud-bug.json — use defaults but log the
+    // specific reason so an operator with malformed config can diagnose
+    // why their `autoResolve.mode = 'off'` is being silently ignored.
+    const code = err && typeof err === 'object' && 'code' in err ? err.code : undefined;
+    if (code !== 'ENOENT') {
+      process.stderr.write(
+        `clud-bug resolve-threads: .clud-bug.json read/parse error (${err && typeof err === 'object' && 'message' in err ? err.message : String(err)}); using defaults.\n`,
+      );
+    }
     autoResolveConfig = readAutoResolveConfigFromCludBug(null);
   }
 
@@ -788,13 +796,17 @@ async function runResolveThreads(_args) {
   }
 
   // ---- Fetch threads via GraphQL -----------------------------------------
+  // `gh api graphql` uses `-f` for String! variables and `-F` for typed
+  // (number / bool) variables. Owner + repo are String! per the query;
+  // pr is Int!. Reviewer-flagged: passing owner/repo as `-F` would coerce
+  // numeric-looking values incorrectly.
   const threadsResult = spawnSync(
     'gh',
     [
       'api', 'graphql',
       '-f', `query=${REVIEW_THREADS_QUERY}`,
-      '-F', `owner=${owner}`,
-      '-F', `repo=${repoName}`,
+      '-f', `owner=${owner}`,
+      '-f', `repo=${repoName}`,
       '-F', `pr=${prNumber}`,
     ],
     { encoding: 'utf8' },

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -170,6 +170,16 @@ Commands:
                         without persistent state. Required env vars: GH_TOKEN,
                         REPO ("owner/name"), PR_NUMBER, HEAD_SHA. Output is a
                         JSON status report \`{posted, skipped, preexisting, error?}\`.
+  resolve-threads       Auto-resolve inline review threads when a fix-push
+                        addresses the original finding (D.2.6). Fetches all
+                        bot-authored unresolved threads, asks the Anthropic
+                        Messages API per-thread whether the new commit addressed
+                        the concern, then resolves (with a marker reply)
+                        ADDRESSED threads + leaves UNCERTAIN/NOT_ADDRESSED open.
+                        Fail-closed: verifier errors route to UNCERTAIN.
+                        Required env vars: GH_TOKEN, ANTHROPIC_API_KEY,
+                        REPO ("owner/name"), PR_NUMBER. Output: JSON
+                        \`{actions, verifierCallCount, shouldRequestChanges}\`.
 
 Options:
   --offline             Skip skills.sh; pin only the bundled baseline specimens.
@@ -229,6 +239,7 @@ async function main() {
     case 'update-skill-usage': return runUpdateSkillUsage(args);
     case 'select-review-event': return runSelectReviewEvent(args);
     case 'post-inline-threads': return runPostInlineThreads(args);
+    case 'resolve-threads': return runResolveThreads(args);
     default:
       process.stderr.write(`Unknown command: ${cmd || '(none)'}\n\n${HELP}`);
       process.exit(2);
@@ -704,6 +715,301 @@ async function runPostInlineThreads(args) {
     posted: plan.comments.length,
     skipped: plan.skipped.map((f) => ({ skill: f.skill, file: f.file, line: f.line, reason: 'not-anchorable' })),
     preexisting: plan.preexisting.map((f) => ({ skill: f.skill })),
+  }) + '\n');
+}
+
+
+// Wave 5b / 0.7.0-rc.8: D.2.6 auto-resolve on fix-push. Fetches all
+// bot-authored unresolved inline threads, asks the Anthropic Messages
+// API per-thread whether the new commit addressed the original
+// finding, and resolves ADDRESSED threads (with a marker reply) while
+// leaving UNCERTAIN/NOT_ADDRESSED open. Fail-closed throughout —
+// verifier errors route to UNCERTAIN; the surrounding workflow
+// step's `continue-on-error: true` is the single failure gate.
+//
+// Required env: GH_TOKEN, ANTHROPIC_API_KEY, REPO ("owner/name"), PR_NUMBER.
+//
+// No `--stdin` — fetches everything from `gh api graphql` itself.
+// Workflow gates this verb on `github.event.action == 'synchronize'`
+// so it only runs on fix-pushes (not initial PR opens, when there
+// are no prior threads to resolve).
+async function runResolveThreads(_args) {
+  const {
+    parseThreadBody,
+    extractAnchorContext,
+    REVIEW_THREADS_QUERY,
+    RESOLVE_THREAD_MUTATION,
+    ADD_REPLY_MUTATION,
+  } = await import('../core/inline-threads.js');
+  const {
+    readAutoResolveConfigFromCludBug,
+    runAutoResolve,
+  } = await import('../core/auto-resolve.js');
+  const {
+    VERIFIER_SYSTEM,
+    buildVerifierPrompt,
+    parseVerifierResponse,
+  } = await import('../core/resolve-verifier.js');
+
+  // ---- Env validation ----------------------------------------------------
+  const repo = String(process.env.REPO ?? '').trim();
+  const prNumberRaw = String(process.env.PR_NUMBER ?? '').trim();
+  const prNumber = Number(prNumberRaw);
+  const ghToken = String(process.env.GH_TOKEN ?? '').trim();
+  const anthropicKey = String(process.env.ANTHROPIC_API_KEY ?? '').trim();
+  if (!repo || !repo.includes('/') || !Number.isInteger(prNumber) || prNumber <= 0 || !ghToken || !anthropicKey) {
+    process.stderr.write(
+      `clud-bug resolve-threads: REPO + PR_NUMBER + GH_TOKEN + ANTHROPIC_API_KEY env vars required.\n`,
+    );
+    process.stdout.write(JSON.stringify({ actions: [], verifierCallCount: 0, shouldRequestChanges: false, error: 'missing-env' }) + '\n');
+    return;
+  }
+  const [owner, repoName] = repo.split('/', 2);
+
+  // ---- Optional .clud-bug.json config (autoResolve block) ----------------
+  // The workflow's working dir is the PR checkout — if .clud-bug.json is
+  // present we read autoResolve from it. Otherwise defaults (mode='verified').
+  let autoResolveConfig;
+  try {
+    const cfgPath = join(process.cwd(), '.claude/skills/.clud-bug.json');
+    const cfgRaw = await readFile(cfgPath, 'utf8');
+    const cfg = JSON.parse(cfgRaw);
+    autoResolveConfig = readAutoResolveConfigFromCludBug(cfg, (msg) => {
+      process.stderr.write(`clud-bug resolve-threads: config warning: ${msg}\n`);
+    });
+  } catch {
+    // Missing or unparseable .clud-bug.json — use defaults.
+    autoResolveConfig = readAutoResolveConfigFromCludBug(null);
+  }
+
+  if (autoResolveConfig.mode === 'off') {
+    process.stdout.write(JSON.stringify({ actions: [], verifierCallCount: 0, shouldRequestChanges: false, reason: 'mode-off' }) + '\n');
+    return;
+  }
+
+  // ---- Fetch threads via GraphQL -----------------------------------------
+  const threadsResult = spawnSync(
+    'gh',
+    [
+      'api', 'graphql',
+      '-f', `query=${REVIEW_THREADS_QUERY}`,
+      '-F', `owner=${owner}`,
+      '-F', `repo=${repoName}`,
+      '-F', `pr=${prNumber}`,
+    ],
+    { encoding: 'utf8' },
+  );
+  if (threadsResult.status !== 0) {
+    process.stderr.write(`clud-bug resolve-threads: gh api graphql (threads) failed (exit ${threadsResult.status}): ${(threadsResult.stderr || '').slice(0, 500)}\n`);
+    process.stdout.write(JSON.stringify({ actions: [], verifierCallCount: 0, shouldRequestChanges: false, error: 'threads-fetch-failed' }) + '\n');
+    return;
+  }
+
+  let threadNodes;
+  try {
+    const parsed = JSON.parse(threadsResult.stdout);
+    threadNodes = parsed?.data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
+    if (!Array.isArray(threadNodes)) threadNodes = [];
+  } catch (e) {
+    process.stderr.write(`clud-bug resolve-threads: threads JSON parse failed: ${e.message}\n`);
+    process.stdout.write(JSON.stringify({ actions: [], verifierCallCount: 0, shouldRequestChanges: false, error: 'threads-parse-failed' }) + '\n');
+    return;
+  }
+
+  // ---- Filter to bot-authored unresolved threads with our marker --------
+  // The workflow's GITHUB_TOKEN posts as `github-actions[bot]`. Match both
+  // the bracketed bot form and the bare `github-actions` form (GraphQL
+  // can return either depending on the node-type field requested).
+  const BOT_AUTHORS = new Set(['github-actions', 'github-actions[bot]']);
+  const candidates = [];
+  for (const t of threadNodes) {
+    if (!t || t.isResolved) continue;
+    const c = t.comments?.nodes?.[0];
+    if (!c) continue;
+    const authorLogin = c.author?.login ?? '';
+    if (!BOT_AUTHORS.has(authorLogin)) continue;
+    const parsed = parseThreadBody(c.body ?? '');
+    if (!parsed) continue;
+    if (!c.path || (c.line === null && c.originalLine === null)) continue;
+    candidates.push({
+      threadId: t.id,
+      file: c.path,
+      line: c.line ?? c.originalLine,
+      parsed,
+    });
+  }
+
+  if (candidates.length === 0) {
+    process.stdout.write(JSON.stringify({ actions: [], verifierCallCount: 0, shouldRequestChanges: false, reason: 'no-bot-threads' }) + '\n');
+    return;
+  }
+
+  // ---- Fetch diff for anchor context -------------------------------------
+  const filesResult = spawnSync(
+    'gh',
+    [
+      'api',
+      `repos/${repo}/pulls/${prNumber}/files`,
+      '--paginate',
+      '--slurp',
+    ],
+    { encoding: 'utf8' },
+  );
+  if (filesResult.status !== 0) {
+    process.stderr.write(`clud-bug resolve-threads: diff fetch failed (exit ${filesResult.status}): ${(filesResult.stderr || '').slice(0, 500)}\n`);
+    process.stdout.write(JSON.stringify({ actions: [], verifierCallCount: 0, shouldRequestChanges: false, error: 'diff-fetch-failed' }) + '\n');
+    return;
+  }
+  let diffFiles = [];
+  try {
+    const pages = JSON.parse(filesResult.stdout);
+    if (Array.isArray(pages)) {
+      for (const page of pages) {
+        if (Array.isArray(page)) diffFiles.push(...page);
+      }
+    }
+  } catch (e) {
+    process.stderr.write(`clud-bug resolve-threads: diff JSON parse failed: ${e.message}\n`);
+    process.stdout.write(JSON.stringify({ actions: [], verifierCallCount: 0, shouldRequestChanges: false, error: 'diff-parse-failed' }) + '\n');
+    return;
+  }
+
+  // ---- Build PriorThread[] for runAutoResolve ----------------------------
+  const priorThreads = candidates.map((c) => {
+    const ctx = extractAnchorContext({ file: c.file, line: c.line }, diffFiles);
+    const findingBody = c.parsed.reasoning
+      ? `${c.parsed.summary}\n\n${c.parsed.reasoning}`
+      : c.parsed.summary;
+    return {
+      threadId: c.threadId,
+      finding: {
+        severity: c.parsed.severity,
+        body: findingBody,
+        skill: c.parsed.skill,
+        file: c.file,
+        line: c.line,
+      },
+      codeBefore: ctx.codeBefore,
+      codeAfter: ctx.codeAfter,
+      ...(ctx.diffAtAnchor !== undefined ? { diffAtAnchor: ctx.diffAtAnchor } : {}),
+    };
+  });
+
+  // ---- Define verifier (Anthropic Messages API via raw fetch) -----------
+  // Model is hardcoded here — the verifier needs a model that handles
+  // structured JSON output reliably. Sonnet 4.6 is the default. Override
+  // via CLUD_BUG_VERIFIER_MODEL env var if needed.
+  const verifierModel = String(process.env.CLUD_BUG_VERIFIER_MODEL ?? '').trim()
+    || 'claude-sonnet-4-6';
+
+  async function verifier(input) {
+    const userPrompt = buildVerifierPrompt(input);
+    try {
+      const resp = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'anthropic-version': '2023-06-01',
+          'x-api-key': anthropicKey,
+        },
+        body: JSON.stringify({
+          model: verifierModel,
+          max_tokens: 300,
+          system: VERIFIER_SYSTEM,
+          messages: [{ role: 'user', content: userPrompt }],
+        }),
+      });
+      if (!resp.ok) {
+        const errText = await resp.text().catch(() => '');
+        return {
+          verdict: 'UNCERTAIN',
+          source: 'api-error',
+          rationale: `Anthropic API ${resp.status}: ${errText.slice(0, 200)}`,
+        };
+      }
+      const body = await resp.json();
+      // Messages API: content is an array of blocks; pick the first text block.
+      const text = (body?.content ?? []).find((b) => b?.type === 'text')?.text ?? '';
+      return parseVerifierResponse(text);
+    } catch (err) {
+      return {
+        verdict: 'UNCERTAIN',
+        source: 'api-error',
+        rationale: `verifier fetch error: ${err?.message ?? String(err)}`,
+      };
+    }
+  }
+
+  // ---- Run pure orchestration -------------------------------------------
+  const result = await runAutoResolve({
+    priorThreads,
+    config: autoResolveConfig,
+    verifier,
+  });
+
+  // ---- Execute the actions via GraphQL mutations ------------------------
+  const actionsReport = [];
+  for (let i = 0; i < result.actions.length; i++) {
+    const action = result.actions[i];
+    const thread = priorThreads[i];
+    if (!action || !thread) continue;
+    const report = {
+      threadId: thread.threadId,
+      file: thread.finding.file,
+      line: thread.finding.line,
+      verdict: action.verdict?.verdict,
+      kind: action.kind,
+    };
+
+    if (action.kind === 'skipped') {
+      actionsReport.push({ ...report, executed: 'skipped' });
+      continue;
+    }
+
+    // Post the marker reply (all non-skipped paths get a reply).
+    const replyResult = spawnSync(
+      'gh',
+      [
+        'api', 'graphql',
+        '-f', `query=${ADD_REPLY_MUTATION}`,
+        '-f', `threadId=${thread.threadId}`,
+        '-f', `body=${action.markerBody}`,
+      ],
+      { encoding: 'utf8' },
+    );
+    if (replyResult.status !== 0) {
+      process.stderr.write(`clud-bug resolve-threads: ADD_REPLY failed for thread ${thread.threadId}: ${(replyResult.stderr || '').slice(0, 200)}\n`);
+      actionsReport.push({ ...report, executed: 'reply-failed' });
+      continue;
+    }
+
+    // Resolve only ADDRESSED threads.
+    if (action.kind === 'resolve') {
+      const resolveResult = spawnSync(
+        'gh',
+        [
+          'api', 'graphql',
+          '-f', `query=${RESOLVE_THREAD_MUTATION}`,
+          '-f', `threadId=${thread.threadId}`,
+        ],
+        { encoding: 'utf8' },
+      );
+      if (resolveResult.status !== 0) {
+        process.stderr.write(`clud-bug resolve-threads: RESOLVE failed for thread ${thread.threadId}: ${(resolveResult.stderr || '').slice(0, 200)}\n`);
+        actionsReport.push({ ...report, executed: 'resolve-failed' });
+        continue;
+      }
+      actionsReport.push({ ...report, executed: 'resolved' });
+    } else {
+      // keep_open or keep_open_request_changes — reply already posted.
+      actionsReport.push({ ...report, executed: 'kept-open' });
+    }
+  }
+
+  process.stdout.write(JSON.stringify({
+    actions: actionsReport,
+    verifierCallCount: result.verifierCallCount,
+    shouldRequestChanges: result.shouldRequestChanges,
   }) + '\n');
 }
 

--- a/src/core/auto-resolve.ts
+++ b/src/core/auto-resolve.ts
@@ -1,0 +1,366 @@
+// Wave 5b — D.2.6 auto-resolve fidelity, npm-workflow flavor.
+//
+// On every fix-push (`pull_request.synchronize`), for each open thread
+// posted by the bot on a prior pass, decide whether the new commit
+// addressed the original concern, and act accordingly:
+//
+//   ADDRESSED      → resolve the thread + post "Auto-resolved (verified)"
+//   NOT_ADDRESSED  → keep open + post "Re-review found this still applies"
+//                    + flag REQUEST_CHANGES intent if 🔴 critical
+//   UNCERTAIN + 🟡 → keep open + post "human review recommended"
+//   UNCERTAIN + 🔴 → keep open + flag REQUEST_CHANGES + escalate. NEVER dismiss.
+//
+// This module owns the pure rule tables + config merge + marker
+// rendering. The CLI verb in `src/cli/main.ts::runResolveThreads` owns
+// the IO: fetching threads via `gh api graphql`, calling Anthropic
+// Messages API for the verifier, applying these actions via REST/
+// GraphQL mutations.
+//
+// Ported from `clud-bug-app/lib/auto-resolve.ts` (and the marker
+// helpers from `clud-bug-app/lib/comment.ts`). Differences from the
+// App impl:
+//   - DROP `aggregateMultiPassVerdicts` — OSS workflow is single-pass.
+//   - DROP heuristic fallback (`heuristicAction`) — OSS supports only
+//     `mode: 'verified' | 'off'` for now; heuristic adds complexity
+//     without a customer ask. Future Wave 5c can add it back if the
+//     App migrates to consume from core.
+//   - DROP per-PR budget gate — OSS workflow uses the customer's own
+//     `ANTHROPIC_API_KEY`; spend-cap is their concern, not ours.
+
+import type { Severity } from './inline-threads.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Configuration for `autoResolve` in `.clud-bug.json`. */
+export interface AutoResolveConfig {
+  /**
+   * Which mode the install opted into.
+   * - 'verified' (default): call the verifier per thread.
+   * - 'off': do nothing — all threads stay open, no verifier calls.
+   */
+  mode: 'verified' | 'off';
+  /**
+   * Action to take when the verifier returns UNCERTAIN + the original
+   * finding was 🔴 critical.
+   *
+   * - 'request_changes' (default): keep open + flag REQUEST_CHANGES.
+   * - 'leave_open': keep open with a milder marker, no escalation.
+   */
+  uncertain_critical_action: 'request_changes' | 'leave_open';
+}
+
+export const DEFAULT_AUTO_RESOLVE_CONFIG: AutoResolveConfig = {
+  mode: 'verified',
+  uncertain_critical_action: 'request_changes',
+};
+
+/**
+ * One open thread from a prior review pass, plus enough state to verify
+ * it. The CLI verb hands these to `runAutoResolve` after parsing the
+ * GraphQL response + the bot's comment-body markers.
+ */
+export interface PriorThread {
+  /** GitHub review-thread node ID (GraphQL ID). Used to resolve the thread. */
+  threadId: string;
+  /** The prior finding the thread anchors. */
+  finding: PriorFinding;
+  /** Code at the finding anchor BEFORE the fix-push. */
+  codeBefore: string;
+  /** Code at the finding anchor AFTER the fix-push. */
+  codeAfter: string;
+  /** Diff hunk at the anchor (optional). */
+  diffAtAnchor?: string;
+}
+
+/**
+ * The minimal shape `applyResolutionRules` + the verifier need to
+ * describe a prior finding. The CLI reconstructs this from
+ * `parseThreadBody(comment.body)` + the GraphQL `path`/`line` fields.
+ */
+export interface PriorFinding {
+  severity: Severity;
+  /** The summary line + (optional) reasoning, joined for the verifier prompt. */
+  body: string;
+  /** The skill slug that raised the finding. */
+  skill: string;
+  /** Repo-relative path. */
+  file: string;
+  /** Optional 1-indexed line number. */
+  line?: number;
+}
+
+/** What the CLI verb should do with the thread. */
+export type ThreadAction =
+  | { kind: 'resolve'; markerBody: string; verdict: VerifyOutcome }
+  | { kind: 'keep_open'; markerBody: string; verdict: VerifyOutcome }
+  | {
+      kind: 'keep_open_request_changes';
+      markerBody: string;
+      verdict: VerifyOutcome;
+      /** True when triggered by UNCERTAIN+🔴 escalation. */
+      escalated: boolean;
+    }
+  | {
+      kind: 'skipped';
+      reason: 'off';
+      thread?: PriorThread;
+    };
+
+/** Verdict shape — re-exported from resolve-verifier for ergonomics. */
+export interface VerifyOutcome {
+  verdict: 'ADDRESSED' | 'NOT_ADDRESSED' | 'UNCERTAIN';
+  rationale: string;
+  source: 'model' | 'api-error';
+}
+
+export interface AutoResolveInput {
+  /** Open threads from prior review passes. May be empty. */
+  priorThreads: PriorThread[];
+  /** Resolved config (after precedence merge). */
+  config: AutoResolveConfig;
+  /** Verifier callback. Tests inject a stub; CLI provides real Anthropic-call fn. */
+  verifier: (args: {
+    finding: PriorFinding;
+    codeBefore: string;
+    codeAfter: string;
+    diffAtAnchor?: string;
+  }) => Promise<VerifyOutcome>;
+}
+
+export interface AutoResolveResult {
+  /** One action per input thread, in input order. */
+  actions: ThreadAction[];
+  /** Total verifier calls made. */
+  verifierCallCount: number;
+  /**
+   * True when any action is `keep_open_request_changes`. The CLI verb /
+   * workflow uses this to decide whether to flip the formal review to
+   * REQUEST_CHANGES (one transition covers all flagged threads).
+   */
+  shouldRequestChanges: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Config resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads `autoResolve` from a `.clud-bug.json` payload + merges with
+ * built-in defaults. Returns a fully-resolved `AutoResolveConfig`.
+ *
+ * Unknown fields tolerated (forward compat). Invalid values fall back
+ * to the default for that key + log a warning. NEVER throws — a
+ * config-validation throw on the fix-push hot path would degrade the
+ * whole step to a fail.
+ */
+export function resolveAutoResolveConfig(
+  raw: unknown,
+  onWarn: (msg: string) => void = () => {},
+): AutoResolveConfig {
+  const defaults = DEFAULT_AUTO_RESOLVE_CONFIG;
+  if (!raw || typeof raw !== 'object') return defaults;
+  const obj = raw as Record<string, unknown>;
+
+  let mode: AutoResolveConfig['mode'] = defaults.mode;
+  if (typeof obj.mode === 'string') {
+    if (obj.mode === 'verified' || obj.mode === 'off') {
+      mode = obj.mode;
+    } else {
+      onWarn(
+        `autoResolve.mode = ${JSON.stringify(obj.mode)} is invalid; falling back to "${defaults.mode}". Valid: verified, off.`,
+      );
+    }
+  }
+
+  let uncertainCritical: AutoResolveConfig['uncertain_critical_action'] =
+    defaults.uncertain_critical_action;
+  if (typeof obj.uncertain_critical_action === 'string') {
+    if (
+      obj.uncertain_critical_action === 'request_changes' ||
+      obj.uncertain_critical_action === 'leave_open'
+    ) {
+      uncertainCritical = obj.uncertain_critical_action;
+    } else {
+      onWarn(
+        `autoResolve.uncertain_critical_action = ${JSON.stringify(obj.uncertain_critical_action)} is invalid; falling back to "${defaults.uncertain_critical_action}".`,
+      );
+    }
+  }
+
+  return {
+    mode,
+    uncertain_critical_action: uncertainCritical,
+  };
+}
+
+/**
+ * Convenience: extracts the `autoResolve` block from a top-level
+ * `.clud-bug.json` config blob.
+ */
+export function readAutoResolveConfigFromCludBug(
+  config: { autoResolve?: unknown } | null | undefined,
+  onWarn?: (msg: string) => void,
+): AutoResolveConfig {
+  if (!config) return DEFAULT_AUTO_RESOLVE_CONFIG;
+  return resolveAutoResolveConfig(config.autoResolve, onWarn);
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point — pure orchestration with injected verifier
+// ---------------------------------------------------------------------------
+
+/**
+ * For each prior thread, call the injected verifier + apply the
+ * resolution rules. Returns one action per input thread, plus
+ * aggregate stats.
+ *
+ * The CLI verb executes the returned actions (GraphQL mutations);
+ * this function is pure modulo the verifier callback.
+ */
+export async function runAutoResolve(
+  input: AutoResolveInput,
+): Promise<AutoResolveResult> {
+  if (input.config.mode === 'off') {
+    return {
+      actions: input.priorThreads.map((thread) => ({
+        kind: 'skipped' as const,
+        reason: 'off' as const,
+        thread,
+      })),
+      verifierCallCount: 0,
+      shouldRequestChanges: false,
+    };
+  }
+
+  const actions: ThreadAction[] = [];
+  let verifierCallCount = 0;
+  let shouldRequestChanges = false;
+
+  for (const thread of input.priorThreads) {
+    // Conditionally include `diffAtAnchor` only when present so the
+    // narrowed `verifier` callback type (which forbids `undefined`
+    // under `exactOptionalPropertyTypes`) stays satisfied.
+    const verifierArgs: Parameters<typeof input.verifier>[0] = {
+      finding: thread.finding,
+      codeBefore: thread.codeBefore,
+      codeAfter: thread.codeAfter,
+      ...(thread.diffAtAnchor !== undefined
+        ? { diffAtAnchor: thread.diffAtAnchor }
+        : {}),
+    };
+    const verdict = await input.verifier(verifierArgs);
+    verifierCallCount++;
+    const action = applyResolutionRules({
+      thread,
+      verdict,
+      config: input.config,
+    });
+    actions.push(action);
+    if (action.kind === 'keep_open_request_changes') shouldRequestChanges = true;
+  }
+
+  return { actions, verifierCallCount, shouldRequestChanges };
+}
+
+// ---------------------------------------------------------------------------
+// Rule table — pure function from (verdict, finding, config) → action
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a verifier verdict + the thread context to the action the CLI
+ * verb should take. Pure function, no I/O.
+ *
+ * Resolution table:
+ *   ADDRESSED, any         → resolve, "Auto-resolved (verified)"
+ *   NOT_ADDRESSED, 🔴      → keep_open_request_changes (escalated=false)
+ *   NOT_ADDRESSED, 🟡      → keep_open, "Re-review found this still applies"
+ *   UNCERTAIN, 🔴, request → keep_open_request_changes (escalated=true)
+ *   UNCERTAIN, 🔴, leave   → keep_open, "Auto-resolve uncertain — human review recommended"
+ *   UNCERTAIN, 🟡          → keep_open, "human review recommended"
+ */
+export function applyResolutionRules(args: {
+  thread: PriorThread;
+  verdict: VerifyOutcome;
+  config: AutoResolveConfig;
+}): ThreadAction {
+  const { verdict, thread, config } = args;
+  const severity = thread.finding.severity;
+
+  if (verdict.verdict === 'ADDRESSED') {
+    return {
+      kind: 'resolve',
+      markerBody: renderAutoResolveMarker({
+        kind: 'verified-addressed',
+        rationale: verdict.rationale,
+      }),
+      verdict,
+    };
+  }
+
+  if (verdict.verdict === 'NOT_ADDRESSED') {
+    const markerBody = renderAutoResolveMarker({
+      kind: 'verified-not-addressed',
+      rationale: verdict.rationale,
+    });
+    if (severity === 'critical') {
+      return {
+        kind: 'keep_open_request_changes',
+        markerBody,
+        verdict,
+        escalated: false,
+      };
+    }
+    return { kind: 'keep_open', markerBody, verdict };
+  }
+
+  // UNCERTAIN.
+  const markerBody = renderAutoResolveMarker({
+    kind: 'verified-uncertain',
+    rationale: verdict.rationale,
+    severity,
+  });
+  if (
+    severity === 'critical' &&
+    config.uncertain_critical_action === 'request_changes'
+  ) {
+    return {
+      kind: 'keep_open_request_changes',
+      markerBody,
+      verdict,
+      escalated: true,
+    };
+  }
+  return { kind: 'keep_open', markerBody, verdict };
+}
+
+// ---------------------------------------------------------------------------
+// Marker rendering — ported from clud-bug-app/lib/comment.ts
+// ---------------------------------------------------------------------------
+
+type AutoResolveMarkerInput =
+  | { kind: 'verified-addressed'; rationale?: string }
+  | { kind: 'verified-not-addressed'; rationale?: string }
+  | { kind: 'verified-uncertain'; rationale?: string; severity: Severity };
+
+/**
+ * Renders the comment body the CLI verb posts as a reply on the
+ * thread before resolving (or alongside keep-open). Wording mirrors
+ * the App's `renderAutoResolveMarker` so both consumers emit a
+ * uniform audit trail.
+ */
+export function renderAutoResolveMarker(input: AutoResolveMarkerInput): string {
+  const tail = input.rationale ? `: ${input.rationale.trim()}` : '.';
+  switch (input.kind) {
+    case 'verified-addressed':
+      return `**✓ Auto-resolved (verified by D.2.6 fix-check)**${tail}`;
+    case 'verified-not-addressed':
+      return `**❌ Re-review found this still applies**${tail}`;
+    case 'verified-uncertain':
+      if (input.severity === 'critical') {
+        return `**⚠ Auto-resolve uncertain on a 🔴 critical — escalated, never silently dismissed**${tail}`;
+      }
+      return `**⚠ Auto-resolve uncertain — human review recommended**${tail}`;
+  }
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -156,6 +156,10 @@ export {
 // constants the CLI's `post-inline-threads` verb invokes via `gh api`.
 // `findingId` returns the SHA-256[:16] hash and is distinct from the
 // plain-string `findingIdentity` above (both serve different matchers).
+//
+// Wave 5b additions: `parseThreadBody` (inverts renderThreadBody) +
+// `ADD_REPLY_MUTATION` (for posting the auto-resolve marker reply
+// before resolving a thread).
 export {
   findingId,
   parseHeadLines,
@@ -163,16 +167,43 @@ export {
   extractAnchorContext,
   renderThreadBody,
   extractFindingIdFromBody,
+  parseThreadBody,
   planInlineThreads,
   REVIEW_THREADS_QUERY,
   REVIEW_THREADS_STATE_QUERY,
   RESOLVE_THREAD_MUTATION,
+  ADD_REPLY_MUTATION,
   type Severity as InlineThreadSeverity,
   type FindingForThread,
   type DiffFile,
   type InlineCommentPlan,
   type PlanInlineThreadsResult,
 } from './inline-threads.js';
+// Wave 5b — D.2.6 auto-resolve on fix-push. Pure rule tables + config
+// merge + marker rendering. The CLI's `resolve-threads` verb owns the
+// Anthropic Messages call + GraphQL mutations; `runAutoResolve` is
+// pure modulo the injected verifier callback.
+export {
+  resolveAutoResolveConfig,
+  readAutoResolveConfigFromCludBug,
+  runAutoResolve,
+  applyResolutionRules,
+  renderAutoResolveMarker,
+  DEFAULT_AUTO_RESOLVE_CONFIG,
+  type AutoResolveConfig,
+  type PriorThread,
+  type PriorFinding,
+  type ThreadAction,
+  type AutoResolveInput,
+  type AutoResolveResult,
+  type VerifyOutcome,
+} from './auto-resolve.js';
+export {
+  VERIFIER_SYSTEM,
+  buildVerifierPrompt,
+  parseVerifierResponse,
+  type VerifySingleFindingInput,
+} from './resolve-verifier.js';
 // SPEC §7 canonical-ruleset applier. Pure diff + idempotent-PATCH logic;
 // CLI side wraps `gh api` in an Octokit-like adapter and the App passes
 // its real Octokit instance. Shipped in v0.7.0-rc.4 for Marketplace prep

--- a/src/core/inline-threads.ts
+++ b/src/core/inline-threads.ts
@@ -274,6 +274,50 @@ export function extractFindingIdFromBody(body: string): string | null {
   return m ? m[1]! : null;
 }
 
+/**
+ * Wave 5b — invert `renderThreadBody` to recover the original finding
+ * tuple from a bot-authored thread comment. The fix-push auto-resolve
+ * CLI verb uses this to reconstruct `PriorFinding` from the GraphQL
+ * `reviewThreads` response without persistent state.
+ *
+ * Returns null when the body doesn't match the canonical shape
+ * `<!-- finding-id: XX -->\n🔴|🟡 \`skill\`\n\nsummary[\n\nreasoning]`.
+ * Same start-anchored posture as `extractFindingIdFromBody` for anti-
+ * injection: a user reply that quotes the marker mid-body won't be
+ * misattributed as bot-authored.
+ */
+export function parseThreadBody(body: string): {
+  findingId: string;
+  severity: Severity;
+  skill: string;
+  summary: string;
+  reasoning?: string;
+} | null {
+  // Marker (line 1), header (line 2: badge + backticked skill), blank,
+  // summary, optional blank + reasoning. The header line shape:
+  //   `🔴 \`critical-issues-only\``  or  `🟡 \`magic-numbers\``
+  const re =
+    /^<!--\s*finding-id:\s*([a-f0-9]{16})\s*-->\n(🔴|🟡)\s+`([^`]+)`\n\n([\s\S]+?)(?:\n\n([\s\S]+))?$/;
+  const m = body.match(re);
+  if (!m) return null;
+  const [, findingId, badge, skill, summary, reasoning] = m;
+  const severity: Severity = badge === '🔴' ? 'critical' : 'minor';
+  const out: {
+    findingId: string;
+    severity: Severity;
+    skill: string;
+    summary: string;
+    reasoning?: string;
+  } = {
+    findingId: findingId!,
+    severity,
+    skill: skill!,
+    summary: summary!.trim(),
+  };
+  if (reasoning && reasoning.trim()) out.reasoning = reasoning.trim();
+  return out;
+}
+
 // ---------------------------------------------------------------------------
 // Inline-thread posting plan
 // ---------------------------------------------------------------------------
@@ -395,6 +439,23 @@ export const RESOLVE_THREAD_MUTATION = `
     resolveReviewThread(input: { threadId: $threadId }) {
       thread {
         isResolved
+      }
+    }
+  }
+`;
+
+// Wave 5b — post a reply on a review thread (used to attach the
+// auto-resolve marker explaining the verifier's verdict) BEFORE
+// calling `RESOLVE_THREAD_MUTATION`. The reply is visible in the PR
+// timeline so reviewers can audit why the bot auto-resolved.
+export const ADD_REPLY_MUTATION = `
+  mutation AddThreadReply($threadId: ID!, $body: String!) {
+    addPullRequestReviewThreadReply(
+      input: { pullRequestReviewThreadId: $threadId, body: $body }
+    ) {
+      comment {
+        id
+        body
       }
     }
   }

--- a/src/core/inline-threads.ts
+++ b/src/core/inline-threads.ts
@@ -384,6 +384,12 @@ export function planInlineThreads(
 // reference the same query strings as the App.
 // ---------------------------------------------------------------------------
 
+// Wave 5b update — `author { login }` added so the resolve-threads CLI
+// verb can filter to bot-authored threads. Without this, the bot-filter
+// reads `comments[0].author?.login` as undefined and accepts everything,
+// which would feed user-authored threads (that happen to start with the
+// marker) into the verifier. Additive change — Wave 5a consumers
+// (post-inline-threads) didn't read `author` so they're unaffected.
 export const REVIEW_THREADS_QUERY = `
   query ReviewThreads($owner: String!, $repo: String!, $pr: Int!) {
     repository(owner: $owner, name: $repo) {
@@ -399,6 +405,9 @@ export const REVIEW_THREADS_QUERY = `
                 line
                 originalLine
                 body
+                author {
+                  login
+                }
               }
             }
           }

--- a/src/core/resolve-verifier.ts
+++ b/src/core/resolve-verifier.ts
@@ -1,0 +1,228 @@
+// Wave 5b — D.2.6 per-thread fix-verifier prompt + response parser.
+//
+// On every fix-push, the CLI verb asks Claude DIRECTLY for each prior
+// thread: "the prior reviewer said X. Here is the BEFORE / AFTER /
+// DIFF. Did the new commit address the original finding?" Verdicts:
+//
+//   ADDRESSED      — fix unambiguously resolves the original concern
+//   NOT_ADDRESSED  — original concern still applies
+//   UNCERTAIN      — can't tell; routes through human review
+//
+// This module is PURE — prompt builder + response parser. The actual
+// Anthropic Messages API call lives in `src/cli/main.ts::runResolveThreads`
+// (raw `fetch()` — no `@anthropic-ai/sdk` dep so the npm package stays
+// dep-light). Tests inject mocked verifier outcomes via the
+// `runAutoResolve` `verifier` callback in `./auto-resolve`.
+//
+// Ported from `clud-bug-app/lib/resolve-verifier.ts:162-260`. Differences:
+//   - No `@ai-sdk/anthropic` / `zod` dependency. Response parsing is
+//     hand-rolled JSON extraction with manual validation.
+//   - DROP `verifySingleFinding` (App-side IO entry point). The CLI
+//     verb owns the API call directly.
+//   - DROP `aggregateMultiPassVerdicts` — OSS is single-pass.
+
+import type { PriorFinding, VerifyOutcome } from './auto-resolve.js';
+
+// ---------------------------------------------------------------------------
+// System prompt — hard-coded, NOT derived from user content (anti-injection)
+// ---------------------------------------------------------------------------
+
+export const VERIFIER_SYSTEM = [
+  'You are a code-review fix verifier. Your only job is to decide whether a',
+  'specific code change addressed a specific prior reviewer concern.',
+  '',
+  'You are NOT writing a new code review. You are NOT looking for new issues.',
+  'You are NOT judging style. You are answering one question: did the change',
+  'between BEFORE and AFTER resolve the concern raised in the prior finding?',
+  '',
+  'Your verdict MUST be exactly one of: ADDRESSED, NOT_ADDRESSED, UNCERTAIN.',
+  '',
+  'Rules:',
+  '- ADDRESSED: the AFTER code unambiguously resolves the original concern.',
+  '  Partial fixes that leave the core problem unsolved are NOT ADDRESSED.',
+  '- NOT_ADDRESSED: the AFTER code still has the original problem, OR the',
+  '  change is unrelated to the concern, OR the change made the problem worse.',
+  '- UNCERTAIN: you cannot tell from the BEFORE / AFTER alone. Use this when',
+  '  the context is too narrow, the change is subtle and could go either way,',
+  '  or the concern depends on code you cannot see. Never guess — say',
+  '  UNCERTAIN when you would be guessing.',
+  '',
+  'Treat the prior finding as a black box: it might be wrong, but you are not',
+  'judging the finding. You are judging whether the new code resolves what it',
+  'said. If the finding asked for X and the change does X, mark ADDRESSED even',
+  'if X is unnecessary.',
+  '',
+  'Reply with a JSON object on a single line, no markdown fence, no surrounding',
+  'prose. Shape:',
+  '  {"verdict":"ADDRESSED"|"NOT_ADDRESSED"|"UNCERTAIN","rationale":"<one sentence>"}',
+  'Rationale MUST be one sentence, max 500 characters.',
+].join('\n');
+
+// ---------------------------------------------------------------------------
+// Input shape
+// ---------------------------------------------------------------------------
+
+export interface VerifySingleFindingInput {
+  finding: PriorFinding;
+  /** Code at the finding's anchor BEFORE the fix-push. Empty when deleted. */
+  codeBefore: string;
+  /** Code at the finding's anchor AFTER the fix-push. Empty when deleted. */
+  codeAfter: string;
+  /** Optional: unified-diff hunk at the anchor. */
+  diffAtAnchor?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt builder — pure (no env, no Date.now, no timestamps)
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the user-facing prompt body.
+ *
+ * Prompt-injection defense:
+ *   - System prompt is module-scope, NOT derived from user content.
+ *   - User content (finding body, code, diff) is wrapped in fence-
+ *     delimited blocks with clear labels. The model knows the
+ *     boundaries.
+ *   - Output is parsed with `parseVerifierResponse` which validates
+ *     the verdict against a fixed enum + caps rationale at 500 chars.
+ *     A model coerced to emit "ADDRESSED!" outside the JSON shape
+ *     gets routed to UNCERTAIN+api-error (fail-closed).
+ */
+export function buildVerifierPrompt(input: VerifySingleFindingInput): string {
+  const f = input.finding;
+  const anchor = f.line !== undefined ? `${f.file}:${f.line}` : f.file;
+  const sev = f.severity === 'critical' ? '🔴 critical' : '🟡 minor';
+
+  const parts: string[] = [];
+  parts.push(
+    `A prior code review (skill: \`${f.skill}\`, severity: ${sev}) flagged \`${anchor}\` with this finding:`,
+  );
+  parts.push('');
+  parts.push('```');
+  parts.push('PRIOR FINDING:');
+  parts.push(f.body);
+  parts.push('```');
+  parts.push('');
+  parts.push(
+    'The PR author has since pushed a new commit. Here is the code BEFORE and AFTER:',
+  );
+  parts.push('');
+  parts.push('```');
+  parts.push('BEFORE:');
+  parts.push(input.codeBefore || '(empty — file did not exist or was empty)');
+  parts.push('```');
+  parts.push('');
+  parts.push('```');
+  parts.push('AFTER:');
+  parts.push(input.codeAfter || '(empty — file was deleted or emptied)');
+  parts.push('```');
+
+  if (input.diffAtAnchor) {
+    parts.push('');
+    parts.push('```');
+    parts.push('DIFF AT ANCHOR:');
+    parts.push(input.diffAtAnchor);
+    parts.push('```');
+  }
+
+  parts.push('');
+  parts.push('Did this change ADDRESS the original finding?');
+  parts.push(
+    'Reply with the JSON object only — single line, no markdown fence, no prose.',
+  );
+
+  return parts.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Response parser — extracts `{verdict, rationale}` from the model text
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses the model's text response into a `VerifyOutcome`. Fail-closed:
+ * any malformed input → UNCERTAIN+api-error with the failure mode in
+ * the rationale, so the caller's auto-resolve rules route through
+ * human review (never silently ADDRESSED).
+ *
+ * Tolerates:
+ *   - Leading/trailing whitespace
+ *   - The model wrapping the JSON in ```json fences (strips them)
+ *   - Extra fields (ignored)
+ *
+ * Rejects:
+ *   - Empty / non-string input
+ *   - Non-JSON / malformed JSON
+ *   - Missing or non-string `verdict`
+ *   - `verdict` not in the allowed enum
+ *   - Missing or empty `rationale`
+ *   - `rationale` longer than 500 chars (caps at 500 in the outcome)
+ */
+export function parseVerifierResponse(text: unknown): VerifyOutcome {
+  if (typeof text !== 'string' || !text.trim()) {
+    return {
+      verdict: 'UNCERTAIN',
+      source: 'api-error',
+      rationale: 'verifier returned empty or non-string response',
+    };
+  }
+
+  // Strip optional ```json … ``` or ``` … ``` fence.
+  let body = text.trim();
+  const fenced = body.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```$/);
+  if (fenced) body = fenced[1]!.trim();
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch (err) {
+    return {
+      verdict: 'UNCERTAIN',
+      source: 'api-error',
+      rationale: `verifier response was not valid JSON: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {
+      verdict: 'UNCERTAIN',
+      source: 'api-error',
+      rationale: 'verifier response was not a JSON object',
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const verdict = obj.verdict;
+  const rationale = obj.rationale;
+
+  if (
+    verdict !== 'ADDRESSED' &&
+    verdict !== 'NOT_ADDRESSED' &&
+    verdict !== 'UNCERTAIN'
+  ) {
+    return {
+      verdict: 'UNCERTAIN',
+      source: 'api-error',
+      rationale: `verifier emitted unknown verdict: ${JSON.stringify(verdict)}`,
+    };
+  }
+
+  if (typeof rationale !== 'string' || !rationale.trim()) {
+    return {
+      verdict: 'UNCERTAIN',
+      source: 'api-error',
+      rationale: 'verifier response missing rationale',
+    };
+  }
+
+  // Cap rationale at 500 chars per the system prompt's contract.
+  const trimmed = rationale.trim().slice(0, 500);
+
+  return {
+    verdict,
+    rationale: trimmed,
+    source: 'model',
+  };
+}

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v13
+# clud-bug-template-version: v14
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -298,6 +298,20 @@ jobs:
           RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} post-inline-threads --stdin)
           echo "::notice title=inline-threads::$RESULT"
 
+      # Wave 5b (D.2.6) — see workflow.yml.tmpl for design notes.
+      - name: Auto-resolve fixed threads
+        if: success() && github.event.action == 'synchronize'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          RESULT=$(npx --yes clud-bug@{{CLUD_BUG_VERSION}} resolve-threads)
+          echo "::notice title=auto-resolve::$RESULT"
+
       # v0.6.29 / Component 4 — see workflow.yml.tmpl for design notes.
       - name: Update skill-usage tracking
         if: success() && steps.clud-bug-review.outputs.structured_output != ''
@@ -381,7 +395,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.7
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v13
+# clud-bug-template-version: v14
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -298,6 +298,20 @@ jobs:
           RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} post-inline-threads --stdin)
           echo "::notice title=inline-threads::$RESULT"
 
+      # Wave 5b (D.2.6) — see workflow.yml.tmpl for design notes.
+      - name: Auto-resolve fixed threads
+        if: success() && github.event.action == 'synchronize'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          RESULT=$(npx --yes clud-bug@{{CLUD_BUG_VERSION}} resolve-threads)
+          echo "::notice title=auto-resolve::$RESULT"
+
       # v0.6.29 / Component 4 — see workflow.yml.tmpl for design notes.
       - name: Update skill-usage tracking
         if: success() && steps.clud-bug-review.outputs.structured_output != ''
@@ -381,7 +395,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.7
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v13
+# clud-bug-template-version: v14
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -532,6 +532,35 @@ jobs:
           RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@{{CLUD_BUG_VERSION}} post-inline-threads --stdin)
           echo "::notice title=inline-threads::$RESULT"
 
+      # v0.7.0-rc.8 / Wave 5b (D.2.6): on fix-push events
+      # (pull_request.synchronize), ask the Anthropic Messages API per
+      # bot-authored unresolved inline thread whether the new commit
+      # addressed the original finding. ADDRESSED → resolve the thread
+      # + post a marker reply; UNCERTAIN / NOT_ADDRESSED → leave open.
+      # Fail-closed: verifier errors route to UNCERTAIN (never silently
+      # dismiss).
+      #
+      # Gated on `synchronize` because:
+      # - `opened` events have no prior threads to resolve.
+      # - Re-running on every event would waste verifier $ on unchanged
+      #   state.
+      #
+      # The verb re-derives prior-finding context from the
+      # `<!-- finding-id: ... -->` markers Wave 5a embeds in each
+      # comment body, so no persistent state is needed across pushes.
+      - name: Auto-resolve fixed threads
+        if: success() && github.event.action == 'synchronize'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          RESULT=$(npx --yes clud-bug@{{CLUD_BUG_VERSION}} resolve-threads)
+          echo "::notice title=auto-resolve::$RESULT"
+
       # v0.6.29 / Component 4: pipe structured_output through
       # `clud-bug update-skill-usage` to compute the per-skill loads +
       # citations delta from this one review. Writes to the ephemeral
@@ -670,7 +699,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.7
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -592,3 +592,39 @@ test('--help advertises post-inline-threads subcommand', () => {
   assert.equal(r.status, 0);
   assert.match(r.stdout, /post-inline-threads/);
 });
+
+// ---------------------------------------------------------------------------
+// Wave 5b (v0.7.0-rc.8) — resolve-threads subcommand validation paths.
+// Happy-path requires gh + Anthropic API mocking — covered by integration
+// smoke on clud-bug-test. These tests cover the env-validation no-op paths.
+// ---------------------------------------------------------------------------
+
+function runResolveThreads(env = {}) {
+  return run(process.cwd(), ['resolve-threads'], { env });
+}
+
+test('resolve-threads: missing env vars → no-op with error=missing-env, exits 0', () => {
+  const r = runResolveThreads({}); // no REPO, PR_NUMBER, GH_TOKEN, or ANTHROPIC_API_KEY
+  assert.equal(r.status, 0, r.stderr);
+  const out = JSON.parse(r.stdout.trim());
+  assert.equal(out.verifierCallCount, 0);
+  assert.equal(out.error, 'missing-env');
+});
+
+test('resolve-threads: missing ANTHROPIC_API_KEY alone → no-op with error=missing-env', () => {
+  const r = runResolveThreads({
+    REPO: 'acme/test',
+    PR_NUMBER: '1',
+    GH_TOKEN: 'gho_x',
+    // ANTHROPIC_API_KEY deliberately omitted
+  });
+  assert.equal(r.status, 0, r.stderr);
+  const out = JSON.parse(r.stdout.trim());
+  assert.equal(out.error, 'missing-env');
+});
+
+test('--help advertises resolve-threads subcommand', () => {
+  const r = run(process.cwd(), ['--help']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /resolve-threads/);
+});

--- a/test/core/auto-resolve.test.js
+++ b/test/core/auto-resolve.test.js
@@ -1,0 +1,314 @@
+// Tests for src/core/auto-resolve.ts — Wave 5b D.2.6 pure rules + config.
+// IO (Anthropic call + GraphQL mutations) is owned by the CLI verb in
+// src/cli/main.ts; this file covers the pure logic that drives it.
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  resolveAutoResolveConfig,
+  readAutoResolveConfigFromCludBug,
+  runAutoResolve,
+  applyResolutionRules,
+  renderAutoResolveMarker,
+  DEFAULT_AUTO_RESOLVE_CONFIG,
+} from '../../src/core/auto-resolve.js';
+import {
+  resolveAutoResolveConfig as barrelConfig,
+  runAutoResolve as barrelRun,
+} from '../../src/core/index.js';
+
+// ---------------------------------------------------------------------------
+// Barrel re-exports
+// ---------------------------------------------------------------------------
+
+describe('core barrel re-exports', () => {
+  it('exposes resolveAutoResolveConfig + runAutoResolve via index.js', () => {
+    expect(barrelConfig).toBe(resolveAutoResolveConfig);
+    expect(barrelRun).toBe(runAutoResolve);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config merge
+// ---------------------------------------------------------------------------
+
+describe('resolveAutoResolveConfig', () => {
+  it('returns defaults when raw is null / undefined / non-object', () => {
+    expect(resolveAutoResolveConfig(null)).toEqual(DEFAULT_AUTO_RESOLVE_CONFIG);
+    expect(resolveAutoResolveConfig(undefined)).toEqual(DEFAULT_AUTO_RESOLVE_CONFIG);
+    expect(resolveAutoResolveConfig('string-not-object')).toEqual(DEFAULT_AUTO_RESOLVE_CONFIG);
+    expect(resolveAutoResolveConfig(42)).toEqual(DEFAULT_AUTO_RESOLVE_CONFIG);
+  });
+
+  it('returns defaults when mode is omitted', () => {
+    expect(resolveAutoResolveConfig({})).toEqual(DEFAULT_AUTO_RESOLVE_CONFIG);
+  });
+
+  it('accepts mode: "verified" + mode: "off"', () => {
+    expect(resolveAutoResolveConfig({ mode: 'verified' }).mode).toBe('verified');
+    expect(resolveAutoResolveConfig({ mode: 'off' }).mode).toBe('off');
+  });
+
+  it('falls back + warns on invalid mode', () => {
+    const warns = [];
+    const cfg = resolveAutoResolveConfig({ mode: 'bogus' }, (m) => warns.push(m));
+    expect(cfg.mode).toBe('verified');
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toMatch(/autoResolve.mode/);
+  });
+
+  it('accepts uncertain_critical_action overrides', () => {
+    const cfg = resolveAutoResolveConfig({
+      mode: 'verified',
+      uncertain_critical_action: 'leave_open',
+    });
+    expect(cfg.uncertain_critical_action).toBe('leave_open');
+  });
+
+  it('falls back + warns on invalid uncertain_critical_action', () => {
+    const warns = [];
+    const cfg = resolveAutoResolveConfig(
+      { uncertain_critical_action: 'shrug' },
+      (m) => warns.push(m),
+    );
+    expect(cfg.uncertain_critical_action).toBe('request_changes');
+    expect(warns).toHaveLength(1);
+  });
+
+  it('tolerates extra fields (forward compat)', () => {
+    const cfg = resolveAutoResolveConfig({
+      mode: 'verified',
+      futureField: 'whatever',
+    });
+    expect(cfg.mode).toBe('verified');
+  });
+});
+
+describe('readAutoResolveConfigFromCludBug', () => {
+  it('returns defaults for null/undefined config', () => {
+    expect(readAutoResolveConfigFromCludBug(null)).toEqual(DEFAULT_AUTO_RESOLVE_CONFIG);
+    expect(readAutoResolveConfigFromCludBug(undefined)).toEqual(DEFAULT_AUTO_RESOLVE_CONFIG);
+  });
+
+  it('extracts autoResolve block from a parsed .clud-bug.json', () => {
+    const cfg = readAutoResolveConfigFromCludBug({ autoResolve: { mode: 'off' } });
+    expect(cfg.mode).toBe('off');
+  });
+
+  it('returns defaults when autoResolve is absent', () => {
+    expect(readAutoResolveConfigFromCludBug({})).toEqual(DEFAULT_AUTO_RESOLVE_CONFIG);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resolution rule table
+// ---------------------------------------------------------------------------
+
+const sampleThread = (severity = 'critical') => ({
+  threadId: 'PRRT_x',
+  finding: {
+    severity,
+    body: 'NPE risk',
+    skill: 'critical-issues-only',
+    file: 'lib/foo.ts',
+    line: 10,
+  },
+  codeBefore: 'old',
+  codeAfter: 'new',
+});
+
+describe('applyResolutionRules', () => {
+  it('ADDRESSED, critical → resolve', () => {
+    const action = applyResolutionRules({
+      thread: sampleThread('critical'),
+      verdict: { verdict: 'ADDRESSED', source: 'model', rationale: 'null guard added' },
+      config: DEFAULT_AUTO_RESOLVE_CONFIG,
+    });
+    expect(action.kind).toBe('resolve');
+    expect(action.markerBody).toMatch(/Auto-resolved/);
+  });
+
+  it('ADDRESSED, minor → resolve', () => {
+    const action = applyResolutionRules({
+      thread: sampleThread('minor'),
+      verdict: { verdict: 'ADDRESSED', source: 'model', rationale: 'fixed' },
+      config: DEFAULT_AUTO_RESOLVE_CONFIG,
+    });
+    expect(action.kind).toBe('resolve');
+  });
+
+  it('NOT_ADDRESSED, critical → keep_open_request_changes (not escalated)', () => {
+    const action = applyResolutionRules({
+      thread: sampleThread('critical'),
+      verdict: { verdict: 'NOT_ADDRESSED', source: 'model', rationale: 'still null' },
+      config: DEFAULT_AUTO_RESOLVE_CONFIG,
+    });
+    expect(action.kind).toBe('keep_open_request_changes');
+    expect(action.escalated).toBe(false);
+  });
+
+  it('NOT_ADDRESSED, minor → keep_open', () => {
+    const action = applyResolutionRules({
+      thread: sampleThread('minor'),
+      verdict: { verdict: 'NOT_ADDRESSED', source: 'model', rationale: 'still magic' },
+      config: DEFAULT_AUTO_RESOLVE_CONFIG,
+    });
+    expect(action.kind).toBe('keep_open');
+  });
+
+  it('UNCERTAIN, critical, request_changes → keep_open_request_changes (escalated)', () => {
+    const action = applyResolutionRules({
+      thread: sampleThread('critical'),
+      verdict: { verdict: 'UNCERTAIN', source: 'model', rationale: 'context narrow' },
+      config: DEFAULT_AUTO_RESOLVE_CONFIG,
+    });
+    expect(action.kind).toBe('keep_open_request_changes');
+    expect(action.escalated).toBe(true);
+  });
+
+  it('UNCERTAIN, critical, leave_open → keep_open (no escalation)', () => {
+    const action = applyResolutionRules({
+      thread: sampleThread('critical'),
+      verdict: { verdict: 'UNCERTAIN', source: 'model', rationale: 'narrow' },
+      config: { ...DEFAULT_AUTO_RESOLVE_CONFIG, uncertain_critical_action: 'leave_open' },
+    });
+    expect(action.kind).toBe('keep_open');
+  });
+
+  it('UNCERTAIN, minor → keep_open', () => {
+    const action = applyResolutionRules({
+      thread: sampleThread('minor'),
+      verdict: { verdict: 'UNCERTAIN', source: 'model', rationale: 'narrow' },
+      config: DEFAULT_AUTO_RESOLVE_CONFIG,
+    });
+    expect(action.kind).toBe('keep_open');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Marker rendering
+// ---------------------------------------------------------------------------
+
+describe('renderAutoResolveMarker', () => {
+  it('verified-addressed includes the rationale', () => {
+    const s = renderAutoResolveMarker({
+      kind: 'verified-addressed',
+      rationale: 'null guard added',
+    });
+    expect(s).toMatch(/Auto-resolved \(verified/);
+    expect(s).toMatch(/null guard added/);
+  });
+
+  it('verified-uncertain on critical escalates wording', () => {
+    const s = renderAutoResolveMarker({
+      kind: 'verified-uncertain',
+      rationale: 'narrow',
+      severity: 'critical',
+    });
+    expect(s).toMatch(/escalated/);
+  });
+
+  it('verified-uncertain on minor does not escalate', () => {
+    const s = renderAutoResolveMarker({
+      kind: 'verified-uncertain',
+      rationale: 'narrow',
+      severity: 'minor',
+    });
+    expect(s).toMatch(/human review recommended/);
+    expect(s).not.toMatch(/escalated/);
+  });
+
+  it('omits trailing colon when rationale is absent', () => {
+    const s = renderAutoResolveMarker({ kind: 'verified-addressed' });
+    expect(s.endsWith('.')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runAutoResolve — pure orchestration
+// ---------------------------------------------------------------------------
+
+describe('runAutoResolve', () => {
+  it('returns skipped:off actions when config.mode === "off"', async () => {
+    const verifier = vi.fn();
+    const r = await runAutoResolve({
+      priorThreads: [sampleThread('critical'), sampleThread('minor')],
+      config: { ...DEFAULT_AUTO_RESOLVE_CONFIG, mode: 'off' },
+      verifier,
+    });
+    expect(verifier).not.toHaveBeenCalled();
+    expect(r.actions).toHaveLength(2);
+    expect(r.actions[0].kind).toBe('skipped');
+    expect(r.verifierCallCount).toBe(0);
+    expect(r.shouldRequestChanges).toBe(false);
+  });
+
+  it('returns empty actions for empty thread list', async () => {
+    const verifier = vi.fn();
+    const r = await runAutoResolve({
+      priorThreads: [],
+      config: DEFAULT_AUTO_RESOLVE_CONFIG,
+      verifier,
+    });
+    expect(verifier).not.toHaveBeenCalled();
+    expect(r.actions).toEqual([]);
+    expect(r.verifierCallCount).toBe(0);
+  });
+
+  it('calls verifier once per thread + applies rules', async () => {
+    const verifier = vi
+      .fn()
+      .mockResolvedValueOnce({ verdict: 'ADDRESSED', source: 'model', rationale: 'fixed' })
+      .mockResolvedValueOnce({ verdict: 'NOT_ADDRESSED', source: 'model', rationale: 'still' });
+    const r = await runAutoResolve({
+      priorThreads: [sampleThread('critical'), sampleThread('minor')],
+      config: DEFAULT_AUTO_RESOLVE_CONFIG,
+      verifier,
+    });
+    expect(verifier).toHaveBeenCalledTimes(2);
+    expect(r.verifierCallCount).toBe(2);
+    expect(r.actions[0].kind).toBe('resolve');
+    expect(r.actions[1].kind).toBe('keep_open');
+  });
+
+  it('sets shouldRequestChanges when any action is keep_open_request_changes', async () => {
+    const verifier = vi
+      .fn()
+      .mockResolvedValueOnce({ verdict: 'ADDRESSED', source: 'model', rationale: 'fixed' })
+      .mockResolvedValueOnce({ verdict: 'NOT_ADDRESSED', source: 'model', rationale: 'still' });
+    const r = await runAutoResolve({
+      priorThreads: [sampleThread('minor'), sampleThread('critical')],
+      config: DEFAULT_AUTO_RESOLVE_CONFIG,
+      verifier,
+    });
+    expect(r.shouldRequestChanges).toBe(true);
+  });
+
+  it('passes diffAtAnchor through to the verifier when present', async () => {
+    const verifier = vi
+      .fn()
+      .mockResolvedValue({ verdict: 'ADDRESSED', source: 'model', rationale: 'fixed' });
+    const thread = { ...sampleThread('critical'), diffAtAnchor: '@@ -1,1 +1,2 @@' };
+    await runAutoResolve({
+      priorThreads: [thread],
+      config: DEFAULT_AUTO_RESOLVE_CONFIG,
+      verifier,
+    });
+    expect(verifier).toHaveBeenCalledWith(
+      expect.objectContaining({ diffAtAnchor: '@@ -1,1 +1,2 @@' }),
+    );
+  });
+
+  it('omits diffAtAnchor key from the verifier call when not provided (exactOptionalPropertyTypes)', async () => {
+    const verifier = vi
+      .fn()
+      .mockResolvedValue({ verdict: 'ADDRESSED', source: 'model', rationale: 'fixed' });
+    await runAutoResolve({
+      priorThreads: [sampleThread('critical')],
+      config: DEFAULT_AUTO_RESOLVE_CONFIG,
+      verifier,
+    });
+    const callArg = verifier.mock.calls[0]?.[0];
+    expect(callArg).not.toHaveProperty('diffAtAnchor');
+  });
+});

--- a/test/core/resolve-verifier.test.js
+++ b/test/core/resolve-verifier.test.js
@@ -1,0 +1,209 @@
+// Tests for src/core/resolve-verifier.ts — Wave 5b verifier prompt
+// builder + response parser. The actual Anthropic Messages API call
+// lives in the CLI verb; this file covers the pure parts.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  VERIFIER_SYSTEM,
+  buildVerifierPrompt,
+  parseVerifierResponse,
+} from '../../src/core/resolve-verifier.js';
+
+// ---------------------------------------------------------------------------
+// System prompt shape
+// ---------------------------------------------------------------------------
+
+describe('VERIFIER_SYSTEM', () => {
+  it('declares the three-verdict enum (anti-injection)', () => {
+    expect(VERIFIER_SYSTEM).toMatch(/ADDRESSED/);
+    expect(VERIFIER_SYSTEM).toMatch(/NOT_ADDRESSED/);
+    expect(VERIFIER_SYSTEM).toMatch(/UNCERTAIN/);
+  });
+
+  it('asks for a JSON object on one line, no markdown fence', () => {
+    expect(VERIFIER_SYSTEM).toMatch(/JSON object/);
+    expect(VERIFIER_SYSTEM).toMatch(/no markdown fence/);
+  });
+
+  it('caps rationale at 500 characters', () => {
+    expect(VERIFIER_SYSTEM).toMatch(/500 characters/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prompt builder — pure shape stability
+// ---------------------------------------------------------------------------
+
+const sampleInput = {
+  finding: {
+    severity: 'critical',
+    body: 'NPE risk on null user',
+    skill: 'critical-issues-only',
+    file: 'lib/utils.ts',
+    line: 15,
+  },
+  codeBefore: 'function describeUser(user) { return user.name; }',
+  codeAfter:
+    'function describeUser(user) { if (!user) return ""; return user.name; }',
+  diffAtAnchor: '@@ -15,1 +15,2 @@\n+ null guard',
+};
+
+describe('buildVerifierPrompt', () => {
+  it('mentions the skill + severity + anchor', () => {
+    const out = buildVerifierPrompt(sampleInput);
+    expect(out).toMatch(/critical-issues-only/);
+    expect(out).toMatch(/🔴 critical/);
+    expect(out).toMatch(/lib\/utils\.ts:15/);
+  });
+
+  it('wraps BEFORE + AFTER + DIFF in labeled fenced blocks (anti-injection)', () => {
+    const out = buildVerifierPrompt(sampleInput);
+    expect(out).toMatch(/PRIOR FINDING:/);
+    expect(out).toMatch(/BEFORE:/);
+    expect(out).toMatch(/AFTER:/);
+    expect(out).toMatch(/DIFF AT ANCHOR:/);
+  });
+
+  it('renders 🟡 minor for minor severity', () => {
+    const out = buildVerifierPrompt({
+      ...sampleInput,
+      finding: { ...sampleInput.finding, severity: 'minor' },
+    });
+    expect(out).toMatch(/🟡 minor/);
+    expect(out).not.toMatch(/🔴 critical/);
+  });
+
+  it('falls back to file (no :line) when finding.line is missing', () => {
+    const out = buildVerifierPrompt({
+      ...sampleInput,
+      finding: { ...sampleInput.finding, line: undefined },
+    });
+    expect(out).toMatch(/`lib\/utils\.ts`/);
+    expect(out).not.toMatch(/utils\.ts:15/);
+  });
+
+  it('emits empty-marker placeholder when codeBefore/codeAfter is empty', () => {
+    const out = buildVerifierPrompt({
+      ...sampleInput,
+      codeBefore: '',
+      codeAfter: '',
+    });
+    expect(out).toMatch(/\(empty — file did not exist or was empty\)/);
+    expect(out).toMatch(/\(empty — file was deleted or emptied\)/);
+  });
+
+  it('omits the DIFF AT ANCHOR block when diffAtAnchor is undefined', () => {
+    const { diffAtAnchor, ...rest } = sampleInput;
+    const out = buildVerifierPrompt(rest);
+    expect(out).not.toMatch(/DIFF AT ANCHOR:/);
+  });
+
+  it('is pure (same input → same output)', () => {
+    expect(buildVerifierPrompt(sampleInput)).toBe(buildVerifierPrompt(sampleInput));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response parser — fail-closed on every malformed path
+// ---------------------------------------------------------------------------
+
+describe('parseVerifierResponse', () => {
+  it('parses a valid one-line JSON response', () => {
+    const o = parseVerifierResponse(
+      '{"verdict":"ADDRESSED","rationale":"null guard added"}',
+    );
+    expect(o.verdict).toBe('ADDRESSED');
+    expect(o.source).toBe('model');
+    expect(o.rationale).toBe('null guard added');
+  });
+
+  it('accepts each valid verdict value', () => {
+    expect(parseVerifierResponse('{"verdict":"ADDRESSED","rationale":"x"}').verdict).toBe('ADDRESSED');
+    expect(parseVerifierResponse('{"verdict":"NOT_ADDRESSED","rationale":"x"}').verdict).toBe('NOT_ADDRESSED');
+    expect(parseVerifierResponse('{"verdict":"UNCERTAIN","rationale":"x"}').verdict).toBe('UNCERTAIN');
+  });
+
+  it('strips ```json fence + parses', () => {
+    const o = parseVerifierResponse(
+      '```json\n{"verdict":"ADDRESSED","rationale":"fixed"}\n```',
+    );
+    expect(o.verdict).toBe('ADDRESSED');
+    expect(o.source).toBe('model');
+  });
+
+  it('strips bare ``` fence', () => {
+    const o = parseVerifierResponse('```\n{"verdict":"UNCERTAIN","rationale":"narrow"}\n```');
+    expect(o.verdict).toBe('UNCERTAIN');
+    expect(o.source).toBe('model');
+  });
+
+  it('tolerates leading/trailing whitespace', () => {
+    const o = parseVerifierResponse(
+      '   {"verdict":"ADDRESSED","rationale":"fixed"}\n\n   ',
+    );
+    expect(o.verdict).toBe('ADDRESSED');
+  });
+
+  it('tolerates extra fields (forward compat)', () => {
+    const o = parseVerifierResponse(
+      '{"verdict":"ADDRESSED","rationale":"fixed","unexpectedField":42}',
+    );
+    expect(o.verdict).toBe('ADDRESSED');
+    expect(o.source).toBe('model');
+  });
+
+  it('routes empty input → UNCERTAIN+api-error (fail-closed)', () => {
+    const o = parseVerifierResponse('');
+    expect(o.verdict).toBe('UNCERTAIN');
+    expect(o.source).toBe('api-error');
+    expect(o.rationale).toMatch(/empty/);
+  });
+
+  it('routes non-string input → UNCERTAIN+api-error', () => {
+    expect(parseVerifierResponse(null).verdict).toBe('UNCERTAIN');
+    expect(parseVerifierResponse(undefined).verdict).toBe('UNCERTAIN');
+    expect(parseVerifierResponse(42).verdict).toBe('UNCERTAIN');
+    expect(parseVerifierResponse({}).source).toBe('api-error');
+  });
+
+  it('routes malformed JSON → UNCERTAIN+api-error', () => {
+    const o = parseVerifierResponse('not valid json {{{');
+    expect(o.verdict).toBe('UNCERTAIN');
+    expect(o.source).toBe('api-error');
+    expect(o.rationale).toMatch(/JSON/);
+  });
+
+  it('routes JSON array (not object) → UNCERTAIN+api-error', () => {
+    const o = parseVerifierResponse('["ADDRESSED"]');
+    expect(o.verdict).toBe('UNCERTAIN');
+    expect(o.source).toBe('api-error');
+  });
+
+  it('routes unknown verdict value → UNCERTAIN+api-error', () => {
+    const o = parseVerifierResponse('{"verdict":"BLEH","rationale":"x"}');
+    expect(o.verdict).toBe('UNCERTAIN');
+    expect(o.source).toBe('api-error');
+    expect(o.rationale).toMatch(/unknown verdict/);
+  });
+
+  it('routes missing rationale → UNCERTAIN+api-error', () => {
+    const o = parseVerifierResponse('{"verdict":"ADDRESSED"}');
+    expect(o.verdict).toBe('UNCERTAIN');
+    expect(o.source).toBe('api-error');
+    expect(o.rationale).toMatch(/missing rationale/);
+  });
+
+  it('routes empty rationale → UNCERTAIN+api-error', () => {
+    const o = parseVerifierResponse('{"verdict":"ADDRESSED","rationale":"   "}');
+    expect(o.verdict).toBe('UNCERTAIN');
+    expect(o.source).toBe('api-error');
+  });
+
+  it('caps rationale at 500 chars', () => {
+    const long = 'x'.repeat(700);
+    const o = parseVerifierResponse(`{"verdict":"ADDRESSED","rationale":"${long}"}`);
+    expect(o.rationale.length).toBe(500);
+    expect(o.source).toBe('model');
+  });
+});

--- a/test/inline-threads.test.js
+++ b/test/inline-threads.test.js
@@ -12,10 +12,12 @@ import {
   extractAnchorContext,
   renderThreadBody,
   extractFindingIdFromBody,
+  parseThreadBody,
   planInlineThreads,
   REVIEW_THREADS_QUERY,
   REVIEW_THREADS_STATE_QUERY,
   RESOLVE_THREAD_MUTATION,
+  ADD_REPLY_MUTATION,
 } from '../src/core/inline-threads.js';
 import {
   findingId as barrelFindingId,
@@ -429,5 +431,66 @@ describe('GraphQL operation strings', () => {
     expect(RESOLVE_THREAD_MUTATION).toMatch(/mutation ResolveThread/);
     expect(RESOLVE_THREAD_MUTATION).toMatch(/resolveReviewThread/);
     expect(RESOLVE_THREAD_MUTATION).toMatch(/\$threadId: ID!/);
+  });
+
+  it('ADD_REPLY_MUTATION calls addPullRequestReviewThreadReply (Wave 5b)', () => {
+    expect(ADD_REPLY_MUTATION).toMatch(/mutation AddThreadReply/);
+    expect(ADD_REPLY_MUTATION).toMatch(/addPullRequestReviewThreadReply/);
+    expect(ADD_REPLY_MUTATION).toMatch(/\$threadId: ID!/);
+    expect(ADD_REPLY_MUTATION).toMatch(/\$body: String!/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseThreadBody — invert renderThreadBody for Wave 5b auto-resolve
+// ---------------------------------------------------------------------------
+
+describe('parseThreadBody — Wave 5b inverse of renderThreadBody', () => {
+  const finding = {
+    severity: 'critical',
+    skill: 'critical-issues-only',
+    file: 'lib/utils.ts',
+    line: 15,
+    summary: 'NPE risk on null user',
+    reasoning: 'getUser() can return null when the cache misses.',
+  };
+
+  it('roundtrips the canonical body shape', () => {
+    const body = renderThreadBody(finding);
+    const parsed = parseThreadBody(body);
+    expect(parsed).not.toBeNull();
+    expect(parsed.findingId).toBe(findingId(finding));
+    expect(parsed.severity).toBe('critical');
+    expect(parsed.skill).toBe('critical-issues-only');
+    expect(parsed.summary).toBe('NPE risk on null user');
+    expect(parsed.reasoning).toMatch(/getUser\(\)/);
+  });
+
+  it('roundtrips minor severity', () => {
+    const minor = { ...finding, severity: 'minor' };
+    const parsed = parseThreadBody(renderThreadBody(minor));
+    expect(parsed.severity).toBe('minor');
+  });
+
+  it('omits reasoning when source finding had none', () => {
+    const noReasoning = { ...finding, reasoning: undefined };
+    const parsed = parseThreadBody(renderThreadBody(noReasoning));
+    expect(parsed.reasoning).toBeUndefined();
+  });
+
+  it('returns null on a body that lacks the marker (regular human comment)', () => {
+    expect(parseThreadBody('Hello, I have a question about this.')).toBeNull();
+  });
+
+  it('returns null on a body where the marker is mid-body (anti-injection)', () => {
+    const body =
+      '> The original finding id was <!-- finding-id: deadbeefdeadbeef -->\n\nI disagree.';
+    expect(parseThreadBody(body)).toBeNull();
+  });
+
+  it('returns null on a body that has the marker but malformed structure (no badge line)', () => {
+    expect(
+      parseThreadBody('<!-- finding-id: deadbeefdeadbeef -->\nWrong format'),
+    ).toBeNull();
   });
 });

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -60,7 +60,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // Workflow refreshed
     const wf = await readFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'utf8');
     assert.match(wf, /allowedTools/);
-    assert.match(wf, /^# clud-bug-template-version: v13/);
+    assert.match(wf, /^# clud-bug-template-version: v14/);
     // Baseline rewritten with current shipped content
     const baseline = await readFile(join(dir, '.claude/skills/critical-issues-only/SKILL.md'), 'utf8');
     assert.match(baseline, /critical-issues-only/);
@@ -75,7 +75,7 @@ test('runUpdate: rewrites stale-marker workflow + baseline; leaves custom skills
     // The refreshed workflow records a from/to version note.
     const wfChange = r.changed.find((c) => c.label === 'review workflow');
     assert.equal(wfChange.from, 'v0');
-    assert.equal(wfChange.to, 'v13');
+    assert.equal(wfChange.to, 'v14');
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
## Summary

OSS parity push, part 2 of 2 (builds on Wave 5a rc.7 inline threads). On fix-push events, the workflow asks the Anthropic Messages API per bot-authored unresolved inline thread whether the new commit addressed the original finding. ADDRESSED threads get auto-resolved (with a marker reply explaining the verdict); UNCERTAIN/NOT_ADDRESSED stay open (critical UNCERTAIN escalates).

## What ships

- **`src/core/auto-resolve.ts`** (~340 LOC pure logic): types (`AutoResolveConfig`, `PriorThread`, `ThreadAction`, etc.), `resolveAutoResolveConfig` + `readAutoResolveConfigFromCludBug`, `applyResolutionRules` (pure rule table), `renderAutoResolveMarker`, `runAutoResolve` (pure orchestration with injected verifier callback). Ported from `clud-bug-app/lib/auto-resolve.ts` with App-only bits dropped: no `aggregateMultiPassVerdicts` (OSS is single-pass), no heuristic fallback (mode is verified | off only — keeps the OSS surface narrow), no per-PR budget gate (customer's own ANTHROPIC_API_KEY).
- **`src/core/resolve-verifier.ts`** (~180 LOC pure): `VERIFIER_SYSTEM` (anti-injection module-scope prompt), `buildVerifierPrompt` (pure builder), `parseVerifierResponse` (fail-closed JSON extractor). Ported from `clud-bug-app/lib/resolve-verifier.ts` with no `ai` SDK / zod deps — manual JSON validation.
- **`src/core/inline-threads.ts` extension** (~60 LOC): `parseThreadBody` inverts `renderThreadBody` (start-anchored to match the Wave 5a anti-injection posture); `ADD_REPLY_MUTATION` GraphQL constant.
- **`src/cli/main.ts` — new `runResolveThreads` verb** (~300 LOC): env-driven IO (no `--stdin`). Fetches threads + diff via `gh api graphql` + `gh api`, calls Anthropic Messages API via raw `fetch()` (no SDK dep), invokes `runAutoResolve` (pure), executes actions (ADD_REPLY then RESOLVE for ADDRESSED; ADD_REPLY only for keep_open variants). Fail-closed throughout; emits JSON status report on stdout.
- **Workflow templates** (all 3 variants): new "Auto-resolve fixed threads" post-step gated on `github.event.action == 'synchronize'`, inserted after "Post inline review threads". `continue-on-error: true`. Template-version header v13 → v14 lockstep (lesson from Wave 5a reviewer finding #2).
- **Version pins**: `package.json` 0.7.0-rc.7 → 0.7.0-rc.8; `strict-mode-gate@v0.7.0-rc.7` → `@v0.7.0-rc.8` across all templates + action.yml docstring.
- **Tests**: 62 new (28 auto-resolve + 24 verifier + 7 parseThreadBody/ADD_REPLY + 3 CLI no-op paths). 649 → 711 total, all green. v13 → v14 bump in `test/update.test.js`.

## Design highlights

- **Stateless via marker re-derivation**: re-parses the `<!-- finding-id: ... -->` markers Wave 5a embeds in each bot-posted comment body. No Redis, no persistent state — GitHub's `reviewThreads` GraphQL + the marker is the source of truth.
- **No new runtime deps**: Anthropic Messages API called via raw `fetch()` (Node 20+ native). `zod` stays the only runtime dep.
- **Fail-closed everywhere**: verifier API errors → UNCERTAIN+api-error (never silently dismiss). Missing env vars → no-op JSON + exit 0. Malformed JSON response → UNCERTAIN+api-error.
- **Cost shape**: ~$0.005/thread/fix-push × N threads (customer's own `ANTHROPIC_API_KEY`). Hardcoded to `claude-sonnet-4-6`; override via `CLUD_BUG_VERIFIER_MODEL` env var.

## Test plan

- [x] `npm run build` clean (TypeScript strict + exactOptionalPropertyTypes)
- [x] `npm test` → 711/711 passing (was 649; +62 new)
- [ ] Bot review (clud-bug-review paused per Phase 5.3 — local feature-dev:code-reviewer stands in)
- [ ] Smoke verify on `clud-bug-test` AFTER tag + publish (task #263) — fix one of the Wave 5a smoke-PR findings, confirm only that thread's `isResolved` flips

## Out of scope

- App-side migration to consume `clud-bug/core/auto-resolve.ts` (optional Wave 5c)
- Heuristic-mode fallback (`mode: 'heuristic'` in App config) — OSS supports `verified | off` only
- D.2.5 multi-pass + D.2.7 auto-fix push — explicitly App-only premium

🤖 Generated with [Claude Code](https://claude.com/claude-code)