### PR TITLE
Wave 5b.1: rc.9 graceful PAT-or-fallback resolve + idempotent markers

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.8
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.9
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.7.0-rc.9] — 2026-06-28
+
+Graceful PAT-or-fallback auto-resolve (Wave 5b.1). The `resolveReviewThread`
+GraphQL mutation can't run under the Actions `GITHUB_TOKEN` ("Resource not
+accessible by integration"); rc.9 makes that path graceful and adds an opt-in
+PAT for true auto-close.
+
+### Added
+
+- **`CLUD_BUG_RESOLVE_PAT` secret (optional)** — workflow templates pass it to
+  the `resolve-threads` step. Present → the step closes verified threads like the
+  hosted App; absent → graceful "verified fixed" reply only. The CLI reads
+  `CLUD_BUG_RESOLVE_PAT` (alias `RESOLVE_PAT`) and scopes it to just the resolve
+  mutation; all other `gh` calls keep `GH_TOKEN`.
+- **`selectResolveAuth` / `anchorSignature` / `renderResolveMarkerTag` /
+  `parseResolveMarkerTag` / `latestResolveMarker`** pure helpers in
+  `src/core/auto-resolve.ts` (unit-tested).
+
+### Changed
+
+- **`src/cli/main.ts::runResolveThreads`** — the no-PAT path posts an accurate
+  "✅ Verified fixed — not auto-closed" reply (instead of claiming
+  "Auto-resolved") and skips the resolve mutation; the PAT path resolves with the
+  PAT scoped to that one call.
+- **Idempotency** — each auto-resolve reply carries a hidden
+  `<!-- clud-bug-resolve v=… sig=… -->` marker. On later fix-pushes a thread whose
+  anchor is unchanged is skipped (no re-verify, no re-reply), so multi-push PRs
+  don't get repeat replies and verifier spend is saved. A cached ADDRESSED thread
+  is still resolved if a PAT becomes available (no-PAT→PAT upgrade, or a prior
+  transient resolve-failure) without re-posting. `REVIEW_THREADS_QUERY` now fetches
+  `comments(first: 100)` to see prior replies; the anchor signature is 16 hex chars
+  (matching `findingId`).
+
+### Why
+
+Wave 5b smoke confirmed the verifier core works but `resolveReviewThread` is
+blocked for the Actions token. PAT-optional + always-graceful keeps the default
+install zero-config and regression-free while giving power users full auto-close.
+
 ## [0.7.0-rc.5] — 2026-06-26
 
 Build-time version bake — eliminates the runtime `readFileSync(package.json)`

--- a/README.md
+++ b/README.md
@@ -257,6 +257,26 @@ Every Clud Bug review opens with a status line that tells you exactly what chang
 
 Same format every time; zero values are always present so the line is easy to scan and parse.
 
+### Auto-resolving review threads (optional PAT)
+
+When you push a fix, Clud Bug re-checks each open review thread and, if it verifies the fix
+landed, posts a **✅ Verified fixed** reply on that thread.
+
+**Closing the thread automatically is optional.** GitHub doesn't let the built-in Actions
+`GITHUB_TOKEN` resolve review threads, so by default Clud Bug posts the "verified fixed"
+reply and you click **Resolve conversation** to dismiss it — no errors, nothing fails.
+
+To have Clud Bug close verified threads for you (matching the hosted App):
+
+1. Create a **fine-grained personal access token** scoped to this repo with **Pull
+   requests: write**.
+2. Add it as a repository secret named **`CLUD_BUG_RESOLVE_PAT`** (Settings → Secrets and
+   variables → Actions → New repository secret).
+
+The next fix-push then auto-closes verified threads. Without the secret everything still
+works; threads just wait for a manual Resolve. The reply is idempotent — re-pushes that
+don't change the code won't re-post, so the thread never gets spammed.
+
 ## Manual install (advanced)
 
 If you don't want to use the CLI, you can install a generic workflow by hand:

