### PR TITLE
Wave 6b: local-review slash command MVP (--with-local-review) (rc.11)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.10
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.11
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.7.0-rc.11] — 2026-06-28
+
+Wave 6b — local review mode (slash-command MVP).
+
+### Added
+
+- **`clud-bug init --with-local-review`** scaffolds `.claude/commands/clud-bug-review.md`,
+  so `/clud-bug-review` works inside a Claude Code session: the agent loads the repo's
+  review skills, fetches the PR diff via `gh`, reviews against the skills using **that
+  session's own tokens** (Max or API), and posts/updates a clud-bug-format comment — no
+  hosted App, no new auth. The local-mode comment carries a `written-by: @<login>
+  (clud-bug local-mode)` marker so the bot's auto-resolve never treats it as `clud-bug[bot]`.
+- `templates/clud-bug-review.md.tmpl` (new); `clud-bug update` refreshes a scaffolded
+  command in place when it carries the `<!-- clud-bug-local-version: -->` marker, and
+  leaves a user-customized (markerless) copy untouched.
+
+### Notes
+
+- This is the slash-command MVP; the optional `clud-bug-mcp` structured-tool package and
+  the pre-push hooks are designed but pending CEO sign-off (package location, hook
+  cache-skip behavior, conformance-level naming) and ship in follow-up PRs.
+
 ## [0.7.0-rc.10] — 2026-06-28
 
 Wave 6a — SPEC v0.5.1 conformance closure.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3,3 +3,14 @@
 This file contains the 20 most recent decisions. Older decisions are archived in [decisions-archive.md](decisions-archive.md).
 
 ---
+## 2026-06-28 01:52 - clud-bug rc.11 (Wave 6b): local-review slash command MVP (/clud-bug-review)
+
+**Reasoning:** Local mode reuses the customer's Claude Code session tokens — no hosted App, no new auth (CEO's locked session-only auth). 'clud-bug init --with-local-review' scaffolds .claude/commands/clud-bug-review.md; the agent loads repo skills, fetches the PR diff via gh, reviews against the skills, and posts/updates a clud-bug-format comment carrying a '(clud-bug local-mode)' written-by marker so the bot's auto-resolve never treats it as clud-bug[bot]. Native gh/git tools — no MCP server required (MCP is an optional enhancement).
+
+**Alternatives considered:** Slash-command body using the clud-bug-mcp structured tools (deferred — needs the MCP package, which awaits CEO sign-off on location; the native-tools MVP is independently shippable). Bundling --with-hooks (deferred — hooks need CEO sign-off on cache-skip behavior).
+
+**Implications:**
+- Edit-in-place uses the REST issues-comments endpoint for the integer comment id (adversarial-review fix: 'gh pr view --json comments' returns GraphQL node ids that 404 on PATCH, causing duplicate comments). update.ts refreshes the command in place only when marker-bearing. clud-bug-mcp package + pre-push hooks + SPEC v0.6.0 §11 are designed (blueprint saved) and pending CEO sign-off on 4 decisions.
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -47,6 +47,7 @@ clud-bug
 ├── templates
 │   ├── skills
 │   ├── audit.yml.tmpl
+│   ├── clud-bug-review.md.tmpl
 │   ├── self-update.yml.tmpl
 │   ├── workflow-py.yml.tmpl
 │   ├── workflow-ts.yml.tmpl
@@ -63,6 +64,7 @@ clud-bug
 │   ├── diff-findings.test.js
 │   ├── edit-workflow.test.js
 │   ├── formal-review.test.js
+│   ├── init-local-review.test.js
 │   ├── init-with-skdd.test.js
 │   ├── inline-threads.test.js
 │   ├── prompt-builder.test.js

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (51 decisions)
+## 2026-06 (52 decisions)
 
