### PR TITLE
Wave 6a: §6.6 conformance-fixture gate + §3.23.1 configure-github payload (rc.10)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.9
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.10
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
+      # SPEC §6.6 conformance fixtures (byte-identical release-gate). Runs
+      # after build so scripts/fixture-check.mjs can import from dist/.
+      - run: npm run test:fixtures
 
   actionlint:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.7.0-rc.10] — 2026-06-28
+
+Wave 6a — SPEC v0.5.1 conformance closure.
+
+### Added
+
+- **§6.6 conformance-fixture gate** — `fixtures/reviews/<scenario>/{input.json,
+  expected.md}` for 5 canonical scenarios (clean, critical-only, mixed-severities,
+  resolved-from-prior, dedicated-section). `scripts/fixture-check.mjs` renders each
+  `input.json` through `renderReview` and asserts byte-identity with the committed
+  golden (`--update` regenerates). Wired into CI as `npm run test:fixtures`, so a
+  renderer change that alters the comment shape now fails the build until the
+  goldens are reviewed + regenerated.
+
+### Changed
+
+- **§3.23.1 `configure-github` status payload** — the idempotent no-op now prints
+  `alreadyCanonical: true rulesetVersion: v1` as named fields (was embedded prose),
+  satisfying the NORMATIVE §3.23.1 contract. New `--json` flag emits the payload as
+  JSON for machine consumption across all outcomes.
+
 ## [0.7.0-rc.9] — 2026-06-28
 
 Graceful PAT-or-fallback auto-resolve (Wave 5b.1). The `resolveReviewThread`

--- a/docs/decisions-branches/wave-6a-fixtures-conformance.md
+++ b/docs/decisions-branches/wave-6a-fixtures-conformance.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-28 01:12 - clud-bug rc.10 (Wave 6a): §6.6 conformance-fixture gate + §3.23.1 configure-github payload
+
+**Reasoning:** Closes two NORMATIVE SPEC v0.5.1 gaps. §6.6: 5 review fixtures + scripts/fixture-check.mjs renders renderReview byte-identical against committed goldens, wired as a CI gate so a comment-shape change fails the build until goldens are reviewed. §3.23.1: the idempotent configure-github no-op now emits alreadyCanonical + rulesetVersion as named fields (+ --json) for machine consumers.
+
+**Alternatives considered:** Vendoring the canonical fixtures in protocol/fixtures/reviews per the SPEC location (deferred — the clud-bug gate is the substance; the protocol copy is a byte-identical follow-up). Hand-writing expected.md (rejected — goldens are generated via --update to guarantee byte-identity).
+
+**Implications:**
+- fixture-check.mjs imports from dist/, so CI must build first (it does). configure-github --dry-run --json now reports dryRun:true even on an already-canonical repo (adversarial-review fix). §6.8.3 per-pass cost comment (clud-bug-app) + the protocol canonical-fixtures copy remain as 6a follow-ups.
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -27,6 +27,8 @@ clud-bug
 │   ├── decisions.md
 │   ├── file-structure.md
 │   └── timeline.md
+├── fixtures
+│   └── reviews
 ├── scripts
 │   ├── fixture-check.mjs
 │   └── gen-version.mjs
@@ -56,6 +58,7 @@ clud-bug
 │   ├── audit.test.js
 │   ├── branch-protection.test.js
 │   ├── cli.test.js
+│   ├── configure-github.test.js
 │   ├── detect.test.js
 │   ├── diff-findings.test.js
 │   ├── edit-workflow.test.js

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (50 decisions)
+## 2026-06 (51 decisions)
 