--- a/docs/decisions-branches/wave-5b1-rc9-graceful-resolve.md
+++ b/docs/decisions-branches/wave-5b1-rc9-graceful-resolve.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-28 00:41 - clud-bug rc.9: graceful PAT-or-fallback auto-resolve + idempotent markers
+
+**Reasoning:** GitHub's Actions GITHUB_TOKEN can't run resolveReviewThread; rc.9 makes the npm workflow graceful (posts a 'verified fixed' reply with no error when no PAT) and adds an opt-in CLUD_BUG_RESOLVE_PAT secret for real auto-close. Each reply carries a hidden verdict+anchor-sig marker so repeat fix-pushes don't re-reply and skip redundant verifier calls.
+
+**Alternatives considered:** Editing the original finding comment to badge it (rejected: needs de-anchoring the finding-id re-match regexes; deferred to a fast-follow). Literal-parity with no dedup (CEO chose the idempotency guard instead).
+
+**Implications:**
+- Cached ADDRESSED threads now resolve when a PAT becomes available (adversarial-review fix). Anchor sig widened to 16 hex (findingId parity). Tag + npm publish of rc.9 is a USER ACTION; PAT-path + cached-resolve verified via clud-bug-test smoke only.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (49 decisions)
+## 2026-06 (50 decisions)
 
-- **2026-06-27** — Wave 5b — D.2.6 auto-resolve on fix-push in npm workflow (rc.8) *(wave-5b-auto-resolve)* — [decisions-branches/wave-5b-auto-resolve.md](decisions-branches/wave-5b-auto-resolve.md)
-- *... 47 more decisions ...*
+- **2026-06-28** — clud-bug rc.9: graceful PAT-or-fallback auto-resolve + idempotent markers *(wave-5b1-rc9-graceful-resolve)* — [decisions-branches/wave-5b1-rc9-graceful-resolve.md](decisions-branches/wave-5b1-rc9-graceful-resolve.md)
+- *... 48 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.8",
+  "version": "0.7.0-rc.9",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -744,6 +744,11 @@ async function runResolveThreads(_args) {
   const {
     readAutoResolveConfigFromCludBug,
     runAutoResolve,
+    applyResolutionRules,
+    selectResolveAuth,
+    renderResolveMarkerTag,
+    anchorSignature,
+    latestResolveMarker,
   } = await import('../core/auto-resolve.js');
   const {
     VERIFIER_SYSTEM,
@@ -848,6 +853,9 @@ async function runResolveThreads(_args) {
       file: c.path,
       line: c.line ?? c.originalLine,
       parsed,
+      // Wave 5b.1: full comment list so idempotency can spot a prior
+      // bot reply's resolve marker (verdict + anchor sig) on this thread.
+      comments: t.comments?.nodes ?? [],
     });
   }
 
@@ -952,19 +960,96 @@ async function runResolveThreads(_args) {
     }
   }
 
-  // ---- Run pure orchestration -------------------------------------------
+  // ---- Resolve auth (Wave 5b.1: PAT optional + graceful fallback) -------
+  // A dedicated PAT lets us actually close threads; without one the Actions
+  // GITHUB_TOKEN can't resolve, so we post a "verified fixed" reply only.
+  const auth = selectResolveAuth(process.env);
+
+  // ---- Idempotency: skip threads whose anchor is unchanged --------------
+  // For each candidate, hash the post-fix anchor and look for a prior bot
+  // reply carrying the same (verdict, sig) marker. If the anchor hasn't moved
+  // since that marker, we re-use the cached verdict — NO verifier call, NO
+  // re-post — which kills repeat replies on multi-push PRs and saves spend.
+  const verifyItems = []; // { thread, sig } — need (re)verification
+  const cachedItems = []; // { thread, action } — anchor unchanged, no I/O
+  for (let i = 0; i < priorThreads.length; i++) {
+    const thread = priorThreads[i];
+    const candidate = candidates[i];
+    if (!thread) continue;
+    const sig = anchorSignature(thread.finding, thread.codeAfter);
+    const prior = latestResolveMarker(candidate?.comments ?? [], BOT_AUTHORS);
+    if (prior && prior.sig === sig) {
+      const action = applyResolutionRules({
+        thread,
+        verdict: {
+          verdict: prior.verdict,
+          source: 'model',
+          rationale: '(unchanged since last check)',
+        },
+        config: autoResolveConfig,
+        canResolve: auth.hasDedicatedPat,
+      });
+      cachedItems.push({ thread, action });
+    } else {
+      verifyItems.push({ thread, sig });
+    }
+  }
+
+  // ---- Run pure orchestration on the threads that need (re)verification --
   const result = await runAutoResolve({
-    priorThreads,
+    priorThreads: verifyItems.map((v) => v.thread),
     config: autoResolveConfig,
     verifier,
+    canResolve: auth.hasDedicatedPat,
   });