-- **2026-06-28** — clud-bug rc.10 (Wave 6a): §6.6 conformance-fixture gate + §3.23.1 configure-github payload *(wave-6a-fixtures-conformance)* — [decisions-branches/wave-6a-fixtures-conformance.md](decisions-branches/wave-6a-fixtures-conformance.md)
-- *... 49 more decisions ...*
+- **2026-06-28** — clud-bug rc.11 (Wave 6b): local-review slash command MVP (/clud-bug-review) *(main)* — [decisions.md](decisions.md)
+- *... 50 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.10",
+  "version": "0.7.0-rc.11",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -62,6 +62,10 @@ function parseArgs(argv) {
     // users get the same one-command bootstrap as Python-first users
     // (logmind v0.6.8's --with-skdd is the symmetric counterpart).
     withSkdd: false,
+    // v0.7.0 (Wave 6b): `clud-bug init --with-local-review` also scaffolds
+    // .claude/commands/clud-bug-review.md so `/clud-bug-review` works in a
+    // Claude Code session (reviews the current PR with the session's tokens).
+    withLocalReview: false,
     // v0.7.0-rc.4: `clud-bug configure-github` flags.
     // --dry-run prints the diff but skips PATCH; --branch overrides "main".
     dryRun: false,
@@ -88,6 +92,7 @@ function parseArgs(argv) {
     else if (a === '--health') args.health = true;
     else if (a === '--no-artifacts') args.artifacts = false;
     else if (a === '--with-skdd') args.withSkdd = true;
+    else if (a === '--with-local-review') args.withLocalReview = true;
     else if (a === '--dry-run') args.dryRun = true;
     else if (a === '--branch') args.branch = argv[++i];
     else args._.push(a);
@@ -185,6 +190,10 @@ Options:
   --offline             Skip skills.sh; pin only the bundled baseline specimens.
   --accept-all,-y       Accept the recommended specimens without prompting.
   --commit              git add + commit the generated kit when done (init only).
+  --with-local-review   (init) Scaffold .claude/commands/clud-bug-review.md so
+                        \`/clud-bug-review\` works in a Claude Code session —
+                        reviews the current branch's PR using that session's
+                        own tokens (no hosted App, no extra auth).
   --quiet,-q            Token-frugal mode for agent invocations. Suppresses
                         progress chatter; emits exactly one final
                         \`ok <key-value>\` summary line per command. Errors
@@ -1236,6 +1245,19 @@ async function runInit(args) {
   const selfUpdatePath = join(cwd, '.github', 'workflows', 'clud-bug-self-update.yml');
   await writeFile(selfUpdatePath, selfUpdateTmpl);
   log(`    wrote ${rel(cwd, selfUpdatePath)}`);
+
+  // v0.7.0 (Wave 6b): optional local-review slash command. Scaffolds
+  // `.claude/commands/clud-bug-review.md` so `/clud-bug-review` works inside a
+  // Claude Code session — the agent reviews the current branch's open PR using
+  // THAT session's own tokens (Max or API), no hosted App or new auth required.
+  // `.claude/` is already in the --commit add-list below, so it's staged too.
+  if (args.withLocalReview) {
+    const commandPath = join(cwd, '.claude', 'commands', 'clud-bug-review.md');
+    await mkdir(dirname(commandPath), { recursive: true });
+    const commandContent = await renderFile(join(TEMPLATES, 'clud-bug-review.md.tmpl'), {});
+    await writeFile(commandPath, commandContent);
+    log(`    wrote ${rel(cwd, commandPath)}`);
+  }
 
   // Stamp the manifest. Sets strictMode: true ONLY on fresh installs —
   // a manifest that's never been touched by clud-bug init/update has no

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -143,6 +143,25 @@ export async function runUpdate(opts: RunUpdateOptions): Promise<RunUpdateResult
   for (const p of agentDocs.created) changed.push({ path: join(cwd, p), label: `agent docs: created ${p}` });
   for (const p of agentDocs.touched) changed.push({ path: join(cwd, p), label: `agent docs: ${p}` });
 
+  // 5b. Refresh the local-review slash command (Wave 6b) when it was scaffolded
+  //     via `clud-bug init --with-local-review`. Only files carrying the
+  //     `<!-- clud-bug-local-version:` marker are refreshed; a markerless file
+  //     is user-owned (hand-customized) and left untouched.
+  const localReviewPath = join(cwd, '.claude', 'commands', 'clud-bug-review.md');
+  if (await pathExists(localReviewPath)) {
+    const prior = await readSafe(localReviewPath);
+    if (prior && prior.includes('<!-- clud-bug-local-version:')) {
+      const newCommand = await renderFile(join(templatesDir, 'clud-bug-review.md.tmpl'), {});
+      await maybeWrite(localReviewPath, newCommand, changed, unchanged, 'local-review slash command');
+    } else {
+      skipped.push({
+        path: localReviewPath,
+        label: 'local-review slash command',
+        reason: 'markerless (user-customized); delete + `clud-bug init --with-local-review` to refresh',
+      });
+    }
+  }
+
   // 6. Stamp the manifest with the version that ran the update.
   manifest['lastUpdate'] = new Date().toISOString();
   manifest['lastUpdateVersion'] = ourVersion;

--- a/templates/clud-bug-review.md.tmpl
+++ b/templates/clud-bug-review.md.tmpl
@@ -1,0 +1,115 @@
+---
+description: Review the current branch's open PR locally, in this Claude Code session
+argument-hint: "[pr-number]"
+---
+
+<!-- clud-bug-local-version: v1 -->
+
+You are running **clud-bug** as a local code review — inside this Claude Code
+session, using this session's own model tokens (Max or API, whatever you have).
+No hosted App, no extra auth: you already have `gh`, `git`, and file access.
+
+## 1. Find the PR
+
+PR number: `$ARGUMENTS`
+
+If `$ARGUMENTS` is empty, detect the current branch's open PR:
+
+```bash
+gh pr list --head "$(git branch --show-current)" --state open --json number --jq '.[0].number'
+```
+
+If there is no open PR, stop and tell the user to open one (or pass a PR number).
+
+## 2. Load the review skills
+
+Read the manifest and every referenced skill body from the checkout:
+
+- `.claude/skills/.clud-bug.json` — which skills are installed, plus `strictMode`.
+- For each installed skill, `.claude/skills/<name>/SKILL.md` — the discipline to apply.
+
+Load skills **before** the diff. At minimum the baseline set applies:
+**critical-issues-only** (flag only correctness / security / performance — skip
+nits), **evidence-based-review** (quote the exact line you criticize — no
+hand-waving), **respect-existing-conventions** (don't fight the codebase's
+established patterns).
+
+## 3. Fetch the diff
+
+```bash
+gh pr diff <PR_NUMBER>
+```
+
+## 4. Review
+
+Review the diff against every loaded skill. For each finding record: `file`,
+`line`, `severity` (`critical` | `minor` | `preexisting`), the `skill` that
+motivated it, and a one-line `summary`. Apply the skills strictly — especially
+critical-issues-only (no nits) and evidence-based-review (quote the code).
+
+## 5. Render the review comment
+
+Build the body in clud-bug's standard shape (omit any empty findings section):
+
+```
+## 🐛 Clud Bug review — <clean | critical findings>
+
+**This round:** N critical · N minor · N resolved from prior · N still open
+
+Found: N 🔴 / N 🟡 / N 🟣
+
+### Per-skill scan
+- [<skill>]: <one line on what it scanned + found>
+
+### Critical findings
+🔴 [<skill>]: <summary> (<file>:<line>).
+
+### Minor findings
+🟡 [<skill>]: <summary> (<file>:<line>).
+
+### Pre-existing findings
+🟣 [<skill>]: <summary> (<file>:<line>).
+
+Skills referenced: [<skill>, <skill>]
+
+<!-- written-by: @<your-gh-login> (clud-bug local-mode) -->
+<!-- review-sha: <HEAD_SHA> -->
+```
+
+Get your gh login with `gh api user --jq .login` and the head sha with
+`git rev-parse HEAD`. The `written-by` marker **MUST** end with
+`(clud-bug local-mode)` so the bot's auto-resolve never mistakes this for a
+`clud-bug[bot]` comment.
+
+## 6. Post (or update) the comment
+
+Look for an existing local-mode comment and edit it in place (one rolling review
+comment), otherwise post a fresh one. Use the **REST** issues-comments endpoint
+for the lookup — its `.id` is the **integer** comment id the PATCH endpoint needs.
+(Do NOT use `gh pr view --json comments`; that returns GraphQL node IDs, which
+404 on the REST PATCH and cause duplicate comments.) `gh` fills `{owner}/{repo}`.
+
+```bash
+# existing local-mode comment id (integer), if any:
+EXISTING_ID=$(gh api --paginate "repos/{owner}/{repo}/issues/<PR_NUMBER>/comments" \
+  --jq '[.[] | select(.body | test("written-by: @.* \\(clud-bug local-mode\\)"))] | first | .id // empty')
+```
+
+- `$EXISTING_ID` empty → `gh pr comment <PR_NUMBER> --body-file <body.md>`
+- `$EXISTING_ID` set → `gh api "repos/{owner}/{repo}/issues/comments/$EXISTING_ID" -X PATCH -F body=@<body.md>`
+
+## 7. Summarize
+
+Print one line:
+`clud-bug local-review: N critical · N minor · N preexisting — <PASS | FAIL (strictMode) | advisory>`
+
+If `.clud-bug.json` has `strictMode: true` and there are critical findings, say
+**FAIL** and tell the user to fix them before merging.
+
+---
+
+_Optional: if the `clud-bug-mcp` MCP server is connected, you may use its
+structured tools (`load_skills_from_pr_base`, `fetch_pr_diff`,
+`partition_findings_by_severity`, `emit_review_comment`) in place of the raw
+`gh`/`git` calls above — same flow, with the base-ref skill read and the exact
+review rendering done for you._

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -400,7 +400,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.10
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.11
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -400,7 +400,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.10
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.11
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -704,7 +704,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.10
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.11
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/init-local-review.test.js
+++ b/test/init-local-review.test.js
@@ -1,0 +1,60 @@
+// Wave 6b — `clud-bug init --with-local-review` scaffolds the local-mode
+// /clud-bug-review slash command at .claude/commands/clud-bug-review.md.
+
+import { test } from 'vitest';
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, access } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const CLI = join(dirname(dirname(fileURLToPath(import.meta.url))), 'bin', 'clud-bug.js');
+
+function runInit(dir, extraArgs) {
+  return spawnSync(
+    process.execPath,
+    [CLI, 'init', '--offline', '--accept-all', '--no-set-protection', ...extraArgs],
+    {
+      cwd: dir,
+      env: { ...process.env, HOME: dir, CLUD_BUG_QUIET: '1' },
+      encoding: 'utf8',
+      timeout: 30000,
+    },
+  );
+}
+
+test('--with-local-review is advertised in --help', () => {
+  const r = spawnSync(process.execPath, [CLI, '--help'], { encoding: 'utf8' });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /--with-local-review/);
+});
+
+test('init --with-local-review scaffolds the /clud-bug-review slash command', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-lr-'));
+  await mkdir(join(dir, '.git'), { recursive: true });
+  const r = runInit(dir, ['--with-local-review']);
+  assert.equal(r.status, 0, r.stderr);
+  const body = await readFile(join(dir, '.claude', 'commands', 'clud-bug-review.md'), 'utf8');
+  assert.match(body, /<!-- clud-bug-local-version:/);
+  assert.match(body, /description: Review the current branch's open PR locally/);
+  assert.match(body, /\(clud-bug local-mode\)/);
+  // rc.11 review fix: edit-in-place must look the comment up via the REST
+  // issues-comments endpoint (integer id), NOT `gh pr view --json comments`
+  // (GraphQL node id → PATCH 404 → duplicate comments on every re-run).
+  assert.match(body, /repos\/\{owner\}\/\{repo\}\/issues\/<PR_NUMBER>\/comments/);
+});
+
+test('init without --with-local-review does NOT scaffold the slash command', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-nolr-'));
+  await mkdir(join(dir, '.git'), { recursive: true });
+  const r = runInit(dir, []);
+  assert.equal(r.status, 0, r.stderr);
+  let exists = true;
+  try {
+    await access(join(dir, '.claude', 'commands', 'clud-bug-review.md'));
+  } catch {
+    exists = false;
+  }
+  assert.equal(exists, false, 'slash command should not exist without the flag');
+});


### PR DESCRIPTION
## Wave 6b — local review mode (slash-command MVP) (rc.11)

The CEO's highest-priority pre-launch feature, in its first shippable form: **local review
runs inside a Claude Code session using that session's own tokens** — no hosted App, no new
auth.

### What ships
- **`clud-bug init --with-local-review`** scaffolds `.claude/commands/clud-bug-review.md`.
  In a Claude Code session, `/clud-bug-review [pr]` makes the agent: find the PR → load the
  repo's review skills → `gh pr diff` → review against the skills → render a clud-bug-format
  comment → post or **edit-in-place** → print a PASS/FAIL summary.
- Uses **native `gh`/`git`** — no MCP server required (the `clud-bug-mcp` structured-tools
  package is an optional enhancement, shipping later).
- The local-mode comment carries `written-by: @<login> (clud-bug local-mode)` so the hosted
  bot's auto-resolve never mistakes it for `clud-bug[bot]`.
- `clud-bug update` refreshes a scaffolded command in place when it carries the
  `<!-- clud-bug-local-version: -->` marker; a user-customized (markerless) copy is left alone.

### Tests & review
- New integration test (help advertises the flag; `--with-local-review` scaffolds the
  command; plain init does not). **739 tests green, 5/5 fixtures, actionlint clean.**
- 2-lens adversarial review (wiring + template quality). One real **HIGH** bug found + fixed:
  edit-in-place used `gh pr view --json comments | .id` (a GraphQL node id) against the REST
  PATCH endpoint (needs the integer id) → 404 → duplicate comments on every re-run. Now uses
  the REST issues-comments endpoint, with a regression assertion.

### Deferred (need your sign-off — see `~/.claude/plans/morning-briefing.md`)
- `clud-bug-mcp` package (location: monorepo vs separate repo), pre-push hooks (cache-skip
  behavior), SPEC v0.6.0 §11 (conformance-level naming). All designed; blueprint saved.

### USER ACTION (after merge)
- Tag `v0.7.0-rc.11` → publishes to `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