-- **2026-06-28** — clud-bug rc.9: graceful PAT-or-fallback auto-resolve + idempotent markers *(wave-5b1-rc9-graceful-resolve)* — [decisions-branches/wave-5b1-rc9-graceful-resolve.md](decisions-branches/wave-5b1-rc9-graceful-resolve.md)
-- *... 48 more decisions ...*
+- **2026-06-28** — clud-bug rc.10 (Wave 6a): §6.6 conformance-fixture gate + §3.23.1 configure-github payload *(wave-6a-fixtures-conformance)* — [decisions-branches/wave-6a-fixtures-conformance.md](decisions-branches/wave-6a-fixtures-conformance.md)
+- *... 49 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/fixtures/reviews/clean/expected.md
+++ b/fixtures/reviews/clean/expected.md
@@ -1,0 +1,12 @@
+## 🐛 Clud Bug review — clean
+
+**This round:** 0 critical · 0 minor · 0 resolved from prior · 0 still open
+
+Found: 0 🔴 / 0 🟡 / 0 🟣
+
+### Per-skill scan
+- [critical-issues-only]: scanned all changed paths. 0 findings.
+
+Skills referenced: [none] — no installed skill applied to this diff.
+
+<!-- last-reviewed-sha: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -->

--- a/fixtures/reviews/clean/input.json
+++ b/fixtures/reviews/clean/input.json
@@ -1,0 +1,12 @@
+{
+  "status_header": "clean",
+  "summary_counts": { "critical": 0, "minor": 0, "preexisting": 0, "resolved_from_prior": 0, "still_open": 0 },
+  "per_skill_scan": [
+    { "skill": "critical-issues-only", "outcome": "scanned all changed paths. 0 findings." }
+  ],
+  "critical_findings": [],
+  "minor_findings": [],
+  "preexisting_findings": [],
+  "skills_referenced": [],
+  "last_reviewed_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}

--- a/fixtures/reviews/critical-only/expected.md
+++ b/fixtures/reviews/critical-only/expected.md
@@ -1,0 +1,21 @@
+## 🐛 Clud Bug review — critical findings
+
+**This round:** 1 critical · 0 minor · 0 resolved from prior · 0 still open
+
+Found: 1 🔴 / 0 🟡 / 0 🟣
+
+### Per-skill scan
+- [critical-issues-only]: scanned all changed paths. 1 critical finding below.
+
+### Critical findings
+
+🔴 [critical-issues-only]: session token logged in cleartext (src/auth.ts:42).
+<details><summary>Reasoning</summary>
+
+The token is written to debug.log on line 42, which ships to the log aggregator. Redact it before logging.
+
+</details>
+
+Skills referenced: [critical-issues-only]
+
+<!-- last-reviewed-sha: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb -->

--- a/fixtures/reviews/critical-only/input.json
+++ b/fixtures/reviews/critical-only/input.json
@@ -1,0 +1,20 @@
+{
+  "status_header": "critical findings",
+  "summary_counts": { "critical": 1, "minor": 0, "preexisting": 0, "resolved_from_prior": 0, "still_open": 0 },
+  "per_skill_scan": [
+    { "skill": "critical-issues-only", "outcome": "scanned all changed paths. 1 critical finding below." }
+  ],
+  "critical_findings": [
+    {
+      "skill": "critical-issues-only",
+      "file": "src/auth.ts",
+      "line": 42,
+      "summary": "session token logged in cleartext",
+      "reasoning": "The token is written to debug.log on line 42, which ships to the log aggregator. Redact it before logging."
+    }
+  ],
+  "minor_findings": [],
+  "preexisting_findings": [],
+  "skills_referenced": ["critical-issues-only"],
+  "last_reviewed_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+}

--- a/fixtures/reviews/dedicated-section/expected.md
+++ b/fixtures/reviews/dedicated-section/expected.md
@@ -1,0 +1,21 @@
+## 🐛 Clud Bug review — critical findings
+
+**This round:** 1 critical · 0 minor · 0 resolved from prior · 0 still open
+
+Found: 1 🔴 / 0 🟡 / 0 🟣
+
+### Per-skill scan
+- [brand-voice-review]: dedicated-mode: see the Brand voice section below.
+- [critical-issues-only]: 1 critical finding below.
+
+### Brand voice [brand-voice-review]
+
+🔴 [brand-voice-review]: label uses passive voice instead of the verb-noun pattern (src/ui/Button.tsx:12).
+
+### Critical findings
+
+🔴 [critical-issues-only]: authentication bypass in the admin endpoint (src/api.ts:55).
+
+Skills referenced: [brand-voice-review, critical-issues-only]
+
+<!-- last-reviewed-sha: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee -->

--- a/fixtures/reviews/dedicated-section/input.json
+++ b/fixtures/reviews/dedicated-section/input.json
@@ -1,0 +1,24 @@
+{
+  "status_header": "critical findings",
+  "summary_counts": { "critical": 1, "minor": 0, "preexisting": 0, "resolved_from_prior": 0, "still_open": 0 },
+  "per_skill_scan": [
+    { "skill": "brand-voice-review", "outcome": "dedicated-mode: see the Brand voice section below." },
+    { "skill": "critical-issues-only", "outcome": "1 critical finding below." }
+  ],
+  "dedicated_sections": [
+    {
+      "section_name": "Brand voice",
+      "skill": "brand-voice-review",
+      "findings": [
+        { "skill": "brand-voice-review", "file": "src/ui/Button.tsx", "line": 12, "summary": "label uses passive voice instead of the verb-noun pattern" }
+      ]
+    }
+  ],
+  "critical_findings": [
+    { "skill": "critical-issues-only", "file": "src/api.ts", "line": 55, "summary": "authentication bypass in the admin endpoint" }
+  ],
+  "minor_findings": [],
+  "preexisting_findings": [],
+  "skills_referenced": ["brand-voice-review", "critical-issues-only"],
+  "last_reviewed_sha": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+}

--- a/fixtures/reviews/mixed-severities/expected.md
+++ b/fixtures/reviews/mixed-severities/expected.md
@@ -1,0 +1,29 @@
+## 🐛 Clud Bug review — critical findings
+
+**This round:** 1 critical · 1 minor · 0 resolved from prior · 0 still open
+
+Found: 1 🔴 / 1 🟡 / 1 🟣
+
+### Per-skill scan
+- [critical-issues-only]: 1 critical finding below.
+- [evidence-based-review]: 1 minor + 1 pre-existing finding below.
+
+### Critical findings
+
+🔴 [critical-issues-only]: missing input validation on amount (src/payments.ts:17).
+
+### Minor findings
+
+🟡 [evidence-based-review]: rename helper to clarify intent (src/utils.ts:5).
+
+### Pre-existing findings
+
+🟣 [evidence-based-review]: pre-existing nullability gap in an unrelated module (src/legacy.ts:91).
+
+### Diagnostics
+
+- 1 file exceeded the per-file diff cap and was truncated.
+
+Skills referenced: [critical-issues-only, evidence-based-review]
+
+<!-- last-reviewed-sha: cccccccccccccccccccccccccccccccccccccccc -->

--- a/fixtures/reviews/mixed-severities/input.json
+++ b/fixtures/reviews/mixed-severities/input.json
@@ -1,0 +1,20 @@
+{
+  "status_header": "critical findings",
+  "summary_counts": { "critical": 1, "minor": 1, "preexisting": 1, "resolved_from_prior": 0, "still_open": 0 },
+  "per_skill_scan": [
+    { "skill": "critical-issues-only", "outcome": "1 critical finding below." },
+    { "skill": "evidence-based-review", "outcome": "1 minor + 1 pre-existing finding below." }
+  ],
+  "critical_findings": [
+    { "skill": "critical-issues-only", "file": "src/payments.ts", "line": 17, "summary": "missing input validation on amount" }
+  ],
+  "minor_findings": [
+    { "skill": "evidence-based-review", "file": "src/utils.ts", "line": 5, "summary": "rename helper to clarify intent" }
+  ],
+  "preexisting_findings": [
+    { "skill": "evidence-based-review", "file": "src/legacy.ts", "line": 91, "summary": "pre-existing nullability gap in an unrelated module" }
+  ],
+  "diagnostics": ["1 file exceeded the per-file diff cap and was truncated."],
+  "skills_referenced": ["critical-issues-only", "evidence-based-review"],
+  "last_reviewed_sha": "cccccccccccccccccccccccccccccccccccccccc"
+}

--- a/fixtures/reviews/resolved-from-prior/expected.md
+++ b/fixtures/reviews/resolved-from-prior/expected.md
@@ -1,0 +1,12 @@
+## 🐛 Clud Bug review — clean
+
+**This round:** 0 critical · 0 minor · 2 resolved from prior · 1 still open
+
+Found: 0 🔴 / 0 🟡 / 0 🟣
+
+### Per-skill scan
+- [critical-issues-only]: 0 new findings. 2 prior findings confirmed resolved, 1 still open.
+
+Skills referenced: [critical-issues-only]
+
+<!-- last-reviewed-sha: dddddddddddddddddddddddddddddddddddddddd -->

--- a/fixtures/reviews/resolved-from-prior/input.json
+++ b/fixtures/reviews/resolved-from-prior/input.json
@@ -1,0 +1,12 @@
+{
+  "status_header": "clean",
+  "summary_counts": { "critical": 0, "minor": 0, "preexisting": 0, "resolved_from_prior": 2, "still_open": 1 },
+  "per_skill_scan": [
+    { "skill": "critical-issues-only", "outcome": "0 new findings. 2 prior findings confirmed resolved, 1 still open." }
+  ],
+  "critical_findings": [],
+  "minor_findings": [],
+  "preexisting_findings": [],
+  "skills_referenced": ["critical-issues-only"],
+  "last_reviewed_sha": "dddddddddddddddddddddddddddddddddddddddd"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.9",
+  "version": "0.7.0-rc.10",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/scripts/fixture-check.mjs
+++ b/scripts/fixture-check.mjs
@@ -1,1 +1,88 @@
-// Stub — populated when render-review.ts conversion lands.
+// SPEC §6.6 conformance-fixture harness (NORMATIVE release-gate).
+//
+// For every scenario dir under `fixtures/reviews/<scenario>/`, render
+// `input.json` through the SAME `renderReview` used to post the PR comment
+// body and assert the output is byte-identical to the committed
+// `expected.md` golden. A renderer change that alters the comment shape
+// fails this gate until the goldens are regenerated + reviewed.
+//
+//   node scripts/fixture-check.mjs            # check (CI gate)
+//   node scripts/fixture-check.mjs --update   # regenerate goldens
+//
+// Imports from `dist/` — run `npm run build` first (CI does, and the
+// `test:fixtures` script is wired after the build step).
+
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const FIXTURES = resolve(ROOT, 'fixtures/reviews');
+const UPDATE = process.argv.includes('--update');
+
+if (!existsSync(FIXTURES)) {
+  console.error(`fixture-check: ${FIXTURES} does not exist.`);
+  process.exit(1);
+}
+
+const { renderReview } = await import('../dist/core/render-review.js');
+
+const scenarios = (await readdir(FIXTURES, { withFileTypes: true }))
+  .filter((e) => e.isDirectory())
+  .map((e) => e.name)
+  .sort((a, b) => a.localeCompare(b));
+
+if (scenarios.length === 0) {
+  console.error(`fixture-check: no scenario directories under ${FIXTURES}.`);
+  process.exit(1);
+}
+
+let passed = 0;
+let failed = 0;
+
+for (const name of scenarios) {
+  const dir = resolve(FIXTURES, name);
+  let actual;
+  try {
+    const input = JSON.parse(await readFile(resolve(dir, 'input.json'), 'utf8'));
+    actual = renderReview(input);
+  } catch (err) {
+    console.error(`FAIL  ${name} — input.json parse/render error: ${err.message}`);
+    failed++;
+    continue;
+  }
+
+  if (UPDATE) {
+    await writeFile(resolve(dir, 'expected.md'), actual, 'utf8');
+    console.log(`  updated  ${name}`);
+    passed++;
+    continue;
+  }
+
+  let expected;
+  try {
+    expected = await readFile(resolve(dir, 'expected.md'), 'utf8');
+  } catch {
+    console.error(`FAIL  ${name} — expected.md missing (run with --update to create it).`);
+    failed++;
+    continue;
+  }
+
+  if (actual === expected) {
+    console.log(`  ok  ${name}`);
+    passed++;
+  } else {
+    let i = 0;
+    while (i < actual.length && i < expected.length && actual[i] === expected[i]) i++;
+    const win = (s) => JSON.stringify(s.slice(Math.max(0, i - 8), i + 16));
+    console.error(`FAIL  ${name} — first diff at char ${i}:`);
+    console.error(`        expected ${win(expected)}`);
+    console.error(`        actual   ${win(actual)}`);
+    failed++;
+  }
+}
+
+console.log(`\nfixture-check: ${passed} passed, ${failed} failed${UPDATE ? ' (updated)' : ''}.`);
+if (failed > 0) process.exit(1);

--- a/src/cli/configure-github.ts
+++ b/src/cli/configure-github.ts
@@ -38,6 +38,8 @@ export interface RunConfigureGithubOptions {
   dryRun?: boolean;
   /** Suppress progress chatter; emit only the final `ok` summary. */
   quiet?: boolean;
+  /** Emit the SPEC §3.23.1 status payload as JSON instead of key-colon-value. */
+  json?: boolean;
   /** Resolver for the GitHub token (tests pass a stub). */
   resolveToken?: () => Promise<string | null>;
   /** Octokit factory (tests inject a fake; defaults to the gh-adapter). */
@@ -57,6 +59,7 @@ Options:
   --dry-run         Compute diff and print it, but do NOT call PATCH endpoints.
   --branch <name>   Target branch (default: main).
   --quiet,-q        Suppress progress chatter; emit only the final summary.
+  --json            Emit the status payload as JSON (machine consumption).
   --help,-h         Show this help.
 
 Auth (resolved in order):
@@ -68,6 +71,40 @@ Exit codes:
   1  auth missing, PATCH error, or unrecoverable transport failure
   2  CLI usage error (missing target, bad flag)
 `;
+
+/** Resolved outcome of a configure-github run, for the §3.23.1 status payload. */
+export interface ConfigureSummary {
+  owner: string;
+  repo: string;
+  /** True when the repo already matches canonical-v1 (idempotent no-op). */
+  alreadyCanonical: boolean;
+  /** True when this was a --dry-run (no PATCH calls made). */
+  dryRun: boolean;
+  /** Number of changes (applied, or pending for dry-run; 0 for a no-op). */
+  changes: number;
+}
+
+/**
+ * SPEC §3.23.1 (NORMATIVE): emit a single-line status payload carrying
+ * `alreadyCanonical` + `rulesetVersion` as named fields — JSON for machine
+ * consumption, key-colon-value for humans.
+ */
+export function formatConfigureSummary(summary: ConfigureSummary, json: boolean): string {
+  const { owner, repo, alreadyCanonical, dryRun, changes } = summary;
+  if (json) {
+    return (
+      JSON.stringify({ owner, repo, alreadyCanonical, rulesetVersion: 'v1', dryRun, changes }) + '\n'
+    );
+  }
+  if (alreadyCanonical) {
+    return `ok configure-github: owner: ${owner} repo: ${repo} alreadyCanonical: true rulesetVersion: v1\n`;
+  }
+  const plural = changes === 1 ? '' : 's';
+  if (dryRun) {
+    return `ok configure-github: dry-run on ${owner}/${repo} — ${changes} change${plural} pending\n`;
+  }
+  return `ok configure-github: ${owner}/${repo} converged to canonical-v1 (${changes} change${plural})\n`;
+}
 
 /**
  * Entry point — wired into `clud-bug.js` dispatch. Returns a Node-style
@@ -83,6 +120,7 @@ export async function runConfigureGithub(
     branch = 'main',
     dryRun = false,
     quiet = false,
+    json = false,
     resolveToken = defaultResolveToken,
     octokitFactory = ghCliOctokit,
     stdout = (msg) => process.stdout.write(msg),
@@ -147,7 +185,7 @@ export async function runConfigureGithub(
 
   if (result.alreadyCanonical) {
     if (!quiet) stdout('  No changes — repo already matches canonical-v1.\n');
-    stdout(`ok configure-github: ${owner}/${repo} already canonical-v1\n`);
+    stdout(formatConfigureSummary({ owner, repo, alreadyCanonical: true, dryRun, changes: 0 }, json));
     return 0;
   }
 
@@ -158,15 +196,11 @@ export async function runConfigureGithub(
   }
 
   if (dryRun) {
-    stdout(
-      `ok configure-github: dry-run on ${owner}/${repo} — ${result.changes.length} change${result.changes.length === 1 ? '' : 's'} pending\n`,
-    );
+    stdout(formatConfigureSummary({ owner, repo, alreadyCanonical: false, dryRun: true, changes: result.changes.length }, json));
     return 0;
   }
 
-  stdout(
-    `ok configure-github: ${owner}/${repo} converged to canonical-v1 (${result.changes.length} change${result.changes.length === 1 ? '' : 's'})\n`,
-  );
+  stdout(formatConfigureSummary({ owner, repo, alreadyCanonical: false, dryRun: false, changes: result.changes.length }, json));
   return 0;
 }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1789,6 +1789,7 @@ async function runConfigureGithubCmd(args) {
     branch: args.branch || 'main',
     dryRun: Boolean(args.dryRun),
     quiet: QUIET,
+    json: Boolean(args.json),
   });
   if (code !== 0) process.exit(code);
 }

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -400,7 +400,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.9
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.10
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -400,7 +400,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.9
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.10
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -704,7 +704,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.9
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.10
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/configure-github.test.js
+++ b/test/configure-github.test.js
@@ -1,0 +1,56 @@
+// SPEC §3.23.1 — configure-github idempotency status-payload conformance.
+// The pure output formatter must surface `alreadyCanonical` + `rulesetVersion`
+// as named fields (JSON for machines, key-colon-value for humans).
+
+import { describe, expect, it } from 'vitest';
+
+import { formatConfigureSummary } from '../src/cli/configure-github.js';
+
+describe('formatConfigureSummary — §3.23.1 status payload', () => {
+  it('no-op human output surfaces alreadyCanonical: true + rulesetVersion: v1', () => {
+    const s = formatConfigureSummary(
+      { owner: 'thrillmade', repo: 'protocol', alreadyCanonical: true, dryRun: false, changes: 0 },
+      false,
+    );
+    expect(s).toMatch(/alreadyCanonical: true/);
+    expect(s).toMatch(/rulesetVersion: v1/);
+    expect(s).toMatch(/thrillmade/);
+    expect(s).toMatch(/protocol/);
+    expect(s.endsWith('\n')).toBe(true);
+  });
+
+  it('no-op JSON output is a parseable single line with the named fields', () => {
+    const s = formatConfigureSummary(
+      { owner: 'thrillmade', repo: 'protocol', alreadyCanonical: true, dryRun: false, changes: 0 },
+      true,
+    );
+    const obj = JSON.parse(s);
+    expect(obj).toMatchObject({
+      owner: 'thrillmade',
+      repo: 'protocol',
+      alreadyCanonical: true,
+      rulesetVersion: 'v1',
+    });
+  });
+
+  it('applied JSON reports alreadyCanonical: false + the change count', () => {
+    const obj = JSON.parse(
+      formatConfigureSummary(
+        { owner: 'o', repo: 'r', alreadyCanonical: false, dryRun: false, changes: 2 },
+        true,
+      ),
+    );
+    expect(obj.alreadyCanonical).toBe(false);
+    expect(obj.changes).toBe(2);
+    expect(obj.rulesetVersion).toBe('v1');
+  });
+
+  it('dry-run human output keeps the existing pending-changes prose', () => {
+    const s = formatConfigureSummary(
+      { owner: 'o', repo: 'r', alreadyCanonical: false, dryRun: true, changes: 3 },
+      false,
+    );
+    expect(s).toMatch(/dry-run/);
+    expect(s).toMatch(/3 changes pending/);
+  });
+});

--- a/test/core/configure-github.test.js
+++ b/test/core/configure-github.test.js
@@ -463,7 +463,36 @@ test('runConfigureGithub: already-canonical → exit 0 with summary', async () =
     stderr: () => {},
   });
   assert.equal(code, 0);
-  assert.match(stdoutBuf, /ok configure-github: octo\/demo already canonical-v1/);
+  // SPEC §3.23.1: the idempotent no-op MUST surface alreadyCanonical as a named field.
+  assert.match(stdoutBuf, /alreadyCanonical: true/);
+  assert.match(stdoutBuf, /rulesetVersion: v1/);
+  assert.match(stdoutBuf, /octo/);
+  assert.match(stdoutBuf, /demo/);
+});
+
+test('runConfigureGithub: already-canonical + --dry-run --json → payload reports dryRun:true', async () => {
+  let stdoutBuf = '';
+  const { octokit } = makeOctokitMock({
+    branchProtection: CANONICAL_BRANCH_PROTECTION_STATE,
+    repoSettings: CANONICAL_REPO_STATE,
+  });
+  const code = await runConfigureGithub({
+    target: 'octo/demo',
+    dryRun: true,
+    json: true,
+    resolveToken: async () => 'token',
+    octokitFactory: () => octokit,
+    quiet: true,
+    stdout: (m) => {
+      stdoutBuf += m;
+    },
+    stderr: () => {},
+  });
+  assert.equal(code, 0);
+  const payload = JSON.parse(stdoutBuf);
+  assert.equal(payload.alreadyCanonical, true);
+  // The no-op branch is reachable under --dry-run; the payload must reflect it.
+  assert.equal(payload.dryRun, true);
 });
 
 test('runConfigureGithub: --dry-run reports diff but skips PATCH', async () => {


### PR DESCRIPTION
## Wave 6a — SPEC v0.5.1 conformance closure (rc.10)

Closes two NORMATIVE gaps from the v0.5.1 audit.

### §6.6 conformance-fixture gate (NORMATIVE release-gate)
- New `fixtures/reviews/<scenario>/{input.json, expected.md}` for 5 canonical scenarios: **clean, critical-only, mixed-severities, resolved-from-prior, dedicated-section**.
- `scripts/fixture-check.mjs` (was a 1-line stub) renders each `input.json` through the same `renderReview` that builds the PR comment body and asserts **byte-identity** with the committed golden. `--update` regenerates the goldens (they're generated *by* the renderer, so they match by construction).
- Wired into CI as `npm run test:fixtures` (after build+test). A future renderer change that alters the comment shape now **fails the build** until the goldens are reviewed + regenerated.

### §3.23.1 `configure-github` status payload (NORMATIVE)
- The idempotent no-op previously printed prose (`already canonical-v1`); it now emits **`alreadyCanonical: true rulesetVersion: v1`** as named fields (human), or JSON via the new **`--json`** flag — satisfying the §3.23.1 machine-readable contract.
- New pure `formatConfigureSummary()` covers all three outcomes (no-op / dry-run / applied); `main.ts` wires `--json`.

### Tests & review
- New `formatConfigureSummary` unit tests + updated the existing already-canonical integration test to the §3.23.1 contract. **736 tests green, 5/5 fixtures, `tsc` clean, actionlint clean.**
- 3-lens adversarial review (correctness / SPEC-conformance / robustness). One real bug found + fixed: the no-op call site hardcoded `dryRun:false`, so `--dry-run --json` on an already-canonical repo wrongly reported `dryRun:false` — now uses the actual flag, with a regression test.

### Follow-ups (not in this PR)
- §6.8.3 per-pass cost comment in `clud-bug-app` (a SHOULD; confirmed absent).
- Canonical fixtures copy in `protocol/fixtures/reviews/` (byte-identical to these).

### USER ACTION (after merge)
- Tag `v0.7.0-rc.10` → publishes to `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