+
+  let shouldRequestChanges = result.shouldRequestChanges;
+  for (const c of cachedItems) {
+    if (c.action.kind === 'keep_open_request_changes') shouldRequestChanges = true;
+  }
 
   // ---- Execute the actions via GraphQL mutations ------------------------
   const actionsReport = [];
+
+  // Unchanged threads: never re-post the reply (idempotent). BUT if the
+  // thread is verified ADDRESSED and a PAT is now available, resolve it —
+  // the marker reply already exists, so this closes a thread that couldn't
+  // be resolved before (no-PAT → PAT upgrade, or a prior transient
+  // resolve-failure) WITHOUT re-verifying or re-replying.
+  for (const c of cachedItems) {
+    const baseReport = {
+      threadId: c.thread.threadId,
+      file: c.thread.finding.file,
+      line: c.thread.finding.line,
+      verdict: c.action.verdict?.verdict,
+      kind: c.action.kind,
+    };
+    if (c.action.kind === 'resolve' && auth.hasDedicatedPat) {
+      const resolveResult = spawnSync(
+        'gh',
+        [
+          'api', 'graphql',
+          '-f', `query=${RESOLVE_THREAD_MUTATION}`,
+          '-f', `threadId=${c.thread.threadId}`,
+        ],
+        { encoding: 'utf8', env: { ...process.env, GH_TOKEN: auth.token } },
+      );
+      if (resolveResult.status !== 0) {
+        process.stderr.write(`clud-bug resolve-threads: RESOLVE (cached) failed for thread ${c.thread.threadId}: ${(resolveResult.stderr || '').slice(0, 200)}\n`);
+        actionsReport.push({ ...baseReport, executed: 'resolve-failed' });
+      } else {
+        actionsReport.push({ ...baseReport, executed: 'resolved-from-cache' });
+      }
+    } else {
+      actionsReport.push({ ...baseReport, executed: 'unchanged' });
+    }
+  }
+
   for (let i = 0; i < result.actions.length; i++) {
     const action = result.actions[i];
-    const thread = priorThreads[i];
-    if (!action || !thread) continue;
+    const item = verifyItems[i];
+    if (!action || !item) continue;
+    const thread = item.thread;
     const report = {
       threadId: thread.threadId,
       file: thread.finding.file,
@@ -978,14 +1063,17 @@ async function runResolveThreads(_args) {
       continue;
     }
 
-    // Post the marker reply (all non-skipped paths get a reply).
+    // Reply body carries a hidden idempotency marker (verdict + anchor sig)
+    // so a later fix-push won't re-reply while the anchor is unchanged.
+    const tag = renderResolveMarkerTag(action.verdict.verdict, item.sig);
+    const replyBody = `${action.markerBody}\n\n${tag}`;
     const replyResult = spawnSync(
       'gh',
       [
         'api', 'graphql',
         '-f', `query=${ADD_REPLY_MUTATION}`,
         '-f', `threadId=${thread.threadId}`,
-        '-f', `body=${action.markerBody}`,
+        '-f', `body=${replyBody}`,
       ],
       { encoding: 'utf8' },
     );
@@ -995,8 +1083,14 @@ async function runResolveThreads(_args) {
       continue;
     }
 
-    // Resolve only ADDRESSED threads.
+    // Resolve only ADDRESSED threads, and only with a dedicated PAT — the
+    // Actions GITHUB_TOKEN can't resolve ("Resource not accessible by
+    // integration"). No PAT → marker-reply-only (graceful, no error).
     if (action.kind === 'resolve') {
+      if (!auth.hasDedicatedPat) {
+        actionsReport.push({ ...report, executed: 'reply-only-no-pat' });
+        continue;
+      }
       const resolveResult = spawnSync(
         'gh',
         [
@@ -1004,7 +1098,8 @@ async function runResolveThreads(_args) {
           '-f', `query=${RESOLVE_THREAD_MUTATION}`,
           '-f', `threadId=${thread.threadId}`,
         ],
-        { encoding: 'utf8' },
+        // Scope the PAT to JUST this call; all other gh calls keep GH_TOKEN.
+        { encoding: 'utf8', env: { ...process.env, GH_TOKEN: auth.token } },
       );
       if (resolveResult.status !== 0) {
         process.stderr.write(`clud-bug resolve-threads: RESOLVE failed for thread ${thread.threadId}: ${(resolveResult.stderr || '').slice(0, 200)}\n`);
@@ -1021,7 +1116,8 @@ async function runResolveThreads(_args) {
   process.stdout.write(JSON.stringify({
     actions: actionsReport,
     verifierCallCount: result.verifierCallCount,
-    shouldRequestChanges: result.shouldRequestChanges,
+    shouldRequestChanges,
+    resolveTokenSource: auth.source,
   }) + '\n');
 }
 

--- a/src/core/auto-resolve.ts
+++ b/src/core/auto-resolve.ts
@@ -27,6 +27,8 @@
 //   - DROP per-PR budget gate — OSS workflow uses the customer's own
 //     `ANTHROPIC_API_KEY`; spend-cap is their concern, not ours.
 
+import { createHash } from 'node:crypto';
+
 import type { Severity } from './inline-threads.js';
 
 // ---------------------------------------------------------------------------
@@ -120,6 +122,13 @@ export interface AutoResolveInput {
   priorThreads: PriorThread[];
   /** Resolved config (after precedence merge). */
   config: AutoResolveConfig;
+  /**
+   * Whether the caller can actually resolve threads (a dedicated PAT is
+   * present). Drives the addressed-marker wording: PAT → "Auto-resolved";
+   * no-PAT → "Verified fixed — not auto-closed". Defaults to true (the App
+   * path / unit tests, where the App token can resolve).
+   */
+  canResolve?: boolean;
   /** Verifier callback. Tests inject a stub; CLI provides real Anthropic-call fn. */
   verifier: (args: {
     finding: PriorFinding;
@@ -256,6 +265,7 @@ export async function runAutoResolve(
       thread,
       verdict,
       config: input.config,
+      canResolve: input.canResolve !== false,
     });
     actions.push(action);
     if (action.kind === 'keep_open_request_changes') shouldRequestChanges = true;
@@ -284,8 +294,11 @@ export function applyResolutionRules(args: {
   thread: PriorThread;
   verdict: VerifyOutcome;
   config: AutoResolveConfig;
+  /** Whether the resolve mutation is available (PAT present). Defaults true. */
+  canResolve?: boolean;
 }): ThreadAction {
   const { verdict, thread, config } = args;
+  const canResolve = args.canResolve !== false;
   const severity = thread.finding.severity;
 
   if (verdict.verdict === 'ADDRESSED') {
@@ -294,6 +307,7 @@ export function applyResolutionRules(args: {
       markerBody: renderAutoResolveMarker({
         kind: 'verified-addressed',
         rationale: verdict.rationale,
+        resolved: canResolve,
       }),
       verdict,
     };
@@ -340,7 +354,7 @@ export function applyResolutionRules(args: {
 // ---------------------------------------------------------------------------
 
 type AutoResolveMarkerInput =
-  | { kind: 'verified-addressed'; rationale?: string }
+  | { kind: 'verified-addressed'; rationale?: string; resolved?: boolean }
   | { kind: 'verified-not-addressed'; rationale?: string }
   | { kind: 'verified-uncertain'; rationale?: string; severity: Severity };
 
@@ -354,6 +368,16 @@ export function renderAutoResolveMarker(input: AutoResolveMarkerInput): string {
   const tail = input.rationale ? `: ${input.rationale.trim()}` : '.';
   switch (input.kind) {
     case 'verified-addressed':
+      // No PAT → we did NOT resolve the thread, so don't claim "Auto-resolved".
+      // Post an accurate "verified fixed" badge + the manual-Resolve hint.
+      if (input.resolved === false) {
+        return (
+          `**✅ Verified fixed — not auto-closed**${tail} ` +
+          `_The Actions \`GITHUB_TOKEN\` can't resolve review threads; click ` +
+          `**Resolve conversation** to dismiss, or add a \`CLUD_BUG_RESOLVE_PAT\` ` +
+          `secret to auto-close (see README)._`
+        );
+      }
       return `**✓ Auto-resolved (verified by D.2.6 fix-check)**${tail}`;
     case 'verified-not-addressed':
       return `**❌ Re-review found this still applies**${tail}`;
@@ -363,4 +387,102 @@ export function renderAutoResolveMarker(input: AutoResolveMarkerInput): string {
       }
       return `**⚠ Auto-resolve uncertain — human review recommended**${tail}`;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Wave 5b.1 (rc.9) — graceful PAT-or-fallback resolve + idempotency
+// ---------------------------------------------------------------------------
+
+/** Which token the resolve mutation should use, and whether it's a dedicated PAT. */
+export interface ResolveAuth {
+  token: string;
+  source: 'pat' | 'gh_token';
+  hasDedicatedPat: boolean;
+}
+
+/**
+ * Picks the token for the `resolveReviewThread` GraphQL mutation. A dedicated
+ * fine-grained PAT (`CLUD_BUG_RESOLVE_PAT`, or the `RESOLVE_PAT` alias) is
+ * preferred — the Actions `GITHUB_TOKEN` can't resolve review threads
+ * ("Resource not accessible by integration"). With no PAT the verb keeps using
+ * `GH_TOKEN` for the other gh calls and skips the resolve mutation entirely.
+ *
+ * Empty / whitespace-only values are treated as absent — GitHub renders an
+ * unset secret as the empty string, so `CLUD_BUG_RESOLVE_PAT=''` must NOT
+ * shadow a hand-set `RESOLVE_PAT` alias.
+ */
+export function selectResolveAuth(env: {
+  CLUD_BUG_RESOLVE_PAT?: string;
+  RESOLVE_PAT?: string;
+  GH_TOKEN?: string;
+}): ResolveAuth {
+  const pat =
+    [env.CLUD_BUG_RESOLVE_PAT, env.RESOLVE_PAT]
+      .map((v) => (v ?? '').trim())
+      .find((v) => v !== '') ?? '';
+  if (pat) return { token: pat, source: 'pat', hasDedicatedPat: true };
+  return { token: (env.GH_TOKEN ?? '').trim(), source: 'gh_token', hasDedicatedPat: false };
+}
+
+/** Verifier verdict, as embedded in the idempotency marker. */
+export type ResolveVerdict = 'ADDRESSED' | 'NOT_ADDRESSED' | 'UNCERTAIN';
+
+const RESOLVE_MARKER_RE =
+  /<!--\s*clud-bug-resolve\s+v=(ADDRESSED|NOT_ADDRESSED|UNCERTAIN)\s+sig=([a-f0-9]{16})\s*-->/;
+
+/**
+ * Hidden HTML-comment marker appended to each auto-resolve reply so a later
+ * fix-push can tell whether it already replied to this thread for the current
+ * (verdict, anchor) — making the reply idempotent instead of one-per-push.
+ */
+export function renderResolveMarkerTag(verdict: ResolveVerdict, sig: string): string {
+  return `<!-- clud-bug-resolve v=${verdict} sig=${sig} -->`;
+}
+
+/** Parses the hidden marker out of a comment body. Null when absent / malformed. */
+export function parseResolveMarkerTag(
+  body: string,
+): { verdict: ResolveVerdict; sig: string } | null {
+  const m = body.match(RESOLVE_MARKER_RE);
+  if (!m || m[1] === undefined || m[2] === undefined) return null;
+  return { verdict: m[1] as ResolveVerdict, sig: m[2] };
+}
+
+/**
+ * 8-hex-char signature of a finding's post-fix anchor. Stable while the anchor
+ * is unchanged, changes when `codeAfter` changes — lets the verb skip
+ * re-verifying + re-replying to a thread whose anchor hasn't moved.
+ */
+export function anchorSignature(
+  finding: { file?: string; line?: number },
+  codeAfter: string,
+): string {
+  const file = finding.file ?? '<no-file>';
+  const line = finding.line ?? 0;
+  // 16 hex chars (64-bit), matching `findingId`'s convention — wide enough
+  // that a collision can't suppress a re-review marker.
+  return createHash('sha256').update(`${file}:${line}:${codeAfter}`).digest('hex').slice(0, 16);
+}
+
+/**
+ * Scans a thread's comments (oldest→newest, as GraphQL returns them) for the
+ * most-recent bot-authored reply carrying a resolve marker. Returns its
+ * `{verdict, sig}` or null. Only bot-authored comments count, so a user pasting
+ * a marker can't spoof the idempotency state.
+ */
+export function latestResolveMarker(
+  comments: Array<
+    { author?: { login?: string | null } | null; body?: string | null } | null | undefined
+  >,
+  botAuthors: Set<string>,
+): { verdict: ResolveVerdict; sig: string } | null {
+  let latest: { verdict: ResolveVerdict; sig: string } | null = null;
+  for (const c of comments) {
+    if (!c) continue;
+    const login = c.author?.login ?? '';
+    if (!botAuthors.has(login)) continue;
+    const tag = parseResolveMarkerTag(c.body ?? '');
+    if (tag) latest = tag;
+  }
+  return latest;
 }

--- a/src/core/inline-threads.ts
+++ b/src/core/inline-threads.ts
@@ -398,7 +398,7 @@ export const REVIEW_THREADS_QUERY = `
           nodes {
             id
             isResolved
-            comments(first: 1) {
+            comments(first: 100) {
               nodes {
                 databaseId
                 path

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -307,6 +307,11 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Optional fine-grained PAT (Pull requests: write). Present → the
+          # workflow resolves fixed threads like the hosted App. Absent (the
+          # default; an unset secret renders empty) → graceful "verified fixed"
+          # reply only, since the Actions GITHUB_TOKEN can't resolve threads.
+          CLUD_BUG_RESOLVE_PAT: ${{ secrets.CLUD_BUG_RESOLVE_PAT }}
         run: |
           set -euo pipefail
           RESULT=$(npx --yes clud-bug@{{CLUD_BUG_VERSION}} resolve-threads)
@@ -395,7 +400,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.8
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -307,6 +307,11 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Optional fine-grained PAT (Pull requests: write). Present → the
+          # workflow resolves fixed threads like the hosted App. Absent (the
+          # default; an unset secret renders empty) → graceful "verified fixed"
+          # reply only, since the Actions GITHUB_TOKEN can't resolve threads.
+          CLUD_BUG_RESOLVE_PAT: ${{ secrets.CLUD_BUG_RESOLVE_PAT }}
         run: |
           set -euo pipefail
           RESULT=$(npx --yes clud-bug@{{CLUD_BUG_VERSION}} resolve-threads)
@@ -395,7 +400,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.8
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -556,6 +556,11 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Optional fine-grained PAT (Pull requests: write). Present → the
+          # workflow resolves fixed threads like the hosted App. Absent (the
+          # default; an unset secret renders empty) → graceful "verified fixed"
+          # reply only, since the Actions GITHUB_TOKEN can't resolve threads.
+          CLUD_BUG_RESOLVE_PAT: ${{ secrets.CLUD_BUG_RESOLVE_PAT }}
         run: |
           set -euo pipefail
           RESULT=$(npx --yes clud-bug@{{CLUD_BUG_VERSION}} resolve-threads)
@@ -699,7 +704,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.8
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/core/auto-resolve.test.js
+++ b/test/core/auto-resolve.test.js
@@ -11,6 +11,11 @@ import {
   applyResolutionRules,
   renderAutoResolveMarker,
   DEFAULT_AUTO_RESOLVE_CONFIG,
+  selectResolveAuth,
+  renderResolveMarkerTag,
+  parseResolveMarkerTag,
+  anchorSignature,
+  latestResolveMarker,
 } from '../../src/core/auto-resolve.js';
 import {
   resolveAutoResolveConfig as barrelConfig,
@@ -310,5 +315,150 @@ describe('runAutoResolve', () => {
     });
     const callArg = verifier.mock.calls[0]?.[0];
     expect(callArg).not.toHaveProperty('diffAtAnchor');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wave 5b.1 (rc.9) — graceful PAT-or-fallback resolve + idempotency helpers
+// ---------------------------------------------------------------------------
+
+describe('selectResolveAuth', () => {
+  it('uses CLUD_BUG_RESOLVE_PAT when present (source pat, dedicated)', () => {
+    expect(selectResolveAuth({ CLUD_BUG_RESOLVE_PAT: 'ghp_pat', GH_TOKEN: 'gho_x' }))
+      .toEqual({ token: 'ghp_pat', source: 'pat', hasDedicatedPat: true });
+  });
+
+  it('falls back to GH_TOKEN when no PAT (source gh_token, not dedicated)', () => {
+    expect(selectResolveAuth({ GH_TOKEN: 'gho_x' }))
+      .toEqual({ token: 'gho_x', source: 'gh_token', hasDedicatedPat: false });
+  });
+
+  it('returns empty token when neither PAT nor GH_TOKEN set', () => {
+    expect(selectResolveAuth({}))
+      .toEqual({ token: '', source: 'gh_token', hasDedicatedPat: false });
+  });
+
+  it('honors the RESOLVE_PAT alias', () => {
+    expect(selectResolveAuth({ RESOLVE_PAT: 'ghp_alias', GH_TOKEN: 'gho_x' }))
+      .toEqual({ token: 'ghp_alias', source: 'pat', hasDedicatedPat: true });
+  });
+
+  it('treats a whitespace-only PAT as absent', () => {
+    expect(selectResolveAuth({ CLUD_BUG_RESOLVE_PAT: '   ', GH_TOKEN: 'gho_x' }))
+      .toEqual({ token: 'gho_x', source: 'gh_token', hasDedicatedPat: false });
+  });
+
+  it('treats an empty primary as absent and uses the alias (unset secret renders empty)', () => {
+    expect(selectResolveAuth({ CLUD_BUG_RESOLVE_PAT: '', RESOLVE_PAT: 'ghp_alias', GH_TOKEN: 'gho_x' }))
+      .toEqual({ token: 'ghp_alias', source: 'pat', hasDedicatedPat: true });
+  });
+});
+
+describe('renderAutoResolveMarker — resolved flag (no-PAT wording)', () => {
+  it('resolved:true keeps the "Auto-resolved" wording', () => {
+    const s = renderAutoResolveMarker({ kind: 'verified-addressed', rationale: 'fixed', resolved: true });
+    expect(s).toMatch(/Auto-resolved \(verified/);
+  });
+
+  it('omitted resolved defaults to "Auto-resolved" (back-compat)', () => {
+    const s = renderAutoResolveMarker({ kind: 'verified-addressed', rationale: 'fixed' });
+    expect(s).toMatch(/Auto-resolved \(verified/);
+  });
+
+  it('resolved:false uses "Verified fixed — not auto-closed" + manual-Resolve hint', () => {
+    const s = renderAutoResolveMarker({ kind: 'verified-addressed', rationale: 'fixed', resolved: false });
+    expect(s).toMatch(/Verified fixed/);
+    expect(s).toMatch(/Resolve conversation/);
+    expect(s).toMatch(/CLUD_BUG_RESOLVE_PAT/);
+    expect(s).not.toMatch(/Auto-resolved/);
+  });
+});
+
+describe('applyResolutionRules — canResolve flows to marker wording', () => {
+  it('ADDRESSED + canResolve:false → resolve kind, no-PAT wording', () => {
+    const action = applyResolutionRules({
+      thread: sampleThread('critical'),
+      verdict: { verdict: 'ADDRESSED', source: 'model', rationale: 'fixed' },
+      config: DEFAULT_AUTO_RESOLVE_CONFIG,
+      canResolve: false,
+    });
+    expect(action.kind).toBe('resolve');
+    expect(action.markerBody).toMatch(/Verified fixed/);
+    expect(action.markerBody).not.toMatch(/Auto-resolved/);
+  });
+
+  it('ADDRESSED + canResolve omitted → "Auto-resolved" wording (back-compat)', () => {
+    const action = applyResolutionRules({
+      thread: sampleThread('critical'),
+      verdict: { verdict: 'ADDRESSED', source: 'model', rationale: 'fixed' },
+      config: DEFAULT_AUTO_RESOLVE_CONFIG,
+    });
+    expect(action.markerBody).toMatch(/Auto-resolved/);
+  });
+});
+
+describe('resolve-marker tag (idempotency)', () => {
+  it('round-trips verdict + sig', () => {
+    const tag = renderResolveMarkerTag('ADDRESSED', 'a1b2c3d4e5f60718');
+    expect(parseResolveMarkerTag(tag)).toEqual({ verdict: 'ADDRESSED', sig: 'a1b2c3d4e5f60718' });
+  });
+
+  it('parses the tag out of a full reply body', () => {
+    const body = `**✓ Auto-resolved (verified)**: nice\n\n${renderResolveMarkerTag('NOT_ADDRESSED', 'deadbeefcafef00d')}`;
+    expect(parseResolveMarkerTag(body)).toEqual({ verdict: 'NOT_ADDRESSED', sig: 'deadbeefcafef00d' });
+  });
+
+  it('returns null when no tag present', () => {
+    expect(parseResolveMarkerTag('just a normal comment')).toBeNull();
+  });
+
+  it('returns null for a malformed verdict', () => {
+    expect(parseResolveMarkerTag('<!-- clud-bug-resolve v=MAYBE sig=a1b2c3d4e5f60718 -->')).toBeNull();
+  });
+});
+
+describe('anchorSignature', () => {
+  const finding = { file: 'lib/foo.ts', line: 10 };
+
+  it('is a stable 8-char hex for an identical anchor', () => {
+    const a = anchorSignature(finding, 'const x = guard(y);');
+    const b = anchorSignature(finding, 'const x = guard(y);');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it('changes when codeAfter changes', () => {
+    const a = anchorSignature(finding, 'const x = guard(y);');
+    const b = anchorSignature(finding, 'const x = y; // regressed');
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('latestResolveMarker', () => {
+  const BOT = new Set(['github-actions', 'github-actions[bot]']);
+  const finding = {
+    author: { login: 'github-actions[bot]' },
+    body: '<!-- finding-id: 0123456789abcdef -->\n🔴 `x`\n\nsummary',
+  };
+
+  it('returns the most-recent bot reply tag', () => {
+    const comments = [
+      finding,
+      { author: { login: 'github-actions[bot]' }, body: `r1 ${renderResolveMarkerTag('ADDRESSED', 'aaaaaaaaaaaaaaaa')}` },
+      { author: { login: 'github-actions[bot]' }, body: `r2 ${renderResolveMarkerTag('NOT_ADDRESSED', 'bbbbbbbbbbbbbbbb')}` },
+    ];
+    expect(latestResolveMarker(comments, BOT)).toEqual({ verdict: 'NOT_ADDRESSED', sig: 'bbbbbbbbbbbbbbbb' });
+  });
+
+  it('returns null when no tagged bot reply exists', () => {
+    expect(latestResolveMarker([finding], BOT)).toBeNull();
+  });
+
+  it('ignores tags authored by non-bot users', () => {
+    const comments = [
+      finding,
+      { author: { login: 'sneaky-user' }, body: `nope ${renderResolveMarkerTag('ADDRESSED', 'cccccccccccccccc')}` },
+    ];
+    expect(latestResolveMarker(comments, BOT)).toBeNull();
   });
 });


### PR DESCRIPTION
## Wave 5b.1 — rc.9 graceful PAT-or-fallback resolve

Wave 5b smoke surfaced that the GraphQL `resolveReviewThread` mutation fails with
`Resource not accessible by integration` under the Actions `GITHUB_TOKEN` — a known
GitHub limitation, not a code bug. This makes auto-resolve **PAT-optional + always-graceful**.

### What changed
- **No PAT (default):** the `resolve-threads` verb posts an accurate **✅ Verified fixed — not auto-closed** reply (instead of claiming "Auto-resolved") and skips the resolve mutation — no errors, the step stays green. Reviewer clicks **Resolve** to dismiss.
- **Opt-in PAT:** add a fine-grained `CLUD_BUG_RESOLVE_PAT` (Pull requests: write) repo secret → the workflow closes verified threads like the hosted App. The PAT is scoped to just the resolve `gh` call; all other calls keep `GH_TOKEN`. Templates (×3) pass the optional secret.
- **Idempotency:** each auto-resolve reply carries a hidden `<!-- clud-bug-resolve v=<verdict> sig=<16hex> -->` marker. On later fix-pushes, a thread whose anchor signature is unchanged is skipped — no re-verify, no re-reply — so multi-push PRs don't get repeat replies and redundant verifier spend is avoided. A cached ADDRESSED thread is still resolved when a PAT later becomes available.
- Accurate wording (`resolved` flag on `renderAutoResolveMarker`), plus `selectResolveAuth`, `anchorSignature`, marker render/parse, and `latestResolveMarker` — all pure + unit-tested.

### Tests & verification
- 17 new unit tests; **731/731 green**; `tsc` clean; fixtures clean; templates render + **actionlint clean**.
- Reviewed by a 5-lens adversarial agent pass (correctness / gh-integration / security / regression / edge), each finding refute-verified. One real bug found + fixed (cached threads now resolve when a PAT becomes available); one security finding correctly refuted (sig still widened to 16-hex for `findingId` parity).
- **No SPEC change** — PAT is an implementation detail.

### USER ACTION (after merge)
- Tag `v0.7.0-rc.9` → `npm-publish.yml` publishes to `next` (OIDC).
- (Optional) add `CLUD_BUG_RESOLVE_PAT` on clud-bug-test for the PAT-path + cached-resolve smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
