### PR TITLE
Wave 6b PR 0: extract the review engine into clud-bug/core (rc.12)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.11
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.12
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.7.0-rc.12] — 2026-06-28
+
+Wave 6b (PR 0) — shared review engine extracted into `core` (single source of truth).
+
+### Added
+
+- **`core/review-plan.ts`, `core/budget-plan.ts`, `core/multi-pass-aggregate.ts`** —
+  clud-bug's review-planning brain now lives in the shared package, ported behavior-identically
+  from `clud-bug-app/lib` (the App's unit suites ported alongside; 77 new tests):
+  - `resolveReviewPasses` — per-skill multi-pass resolver with the `.clud-bug.json` perSkill →
+    SKILL.md `review_passes` → repo-default → builtin precedence chain and the `MAX_PASSES=3` cap.
+  - `estimateBudget` — Layer-1 pre-flight cost gate (`Σ(skill_loads × passes) × worst-case ceiling`).
+  - `aggregatePasses` + `resolveVerdict` — cross-check / consensus / independent aggregation and
+    the §1.8.5 APPROVE/REQUEST_CHANGES table; `consensus` rides the canonical `UnifiedFinding`.
+  This is the foundation the hosted bot, the npm workflow, and local mode all consume. Adds a
+  `beetle | wasp | mantis` `tier` on `ReviewRole` (concrete model binding stays consumer-side).
+  Additive — no existing consumer behavior changes; `resolveReviewPasses` is decoupled from the
+  App's `LoadedSkill` (takes a minimal `{ slug, frontmatter }`).
+
 ## [0.7.0-rc.11] — 2026-06-28
 
 Wave 6b — local review mode (slash-command MVP).

--- a/docs/decisions-branches/wave-6b-core-engine.md
+++ b/docs/decisions-branches/wave-6b-core-engine.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-28 14:48 - Extract review engine (review-plan/budget-plan/multi-pass-aggregate) into clud-bug/core — rc.12
+
+**Reasoning:** Wave 6b PR 0: local mode must run clud-bug's FULL review brain (multi-pass tiering, budget gate, aggregation), not a hand-picked subset. That brain was pure logic trapped in clud-bug-app/lib while clud-bug/core (what local consumes) had only the rendering. Extracting to core makes the hosted bot, the npm workflow, and local mode share ONE engine — the Bug-9 single-source-of-truth principle applied to the engine. Behavior-identical: the App's unit suites were ported (77 tests) and pass; 816 total green.
+
+**Alternatives considered:** Reimplement a lighter local-only planner — rejected: divergent logic defeats single-source-of-truth and the CEO 'apply ALL our logic to local' directive.
+
+**Implications:**
+- PR 0b re-wires the App onto core. consensus now rides the canonical UnifiedFinding (an adversarial review caught it being erased at the aggregatePasses return boundary) so the App's SPEC 6.10.2 auto-fix gate type-checks against core. rc.12 publish is a USER ACTION.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (52 decisions)
+## 2026-06 (53 decisions)
 
-- **2026-06-28** — clud-bug rc.11 (Wave 6b): local-review slash command MVP (/clud-bug-review) *(main)* — [decisions.md](decisions.md)
-- *... 50 more decisions ...*
+- **2026-06-28** — Extract review engine (review-plan/budget-plan/multi-pass-aggregate) into clud-bug/core — rc.12 *(wave-6b-core-engine)* — [decisions-branches/wave-6b-core-engine.md](decisions-branches/wave-6b-core-engine.md)
+- *... 51 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.11",
+  "version": "0.7.0-rc.12",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/core/budget-plan.ts
+++ b/src/core/budget-plan.ts
@@ -1,0 +1,324 @@
+import type { ResolvedReviewPasses } from './review-plan.js';
+
+/**
+ * Layer 1 cost gate — pre-flight estimator for multi-pass review.
+ *
+ * D.2.5 introduces a cost multiplier — a 3-pass review of a 5-skill catalog
+ * is 15 AI calls instead of 5. Without a gate, a misconfigured `reviewPasses`
+ * block can quietly burn through the AI Gateway budget on a single PR. This
+ * module decides BEFORE any AI call whether the review is cheap enough to
+ * run, and if not, returns a structured "deny" verdict the orchestrator
+ * surfaces as a friendly comment.
+ *
+ * Two layers, only the first lands in D.2.5:
+ *
+ *   - Layer 1 (this module): per-PR estimate. Sums `skill_loads × pass_count`
+ *     to produce an `estimatedCalls` count and an `estimatedCostUsd`
+ *     ceiling. If `estimatedCostUsd > cap`, we deny.
+ *
+ *   - Layer 2 (D.4 — NOT in this module): per-install rolling spend. Reads
+ *     `INSTALLS:{id}.spend_usd_30d` from Redis. D.4 wires the actual gating;
+ *     here we just stub the interface.
+ *
+ * The gate is BEST-EFFORT, intentionally pessimistic. We over-estimate cost
+ * (worst-case tokens × highest-tier model) because the alternative is the
+ * customer eating a surprise bill. A 20% over-estimate that occasionally
+ * causes a "we paused; raise the cap" comment is the right failure mode.
+ *
+ * Until D.4 wires real per-install budgets, this module always returns
+ * `{ verdict: 'allow' }`. The implementation is intentionally complete so
+ * D.4 can flip a single switch without changing the orchestrator surface.
+ */
+
+// ---------------------------------------------------------------------------
+// Constants — worst-case cost ceilings
+// ---------------------------------------------------------------------------
+
+/**
+ * Rough USD-per-call ceiling across the model tiers we route to.
+ *
+ * Numbers are deliberately over-stated — we'd rather deny a borderline
+ * review than blow past a billing cap. Reconciled monthly from the AI
+ * Gateway dashboard; the D.4 billing module replaces this with live data.
+ *
+ * Picking the max(model) across the roles array keeps the math local — we
+ * don't need per-pass attribution for the estimate, only for billing
+ * reconciliation later.
+ */
+const MODEL_CEILING_USD: Record<string, number> = {
+  'anthropic/claude-haiku-4.5': 0.02,
+  'anthropic/claude-sonnet-4.6': 0.08,
+  'anthropic/claude-opus-4.6': 0.4,
+  'anthropic/claude-opus-4.7': 0.5,
+  'openai/gpt-5': 0.4,
+  'openai/gpt-5.2': 0.04,
+  'google/gemini-3-flash': 0.02,
+  'google/gemini-3.1-pro-preview': 0.3,
+};
+
+/** Fallback ceiling for unknown model slugs. Conservative. */
+const DEFAULT_PER_CALL_USD = 0.5;
+
+/**
+ * Default per-PR cap. Real number lives in `env.REVIEW_SPEND_CAP_USD` once
+ * D.4 wires that env var — for now this is the hard-coded ceiling.
+ *
+ * $5 = a 3-pass review across 10 expensive skills (~30 calls × $0.15 avg).
+ * Anything above that is almost certainly a misconfigured `reviewPasses`.
+ */
+export const DEFAULT_PER_PR_CAP_USD = 5.0;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface BudgetEstimateInput {
+  /** Resolved per-skill config — one entry per skill in the catalog. */
+  resolved: ResolvedReviewPasses[];
+  /** Model slugs the orchestrator plans to route to, in pass order. */
+  roleModels: string[];
+  /**
+   * Optional per-PR USD cap override. Defaults to `DEFAULT_PER_PR_CAP_USD`.
+   * D.4 wires per-install caps via `INSTALLS:{id}.spend_cap_usd`.
+   */
+  perPrCapUsd?: number;
+  /**
+   * Installation flag — `billing === 'exempt'` orgs bypass the cap entirely.
+   * D.4 reads this from the install record. For D.2.5, the orchestrator
+   * passes the env-allowlist result here.
+   */
+  billingExempt?: boolean;
+}
+
+export interface BudgetEstimate {
+  /** Total AI calls = sum(skill_count × pass_count). */
+  estimatedCalls: number;
+  /** Worst-case cost in USD across all planned calls. */
+  estimatedCostUsd: number;
+  /** Per-call ceiling used (max across the role models). */
+  perCallCeilingUsd: number;
+  /** The cap the estimate was checked against. */
+  capUsd: number;
+}
+
+export type BudgetVerdict =
+  | {
+      verdict: 'allow';
+      estimate: BudgetEstimate;
+    }
+  | {
+      verdict: 'deny';
+      estimate: BudgetEstimate;
+      /** Friendly reason for the orchestrator's "we paused this review" comment. */
+      reason: string;
+    };
+
+// ---------------------------------------------------------------------------
+// Estimator
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the per-call USD ceiling — max across the role models.
+ */
+export function perCallCeiling(models: string[]): number {
+  if (models.length === 0) return DEFAULT_PER_CALL_USD;
+  let max = 0;
+  for (const m of models) {
+    const c = MODEL_CEILING_USD[m] ?? DEFAULT_PER_CALL_USD;
+    if (c > max) max = c;
+  }
+  return max;
+}
+
+/**
+ * Layer-1 cost gate. Decides whether the planned passes fit under the cap.
+ *
+ * Behavior matrix:
+ *   billingExempt = true             → allow (skip cap entirely)
+ *   estimatedCostUsd > cap           → deny + friendly reason
+ *   estimatedCostUsd <= cap          → allow
+ *   resolved.length === 0            → allow (single-pass D.2.0 path)
+ *
+ * Until D.4 wires real per-install spending, callers see allow on every
+ * normal path — the deny branch only fires on truly absurd estimates.
+ */
+export function estimateBudget(input: BudgetEstimateInput): BudgetVerdict {
+  const cap = input.perPrCapUsd ?? DEFAULT_PER_PR_CAP_USD;
+  const ceiling = perCallCeiling(input.roleModels);
+  // The orchestrator (runMultiPass) sends all skills in a SINGLE prompt
+  // each pass and loops only the max skill's count times. Real call count
+  // is max(counts), not sum(counts). Summing over-estimates linearly with
+  // catalog size, making multi-pass unreachable for medium+ skill sets.
+  const calls = input.resolved.length === 0
+    ? 0
+    : input.resolved.reduce((max, r) => Math.max(max, r.count), 0);
+  const cost = calls * ceiling;
+
+  const estimate: BudgetEstimate = {
+    estimatedCalls: calls,
+    estimatedCostUsd: cost,
+    perCallCeilingUsd: ceiling,
+    capUsd: cap,
+  };
+
+  if (input.billingExempt) {
+    return { verdict: 'allow', estimate };
+  }
+  if (cost > cap) {
+    return {
+      verdict: 'deny',
+      estimate,
+      reason: friendlyDenyReason({ cost, cap, calls, ceiling }),
+    };
+  }
+  return { verdict: 'allow', estimate };
+}
+
+function friendlyDenyReason(args: {
+  cost: number;
+  cap: number;
+  calls: number;
+  ceiling: number;
+}): string {
+  return [
+    `clud-bug paused this review — estimated cost \`$${args.cost.toFixed(2)}\``,
+    `exceeds the per-PR cap of \`$${args.cap.toFixed(2)}\`.`,
+    `(${args.calls} planned AI call${args.calls === 1 ? '' : 's'} ×`,
+    `worst-case \`$${args.ceiling.toFixed(2)}\` per call.)`,
+    'Lower `reviewPasses.count` in `.claude/skills/.clud-bug.json` and re-trigger.',
+  ].join(' ');
+}
+
+/**
+ * Exposed for tests + future D.4 wiring. Lets callers register a cost
+ * ceiling for a newly-routed model without editing this module.
+ */
+export function __setModelCeilingForTests(
+  model: string,
+  usd: number | null,
+): void {
+  if (usd === null) {
+    delete MODEL_CEILING_USD[model];
+    return;
+  }
+  MODEL_CEILING_USD[model] = usd;
+}
+
+// ---------------------------------------------------------------------------
+// D.2.6 — auto-resolve verifier cost surface
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-call ceiling for the D.2.6 fix-verifier. Each verifier call is small —
+ * ~500 token I/O at Sonnet rates — so a more aggressive ceiling makes sense
+ * vs the main-review per-call ceiling. We over-state by ~2x to keep the
+ * "$0.10 per PR with 5 findings × 3 fix-pushes" plan budget honest.
+ *
+ * Sonnet 4.6 at $3/$15 per million tokens × 500 token I/O ≈ $0.005;
+ * we use $0.01 as the gate ceiling so a borderline-overbudget verifier doesn't
+ * silently silently flip the install over the cap.
+ */
+const VERIFIER_PER_CALL_CEILING_USD = 0.01;
+
+/**
+ * Default per-PR budget for D.2.6 verifier calls. The spec calls $0.10 the
+ * "5 findings × 3 fix-pushes" ceiling; we use 2x that as the cap so a
+ * sufficiently-large PR (20 threads × 3 fix-pushes = 60 calls) still fits.
+ *
+ * D.4 will plumb per-install caps; for D.2.6 we use a single repo-wide
+ * default. Installs in BILLING_EXEMPT_ORGS bypass this entirely.
+ */
+export const DEFAULT_VERIFIER_PER_PR_CAP_USD = 0.6;
+
+export interface VerifierBudgetInput {
+  /** Number of open threads we plan to verify on this fix-push. */
+  threadCount: number;
+  /**
+   * Pass count from D.2.5 multi-pass — we call the verifier once per pass
+   * per thread (see resolve-verifier integration doc). Defaults to 1
+   * for single-pass installs.
+   */
+  passesPerThread?: number;
+  /**
+   * Optional per-PR cap override. Defaults to DEFAULT_VERIFIER_PER_PR_CAP_USD.
+   */
+  perPrCapUsd?: number;
+  /** BILLING_EXEMPT installs bypass the cap. */
+  billingExempt?: boolean;
+}
+
+export interface VerifierBudgetEstimate {
+  /** Total verifier AI calls = threadCount × passesPerThread. */
+  estimatedCalls: number;
+  /** Worst-case cost. */
+  estimatedCostUsd: number;
+  /** Per-call ceiling used. */
+  perCallCeilingUsd: number;
+  /** Cap checked against. */
+  capUsd: number;
+}
+
+export type VerifierBudgetVerdict =
+  | { verdict: 'allow'; estimate: VerifierBudgetEstimate }
+  | {
+      verdict: 'deny';
+      estimate: VerifierBudgetEstimate;
+      /** Friendly reason for the orchestrator's "skipped: verifier-budget" log. */
+      reason: string;
+    };
+
+/**
+ * Pre-flight gate for the D.2.6 fix-verifier. Called once per fix-push,
+ * BEFORE any verifier call runs. If denied, the orchestrator emits
+ * `skipped: budget` for the entire auto-resolve cycle and routes the
+ * threads through the heuristic fallback (see auto-resolve).
+ *
+ * Behavior:
+ *   billingExempt = true  → allow (bypass cap)
+ *   estimated > cap       → deny
+ *   threadCount === 0     → allow with 0 calls (no-op fix-push, no threads to verify)
+ *   otherwise             → allow
+ */
+export function estimateVerifierBudget(
+  input: VerifierBudgetInput,
+): VerifierBudgetVerdict {
+  const cap = input.perPrCapUsd ?? DEFAULT_VERIFIER_PER_PR_CAP_USD;
+  const passes = input.passesPerThread ?? 1;
+  const calls = input.threadCount * Math.max(1, passes);
+  const cost = calls * VERIFIER_PER_CALL_CEILING_USD;
+
+  const estimate: VerifierBudgetEstimate = {
+    estimatedCalls: calls,
+    estimatedCostUsd: cost,
+    perCallCeilingUsd: VERIFIER_PER_CALL_CEILING_USD,
+    capUsd: cap,
+  };
+
+  if (input.billingExempt) {
+    return { verdict: 'allow', estimate };
+  }
+  if (cost > cap) {
+    return {
+      verdict: 'deny',
+      estimate,
+      reason: friendlyVerifierDenyReason({ cost, cap, calls }),
+    };
+  }
+  return { verdict: 'allow', estimate };
+}
+
+function friendlyVerifierDenyReason(args: {
+  cost: number;
+  cap: number;
+  calls: number;
+}): string {
+  return [
+    `clud-bug paused D.2.6 fix-verification — estimated cost`,
+    `\`$${args.cost.toFixed(2)}\` exceeds the per-PR cap of`,
+    `\`$${args.cap.toFixed(2)}\`. (${args.calls} planned verifier call${args.calls === 1 ? '' : 's'} ×`,
+    `worst-case \`$${VERIFIER_PER_CALL_CEILING_USD.toFixed(2)}\` per call.)`,
+    'Lower `autoResolve.max_threads_per_fix_push` in',
+    '`.claude/skills/.clud-bug.json` or set `autoResolve.mode = "heuristic"`',
+    'to opt out of verified-mode for this install.',
+  ].join(' ');
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -119,6 +119,7 @@ export {
   type RenderedFindingRef,
   type CacheStats,
   type RenderMultiPassMarkdownInput,
+  type Consensus,
   type MultiPassReview,
   type UnifiedFinding,
   type PassAttribution,
@@ -216,6 +217,61 @@ export {
   type ApplyCanonicalRulesetParams,
   type ApplyResult,
 } from './configure-github.js';
+// Wave 6b — review-planning "brain" ported from clud-bug-app/lib. Three pure
+// modules: the multi-pass config resolver (`review-plan`), the Layer-1 cost
+// gate (`budget-plan`), and the multi-pass aggregator (`multi-pass-aggregate`).
+//
+// `ReviewPassMode` is intentionally NOT re-exported here — `review-writeback`
+// above already owns that name in the barrel (both declarations are the same
+// `'cross-check' | 'consensus' | 'independent'` union). Likewise the
+// aggregator's result types (`MultiPassReview`, `UnifiedFinding`,
+// `PassAttribution`, `PassSource`) come from `review-writeback` and are NOT
+// re-declared by the aggregator module — it imports them.
+export {
+  readReviewPassesConfig,
+  extractSkillReviewPassesOverride,
+  resolveReviewPasses,
+  roleForPass,
+  anyMultiPass,
+  totalPassCount,
+  REVIEW_PASS_MODES,
+  MAX_PASSES,
+  MIN_PASSES,
+  BUILTIN_DEFAULT,
+  BUILTIN_ROLES,
+  type ApplyTo,
+  type ReviewPassesEntry,
+  type ReviewRoleTier,
+  type ReviewRole,
+  type ResolvedReviewPasses,
+  type ReviewPassesConfig,
+  type SkillReviewPassesFrontmatter,
+  type ReviewPlanSkill,
+  type ResolveReviewPassesInput,
+  type ResolveReviewPassesResult,
+} from './review-plan.js';
+export {
+  perCallCeiling,
+  estimateBudget,
+  estimateVerifierBudget,
+  __setModelCeilingForTests,
+  DEFAULT_PER_PR_CAP_USD,
+  DEFAULT_VERIFIER_PER_PR_CAP_USD,
+  type BudgetEstimateInput,
+  type BudgetEstimate,
+  type BudgetVerdict,
+  type VerifierBudgetInput,
+  type VerifierBudgetEstimate,
+  type VerifierBudgetVerdict,
+} from './budget-plan.js';
+export {
+  aggregatePasses,
+  deriveConsensus,
+  resolveVerdict,
+  type CrossCheckVerdict,
+  type CrossCheckPassResult,
+  type AggregateInput,
+} from './multi-pass-aggregate.js';
 export {
   API_BASE,
   MAX_SKILLS,

--- a/src/core/multi-pass-aggregate.ts
+++ b/src/core/multi-pass-aggregate.ts
@@ -1,0 +1,545 @@
+import type { ReviewRole } from './review-plan.js';
+import {
+  flattenFindings,
+  type Finding,
+  type Review,
+  type Severity,
+} from './review-schema-zod.js';
+import type {
+  Consensus,
+  MultiPassReview,
+  PassAttribution,
+  PassSource,
+  ReviewPassMode,
+  UnifiedFinding,
+} from './review-writeback.js';
+
+/**
+ * Multi-pass aggregator.
+ *
+ * Takes N passes' review outputs + the active mode + the role definitions
+ * and produces a single unified `MultiPassReview` payload the renderer can
+ * format with per-pass attribution inline.
+ *
+ * The three modes are NOT interchangeable in their output shape — see the
+ * per-mode comments below.
+ *
+ * Design discipline:
+ *   - Pure function. No I/O, no AI calls. Input = N validated reviews +
+ *     metadata; output = aggregated findings list.
+ *   - Order-stable. The renderer needs a deterministic finding order so the
+ *     comment is stable across re-reviews (matters for thread continuity in
+ *     D.2.6). We preserve Pass 1's order, then append later-pass findings.
+ *   - Match semantics live here. Two findings are "the same" if their
+ *     (file, line, skill) tuple matches. Summaries diverge stylistically
+ *     between passes; key matching on summary is too brittle.
+ *   - Resolution rules:
+ *       cross-check   → Pass 2 explicitly classified Pass-1 findings as
+ *                       agreed/disagreed via the cross-check schema; we use
+ *                       its verdict verbatim.
+ *       consensus     → Pass 2 ran independent. Same-tuple findings across
+ *                       passes are marked `agreed`; tuple-unique findings are
+ *                       attributed to their pass with provenance.
+ *       independent   → No merging. We emit a flat list with one entry per
+ *                       (pass, finding) — the renderer formats them as a
+ *                       side-by-side review block.
+ *
+ * The orchestrator owns the AI call orchestration upstream. This module just
+ * deals with shapes — call it once per skill (or once per shared bundle).
+ *
+ * Ported from clud-bug-app/lib/multi-pass-aggregator.ts. The result types
+ * (`MultiPassReview`, `UnifiedFinding`, `PassAttribution`, `PassSource`,
+ * `ReviewPassMode`) live in `./review-writeback.ts` and are imported here so
+ * core has a single declaration for each. The aggregator-internal contracts
+ * (`PassSource` is shared; `Consensus`, `CrossCheckVerdict`,
+ * `CrossCheckPassResult`, `AggregateInput`) are defined below.
+ */
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+// `Consensus` (the SPEC §6.10.1 marker) is defined in `./review-writeback.ts`
+// alongside `UnifiedFinding` and imported above — core keeps a single
+// declaration so it rides on `MultiPassReview.findings[].consensus`.
+
+/**
+ * Derive the SPEC §6.10.1 consensus marker from a finding's per-pass
+ * attribution list. Mapping rules:
+ *
+ *   - any source === 'agreed'    → '2-of-2' (consensus reached)
+ *   - any source === 'disagreed' → 'arbitrated' (cross-check produced
+ *     active dissent; the finding still made it through, which is the
+ *     arbitration outcome we model today — see Consensus type doc)
+ *   - otherwise (just 'first' / 'independent') → '1-of-N' (single-pass)
+ *
+ * Priority order: agreed > disagreed > default. If a finding has BOTH
+ * an `agreed` and a `disagreed` attribution (e.g., 3-pass setup with
+ * Pass 2 agreed + Pass 3 disagreed), `agreed` wins — at least one pass
+ * cross-validated the finding, so the gate has consensus.
+ */
+export function deriveConsensus(attributions: PassAttribution[]): Consensus {
+  let sawDisagreed = false;
+  for (const a of attributions) {
+    if (a.source === 'agreed') return '2-of-2';
+    if (a.source === 'disagreed') sawDisagreed = true;
+  }
+  return sawDisagreed ? 'arbitrated' : '1-of-N';
+}
+
+// (Removed `UnifiedFindingWithConsensus`: core's `UnifiedFinding` now carries
+// the optional `consensus` field directly — see `./review-writeback.ts` — so
+// `finalize()` returns `UnifiedFinding[]` and `aggregatePasses(...).findings[i]
+// .consensus` is on the PUBLIC return type, not erased at the boundary.)
+
+// ---------------------------------------------------------------------------
+// Cross-check schema (what Pass 2 returns under mode: cross-check)
+// ---------------------------------------------------------------------------
+
+/**
+ * The cross-check pass returns:
+ *   - One verdict per Pass-1 finding (agreed / disagreed + rationale).
+ *   - A list of independently-discovered findings (same shape as Finding).
+ *
+ * We define the response shape here (not in review-schema-zod.ts) because
+ * it's an aggregator-internal contract. The orchestrator uses
+ * `crossCheckSchema` (from review-schema-zod) for the AI call output type.
+ */
+export interface CrossCheckVerdict {
+  /** 0-indexed reference to the Pass-1 finding being judged. */
+  pass1Index: number;
+  /** Pass 2's verdict. */
+  verdict: 'agreed' | 'disagreed';
+  /** One-line rationale shown inline. Optional but recommended. */
+  rationale?: string;
+}
+
+export interface CrossCheckPassResult {
+  /** Per-Pass-1-finding judgements. */
+  verdicts: CrossCheckVerdict[];
+  /** Newly-discovered findings, independent of Pass 1's list. */
+  independentFindings: Finding[];
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation entry point
+// ---------------------------------------------------------------------------
+
+export interface AggregateInput {
+  /** Mode driving the merge. */
+  mode: ReviewPassMode;
+  /** Pass 1's review. Required — at minimum we need one pass. */
+  firstPass: Review;
+  /**
+   * Subsequent passes. Shape depends on mode:
+   *   - cross-check: each entry has `crossCheck` populated; `review` may be
+   *     omitted (the cross-check pass doesn't produce a full review object).
+   *   - consensus / independent: each entry has `review` populated; the
+   *     `crossCheck` field is ignored.
+   */
+  subsequentPasses: Array<{
+    /** 1-indexed pass number, starting at 2. */
+    passNumber: number;
+    /** Role label + model used. */
+    role: ReviewRole;
+    /** Cross-check response (only valid when mode === 'cross-check'). */
+    crossCheck?: CrossCheckPassResult;
+    /** Full review (for consensus / independent modes). */
+    review?: Review;
+  }>;
+  /** Role assigned to Pass 1 — needed for attribution headers. */
+  firstPassRole: ReviewRole;
+}
+
+/**
+ * Merges the per-pass results into a single MultiPassReview.
+ */
+export function aggregatePasses(input: AggregateInput): MultiPassReview {
+  switch (input.mode) {
+    case 'cross-check':
+      return aggregateCrossCheck(input);
+    case 'consensus':
+      return aggregateConsensus(input);
+    case 'independent':
+      return aggregateIndependent(input);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mode: cross-check
+// ---------------------------------------------------------------------------
+
+/**
+ * Cross-check: Pass 2 saw Pass 1's findings + the diff. Each Pass-1 finding
+ * gets a per-pass-2 verdict; Pass 2's independent findings are appended.
+ *
+ * Output order:
+ *   1. Pass-1 findings in original order, each with their pass-2 verdict
+ *      attribution attached (one PassAttribution for Pass 1, one for Pass 2
+ *      if applicable, etc.).
+ *   2. Pass-2 (and beyond) independent findings, in pass order.
+ */
+function aggregateCrossCheck(input: AggregateInput): MultiPassReview {
+  const findings: UnifiedFinding[] = [];
+  const firstRoleAttribution = (
+    _f: Finding,
+    source: PassSource = 'first',
+  ): PassAttribution => ({
+    passNumber: 1,
+    roleName: input.firstPassRole.name,
+    model: input.firstPassRole.model,
+    source,
+  });
+
+  // Initialize the unified list with Pass 1's findings. Wire-shape Review
+  // splits findings across 3 severity arrays; flatten to internal Finding[].
+  for (const f of flattenFindings(input.firstPass)) {
+    findings.push({
+      ...f,
+      attributions: [firstRoleAttribution(f)],
+    });
+  }
+
+  // Layer in each subsequent pass's verdicts + independent findings.
+  for (const pass of input.subsequentPasses) {
+    if (!pass.crossCheck) continue; // mis-configured input; skip cleanly
+    // 1. Verdicts on Pass-1 findings — attach a PassAttribution per verdict.
+    for (const v of pass.crossCheck.verdicts) {
+      const target = findings[v.pass1Index];
+      if (!target) continue; // out-of-range index — ignore
+      target.attributions.push({
+        passNumber: pass.passNumber,
+        roleName: pass.role.name,
+        model: pass.role.model,
+        source: v.verdict,
+        // exactOptionalPropertyTypes: omit `note` entirely when the pass
+        // supplied no rationale (vs. setting it to `undefined`). Behavior is
+        // identical for every consumer (renderer/tests read `note` only when
+        // present); the App relied on a looser tsconfig where `note:
+        // undefined` was allowed.
+        ...(v.rationale !== undefined ? { note: v.rationale } : {}),
+      });
+    }
+    // 2. Independent findings — append with provenance.
+    for (const f of pass.crossCheck.independentFindings) {
+      findings.push({
+        ...f,
+        attributions: [
+          {
+            passNumber: pass.passNumber,
+            roleName: pass.role.name,
+            model: pass.role.model,
+            source: 'independent',
+          },
+        ],
+      });
+    }
+  }
+
+  return finalize({
+    mode: 'cross-check',
+    findings,
+    firstPassRole: input.firstPassRole,
+    subsequentPasses: input.subsequentPasses,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mode: consensus
+// ---------------------------------------------------------------------------
+
+/**
+ * Consensus: every pass ran fully independent of the others. We diff the
+ * passes pairwise and label same-tuple findings as `agreed` (intersection)
+ * and tuple-unique findings as `first` / `independent` per pass.
+ *
+ * Output order:
+ *   1. Pass 1's findings in original order (each enriched with `agreed`
+ *      attributions if other passes also raised the same tuple).
+ *   2. Tuple-unique findings from later passes, in pass-number order.
+ */
+function aggregateConsensus(input: AggregateInput): MultiPassReview {
+  const findings: UnifiedFinding[] = [];
+
+  // Index Pass 1's findings by tuple → list index.
+  const tupleToIndex = new Map<string, number>();
+  flattenFindings(input.firstPass).forEach((f, i) => {
+    findings.push({
+      ...f,
+      attributions: [
+        {
+          passNumber: 1,
+          roleName: input.firstPassRole.name,
+          model: input.firstPassRole.model,
+          source: 'first',
+        },
+      ],
+    });
+    tupleToIndex.set(tupleKey(f), i);
+  });
+
+  for (const pass of input.subsequentPasses) {
+    if (!pass.review) continue;
+    for (const f of flattenFindings(pass.review)) {
+      const key = tupleKey(f);
+      const existingIndex = tupleToIndex.get(key);
+      if (existingIndex !== undefined) {
+        // Same-tuple match → consensus. Append an "agreed" attribution.
+        const target = findings[existingIndex];
+        if (!target) continue;
+        target.attributions.push({
+          passNumber: pass.passNumber,
+          roleName: pass.role.name,
+          model: pass.role.model,
+          source: 'agreed',
+        });
+        // Promote severity if this pass flagged it higher (e.g. Pass 1 minor,
+        // Pass 2 critical — we keep the more conservative critical).
+        if (severityRank(f.severity) > severityRank(target.severity)) {
+          target.severity = f.severity;
+        }
+      } else {
+        // New tuple — append + index for future passes.
+        const newIdx = findings.length;
+        findings.push({
+          ...f,
+          attributions: [
+            {
+              passNumber: pass.passNumber,
+              roleName: pass.role.name,
+              model: pass.role.model,
+              source: 'independent',
+            },
+          ],
+        });
+        tupleToIndex.set(key, newIdx);
+      }
+    }
+  }
+
+  return finalize({
+    mode: 'consensus',
+    findings,
+    firstPassRole: input.firstPassRole,
+    subsequentPasses: input.subsequentPasses,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mode: independent
+// ---------------------------------------------------------------------------
+
+/**
+ * Independent: no merging. Every finding from every pass is emitted with
+ * `source: 'first'` (Pass 1) or `source: 'independent'` (Pass N > 1). The
+ * renderer is responsible for formatting as side-by-side blocks.
+ *
+ * Output order: Pass 1's findings, then Pass 2's, then Pass 3's — preserving
+ * each pass's internal order.
+ */
+function aggregateIndependent(input: AggregateInput): MultiPassReview {
+  const findings: UnifiedFinding[] = [];
+  for (const f of flattenFindings(input.firstPass)) {
+    findings.push({
+      ...f,
+      attributions: [
+        {
+          passNumber: 1,
+          roleName: input.firstPassRole.name,
+          model: input.firstPassRole.model,
+          source: 'first',
+        },
+      ],
+    });
+  }
+  for (const pass of input.subsequentPasses) {
+    if (!pass.review) continue;
+    for (const f of flattenFindings(pass.review)) {
+      findings.push({
+        ...f,
+        attributions: [
+          {
+            passNumber: pass.passNumber,
+            roleName: pass.role.name,
+            model: pass.role.model,
+            source: 'independent',
+          },
+        ],
+      });
+    }
+  }
+  return finalize({
+    mode: 'independent',
+    findings,
+    firstPassRole: input.firstPassRole,
+    subsequentPasses: input.subsequentPasses,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Tuple-key used to detect "same finding" across passes.
+ *
+ * We key on (file, line, skill) instead of summary because:
+ *   - Summaries vary stylistically between passes (Sonnet vs Opus phrasing).
+ *   - File + line + cited skill is the SPEC §1.8.1 minimum identity unit.
+ *   - File-level findings (no line) collapse to the same tuple regardless of
+ *     phrasing, which is the desired consensus semantic.
+ */
+function tupleKey(f: Finding): string {
+  return `${f.file}::${f.line ?? '*'}::${f.skill}`;
+}
+
+function severityRank(s: Severity): number {
+  switch (s) {
+    case 'critical':
+      return 3;
+    case 'minor':
+      return 2;
+    case 'preexisting':
+      return 1;
+  }
+}
+
+interface FinalizeInput {
+  mode: ReviewPassMode;
+  /**
+   * Pre-consensus shape — aggregators build these without populating
+   * the `consensus` field; `finalize()` is the single derivation point
+   * via `deriveConsensus(attributions)`. Keeping aggregators free of
+   * the consensus concern avoids drift between cross-check / consensus
+   * / independent paths (one mapping rule, three call sites).
+   */
+  findings: UnifiedFinding[];
+  firstPassRole: ReviewRole;
+  subsequentPasses: AggregateInput['subsequentPasses'];
+}
+
+function finalize(input: FinalizeInput): MultiPassReview {
+  const passCount = 1 + input.subsequentPasses.length;
+  const roles = [
+    {
+      passNumber: 1,
+      roleName: input.firstPassRole.name,
+      model: input.firstPassRole.model,
+    },
+    ...input.subsequentPasses.map((p) => ({
+      passNumber: p.passNumber,
+      roleName: p.role.name,
+      model: p.role.model,
+    })),
+  ];
+
+  // SPEC §6.10.1 consensus marker — single derivation point.
+  // Aggregators emit findings without `consensus`; this map adds it
+  // from the accumulated per-pass attributions. Renderer + auto-fix
+  // gate both consume `finding.consensus` downstream.
+  const findingsWithConsensus: UnifiedFinding[] = input.findings.map(
+    (f) => ({
+      ...f,
+      consensus: deriveConsensus(f.attributions),
+    }),
+  );
+
+  // Derive summary counts + skills_referenced from the aggregated list.
+  const counts = {
+    critical: findingsWithConsensus.filter((f) => f.severity === 'critical').length,
+    minor: findingsWithConsensus.filter((f) => f.severity === 'minor').length,
+    preexisting: findingsWithConsensus.filter((f) => f.severity === 'preexisting')
+      .length,
+    resolved_from_prior: 0,
+    still_open: 0,
+  };
+  const skillsReferenced = uniqInOrder(findingsWithConsensus.map((f) => f.skill));
+
+  // Status header logic:
+  //  - empty → "clean"
+  //  - any critical → "critical findings"
+  //  - else → "clean" (minor + preexisting alone don't headline as critical)
+  const status_header =
+    counts.critical > 0
+      ? ('critical findings' as const)
+      : ('clean' as const);
+
+  // Verdict resolution — see resolveVerdict for the per-mode rules.
+  const verdict = resolveVerdict(input.mode, findingsWithConsensus, passCount);
+
+  return {
+    status_header,
+    summary_counts: counts,
+    skills_referenced: skillsReferenced,
+    findings: findingsWithConsensus,
+    mode: input.mode,
+    passCount,
+    roles,
+    verdict,
+  };
+}
+
+function uniqInOrder(items: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const it of items) {
+    if (seen.has(it)) continue;
+    seen.add(it);
+    out.push(it);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Verdict resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves the APPROVE / REQUEST_CHANGES verdict per the SPEC §1.8.5 table:
+ *
+ *   mode          | request_changes when…
+ *   --------------+------------------------------------------------------
+ *   strict (=cross-check default) | ANY pass flagged critical
+ *   consensus     | ≥2 passes flagged the same critical tuple
+ *   independent   | findings side-by-side — human decides per finding.
+ *                 | For automation purposes we treat ANY critical as
+ *                 | request_changes (safer default; humans can downgrade).
+ *
+ * We expose this both as a return field on `MultiPassReview.verdict` and
+ * separately (for tests + future D.2 wiring) as `resolveVerdict`.
+ *
+ * NOTE: The broader D.2 phase wires APPROVE/REQUEST_CHANGES into actual
+ * PR check states. D.2.5 only computes the verdict — surfacing it is left
+ * to the renderer (which prefixes the header line with the verdict label).
+ */
+export function resolveVerdict(
+  mode: ReviewPassMode,
+  findings: UnifiedFinding[],
+  passCount: number,
+): MultiPassReview['verdict'] {
+  if (findings.length === 0) return 'clean';
+  const criticals = findings.filter((f) => f.severity === 'critical');
+  if (criticals.length === 0) return 'review_only';
+
+  switch (mode) {
+    case 'cross-check':
+    case 'independent':
+      // Strict: any critical → request_changes.
+      return 'request_changes';
+    case 'consensus':
+      // ≥2 passes must agree on the same critical tuple.
+      // Single-pass consensus is degenerate but valid — any critical fires.
+      if (passCount < 2) return 'request_changes';
+      for (const f of criticals) {
+        // Spec: "≥2 passes flagged the same critical tuple."
+        // Each attribution represents exactly one pass, so the correct
+        // count is f.attributions.length. The earlier filter on
+        // `source === 'first' | 'agreed'` silently dropped findings
+        // raised by Pass 2 + confirmed by Pass 3 but missed by Pass 1
+        // (attributions = [independent, agreed], neither matches → the
+        // consensus gate never fired).
+        if (f.attributions.length >= 2) return 'request_changes';
+      }
+      return 'review_only';
+  }
+}

--- a/src/core/review-plan.ts
+++ b/src/core/review-plan.ts
@@ -1,0 +1,485 @@
+import type { SkillFrontmatter } from './skills.js';
+
+/**
+ * Multi-pass review config resolution.
+ *
+ * Each skill carries an effective `{ count, mode }` pair that drives how many
+ * AI calls the reviewer makes for that skill and how the orchestrator
+ * aggregates findings.
+ *
+ * Resolution precedence (highest → lowest):
+ *   1. `.clud-bug.json` `reviewPasses.perSkill[<slug>]`           — per-skill consumer override
+ *   2. SKILL.md frontmatter `review_passes` (parsed from base ref) — skill author intent
+ *   3. `.clud-bug.json` `reviewPasses.default` / top-level fields  — repo default
+ *   4. Hard-coded built-in `{ count: 1, mode: "cross-check" }`     — D.2.5 baseline
+ *
+ * Hard cap: `count` is clamped to `MAX_PASSES = 3`. The plan calls this a
+ * brick wall — there is no escape hatch via config. Anything above gets
+ * silently clamped + logged. Three Claude calls per skill per review is the
+ * outer envelope before cost becomes user-hostile.
+ *
+ * The orchestrator uses the resolved entry to:
+ *   - decide how many passes to run per skill (or per shared-skill bundle when
+ *     `applyTo === "shared-only"`)
+ *   - pass the right role / model to `runStructuredReview`
+ *   - hand the aggregator the right mode
+ *
+ * SKILL.md frontmatter is read by the App's skills loader. We don't bake the
+ * parsing into the loader to keep that module simple — instead, the loader
+ * surfaces `frontmatter.review_passes` as opaque and we coerce it here. The
+ * loader is unchanged for D.2.5 — it just preserves any `review_passes` block
+ * verbatim through `stripFrontmatter` → body, which we never need to touch.
+ *
+ * NOTE: The loader currently only validates well-known fields. SKILL.md
+ * `review_passes` arrives via a NEW frontmatter pass we expose here as
+ * `extractSkillReviewPassesOverride` — the loader's `parseFrontmatter` doesn't
+ * preserve unknown top-level keys, but this helper re-parses the raw
+ * frontmatter on the side, so D.2.5 is additive (no breaking change to
+ * D.2.0 callers / tests).
+ *
+ * Decoupled from the App's `LoadedSkill` on the port to `clud-bug/core`:
+ * `resolveReviewPasses` accepts the minimal `{ slug, frontmatter }` shape
+ * (where `frontmatter` is the core `SkillFrontmatter`) so the engine has no
+ * dependency on the App's skills loader.
+ */
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** The three review modes. See module doc for semantics. */
+export type ReviewPassMode = 'cross-check' | 'consensus' | 'independent';
+
+export const REVIEW_PASS_MODES: readonly ReviewPassMode[] = [
+  'cross-check',
+  'consensus',
+  'independent',
+] as const;
+
+/** Apply scope. `shared-only` restricts multi-pass to shared (default) skills. */
+export type ApplyTo = 'all' | 'shared-only';
+
+/** The smallest config unit per skill. */
+export interface ReviewPassesEntry {
+  /** Number of independent passes (1..MAX_PASSES). Always positive. */
+  count: number;
+  /** Aggregation mode. Only meaningful when count >= 2. */
+  mode: ReviewPassMode;
+}
+
+/**
+ * Reviewer-role tier abstraction. The orchestrator keys on the tier (not the
+ * display `name`) when it needs to reason about reviewer strength
+ * independent of the human-facing label:
+ *   - `beetle`  → fast first-pass reviewer (Sonnet-class).
+ *   - `wasp`    → deeper cross-check / consensus reviewer (Opus-class).
+ *   - `mantis`  → arbiter / third-pass reviewer (Opus-class).
+ *
+ * `name` + `model` stay for back-compat (inline attribution + AI-Gateway
+ * routing); `tier` is additive and optional so config-supplied roles that
+ * omit it still validate.
+ */
+export type ReviewRoleTier = 'beetle' | 'wasp' | 'mantis';
+
+/** One role definition; pairs a label ("Beetle") with a model slug. */
+export interface ReviewRole {
+  /** Display name. Surfaced inline in the comment per the spec. */
+  name: string;
+  /** AI Gateway model slug, e.g. `anthropic/claude-sonnet-4.6`. */
+  model: string;
+  /** Optional reviewer tier. See ReviewRoleTier. */
+  tier?: ReviewRoleTier;
+}
+
+/** Full resolved per-skill config exposed to the orchestrator. */
+export interface ResolvedReviewPasses {
+  /** The skill slug this entry applies to. */
+  slug: string;
+  /** Number of passes to run for this skill. Always >= 1. */
+  count: number;
+  /** Aggregation mode. */
+  mode: ReviewPassMode;
+  /** Roles, in pass order. May have fewer entries than `count`; we recycle. */
+  roles: ReviewRole[];
+  /**
+   * Provenance — which precedence layer produced the chosen count.
+   * Useful in tests + logs to verify the precedence chain.
+   */
+  source:
+    | 'perSkill'
+    | 'frontmatter'
+    | 'repoDefault'
+    | 'builtin';
+}
+
+/**
+ * Shape of `reviewPasses` in `.clud-bug.json`.
+ *
+ * We accept two layouts (per the plan):
+ *
+ *   // (A) flat — repo-wide single setting
+ *   "reviewPasses": {
+ *     "count": 2,
+ *     "mode": "cross-check",
+ *     "applyTo": "all",
+ *     "roles": [{ "name": "Beetle", "model": "..." }]
+ *   }
+ *
+ *   // (B) split — default + perSkill overrides
+ *   "reviewPasses": {
+ *     "default": { "count": 1, "mode": "cross-check" },
+ *     "perSkill": { "security-audit": { "count": 3 } },
+ *     "roles": [...]
+ *   }
+ *
+ * (B) supersedes (A) when both are present; the flat keys are read as the
+ * `default` block. Roles are read from the outer object regardless.
+ */
+export interface ReviewPassesConfig {
+  count?: number;
+  mode?: ReviewPassMode;
+  applyTo?: ApplyTo;
+  roles?: ReviewRole[];
+  default?: Partial<ReviewPassesEntry>;
+  perSkill?: Record<string, Partial<ReviewPassesEntry>>;
+}
+
+/** Frontmatter shape (subset) — only the bit D.2.5 cares about. */
+export interface SkillReviewPassesFrontmatter {
+  count?: number;
+  mode?: ReviewPassMode;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Hard cap, enforced silently. Plan: count > 3 is brand-damaging cost. */
+export const MAX_PASSES = 3;
+
+/** Floor, enforced silently. Negative / zero / non-integer collapses to 1. */
+export const MIN_PASSES = 1;
+
+/** Built-in defaults — pre-config bottom of the precedence stack. */
+export const BUILTIN_DEFAULT: ReviewPassesEntry = {
+  count: 1,
+  mode: 'cross-check',
+};
+
+/** Built-in roles, in order. Used when config omits the `roles` array. */
+export const BUILTIN_ROLES: ReviewRole[] = [
+  { name: 'Beetle', model: 'anthropic/claude-sonnet-4.6', tier: 'beetle' },
+  { name: 'Wasp', model: 'anthropic/claude-opus-4.7', tier: 'wasp' },
+  { name: 'Mantis', model: 'anthropic/claude-opus-4.7', tier: 'mantis' },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Clamp a `count` to `[MIN_PASSES, MAX_PASSES]`. NaN / negative → MIN. */
+function clampCount(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return MIN_PASSES;
+  const truncated = Math.trunc(raw);
+  if (truncated < MIN_PASSES) return MIN_PASSES;
+  if (truncated > MAX_PASSES) return MAX_PASSES;
+  return truncated;
+}
+
+/** Returns the input mode if valid, else undefined. */
+function asMode(raw: unknown): ReviewPassMode | undefined {
+  if (typeof raw !== 'string') return undefined;
+  return (REVIEW_PASS_MODES as readonly string[]).includes(raw)
+    ? (raw as ReviewPassMode)
+    : undefined;
+}
+
+/**
+ * Coerces an arbitrary fragment into a partial entry. Unknown fields and
+ * invalid types collapse to `undefined` so downstream merging is honest about
+ * which fields the layer actually supplied.
+ */
+function coerceEntry(raw: unknown): Partial<ReviewPassesEntry> {
+  if (!raw || typeof raw !== 'object') return {};
+  const r = raw as Record<string, unknown>;
+  const out: Partial<ReviewPassesEntry> = {};
+  if (typeof r.count === 'number') {
+    out.count = clampCount(r.count);
+  }
+  const mode = asMode(r.mode);
+  if (mode) out.mode = mode;
+  return out;
+}
+
+/**
+ * Reads top-level `reviewPasses` from a parsed `.clud-bug.json` object.
+ * Tolerates absence + invalid types.
+ */
+export function readReviewPassesConfig(
+  parsedJson: unknown,
+): ReviewPassesConfig | null {
+  if (!parsedJson || typeof parsedJson !== 'object') return null;
+  const root = parsedJson as Record<string, unknown>;
+  const raw = root.reviewPasses;
+  if (!raw || typeof raw !== 'object') return null;
+
+  const obj = raw as Record<string, unknown>;
+  const cfg: ReviewPassesConfig = {};
+
+  if (typeof obj.count === 'number') cfg.count = clampCount(obj.count);
+  const flatMode = asMode(obj.mode);
+  if (flatMode) cfg.mode = flatMode;
+
+  if (obj.applyTo === 'all' || obj.applyTo === 'shared-only') {
+    cfg.applyTo = obj.applyTo;
+  }
+
+  if (Array.isArray(obj.roles)) {
+    cfg.roles = obj.roles
+      .map((entry) => coerceRole(entry))
+      .filter((r): r is ReviewRole => r !== null);
+  }
+
+  if (obj.default && typeof obj.default === 'object') {
+    cfg.default = coerceEntry(obj.default);
+  }
+
+  if (obj.perSkill && typeof obj.perSkill === 'object') {
+    const out: Record<string, Partial<ReviewPassesEntry>> = {};
+    for (const [slug, value] of Object.entries(
+      obj.perSkill as Record<string, unknown>,
+    )) {
+      out[slug] = coerceEntry(value);
+    }
+    cfg.perSkill = out;
+  }
+
+  return cfg;
+}
+
+function coerceRole(raw: unknown): ReviewRole | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.name !== 'string' || typeof r.model !== 'string') return null;
+  if (!r.name.trim() || !r.model.trim()) return null;
+  return { name: r.name.trim(), model: r.model.trim() };
+}
+
+/**
+ * Re-parses raw SKILL.md frontmatter to extract the (optional)
+ * `review_passes` block. Returns null when the block is absent / malformed.
+ *
+ * We can't reuse the App skills-loader's `parseFrontmatter` — it strips
+ * unknown nested keys for security/forward-compat. This helper is scoped to
+ * one block: it tolerates `count` + `mode` inline scalars and nothing else.
+ *
+ * Raw frontmatter is whatever sits between the leading `---\n` and the
+ * matching `---\n` in the SKILL.md file. The caller (orchestrator) already
+ * has the parsed `body`/frontmatter from the skills loader; what we need here
+ * is the RAW source so we can pluck `review_passes` out.
+ */
+export function extractSkillReviewPassesOverride(
+  rawSkillMd: string,
+): SkillReviewPassesFrontmatter | null {
+  const trimmed = rawSkillMd.replace(/^﻿/, '');
+  const match = trimmed.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!match) return null;
+  const block = match[1] ?? '';
+  // We want the `review_passes:` top-level key + its indented children
+  // (count, mode). Anything outside this block is ignored.
+  const lines = block.split(/\r?\n/);
+  let inBlock = false;
+  const out: SkillReviewPassesFrontmatter = {};
+  for (const line of lines) {
+    if (!inBlock) {
+      // Top-level key match: `review_passes:` with no value (block start).
+      if (/^review_passes\s*:\s*$/.test(line)) {
+        inBlock = true;
+      }
+      continue;
+    }
+    // Inside the block: keep going while the line is indented OR blank.
+    if (line.trim() === '') continue;
+    if (!/^\s/.test(line)) {
+      // De-dent → block ended.
+      break;
+    }
+    const inner = line.trim();
+    const colon = inner.indexOf(':');
+    if (colon === -1) continue;
+    const key = inner.slice(0, colon).trim();
+    const value = inner.slice(colon + 1).trim();
+    if (key === 'count') {
+      const n = Number(value);
+      if (Number.isFinite(n)) out.count = clampCount(n);
+    } else if (key === 'mode') {
+      // Strip surrounding quotes.
+      const m = asMode(value.replace(/^['"]|['"]$/g, ''));
+      if (m) out.mode = m;
+    }
+  }
+  // Return null when neither field landed — keeps the precedence resolver's
+  // "frontmatter layer supplied nothing" branch honest.
+  if (out.count === undefined && out.mode === undefined) return null;
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+/** Minimal skill shape the resolver needs — decoupled from the App loader. */
+export interface ReviewPlanSkill {
+  /** Skill slug (catalog identity). */
+  slug: string;
+  /** Parsed SKILL.md frontmatter (core shape). Only `review_mode` is read. */
+  frontmatter: SkillFrontmatter;
+}
+
+export interface ResolveReviewPassesInput {
+  /** Loaded skills, in catalog order. */
+  skills: ReviewPlanSkill[];
+  /**
+   * Raw SKILL.md text per slug (for the frontmatter `review_passes` block).
+   * Optional — when omitted, frontmatter override is treated as absent.
+   * Map key = slug; value = raw SKILL.md including the leading `---` block.
+   */
+  rawSkillMd?: Record<string, string>;
+  /** Parsed `.clud-bug.json` `reviewPasses` block. May be null/empty. */
+  config: ReviewPassesConfig | null;
+}
+
+export interface ResolveReviewPassesResult {
+  /** Resolved entry per skill, in input order. */
+  perSkill: ResolvedReviewPasses[];
+  /**
+   * Effective roles list — falls back to BUILTIN_ROLES when config omits.
+   * The aggregator + writeback use this for inline attribution.
+   */
+  roles: ReviewRole[];
+  /**
+   * `applyTo` scope. When `shared-only`, the orchestrator only multi-passes
+   * skills with `review_mode === 'shared'`. Defaults to `all`.
+   */
+  applyTo: ApplyTo;
+}
+
+/**
+ * Walks the precedence stack and produces an effective `{ count, mode }` per
+ * skill plus the resolved roles + apply scope.
+ *
+ * Pure function; no I/O. The orchestrator handles the actual fetch ordering
+ * upstream (config from the skills loader, raw SKILL.md from a separate fetch
+ * in D.2.5 — the loader returns `body` with frontmatter stripped, so the
+ * orchestrator passes the un-stripped source on the side).
+ */
+export function resolveReviewPasses(
+  input: ResolveReviewPassesInput,
+): ResolveReviewPassesResult {
+  const { skills, rawSkillMd = {}, config } = input;
+
+  // 1. Repo-level default — collapses the two .clud-bug.json layouts.
+  const repoDefault: Partial<ReviewPassesEntry> = (() => {
+    if (!config) return {};
+    const flat: Partial<ReviewPassesEntry> = {};
+    if (config.count !== undefined) flat.count = clampCount(config.count);
+    if (config.mode) flat.mode = config.mode;
+    const explicit = config.default ?? {};
+    // `default` wins over flat — explicit always beats inferred.
+    return { ...flat, ...explicit };
+  })();
+
+  // 2. Roles + applyTo carry over uniformly.
+  const roles =
+    config?.roles && config.roles.length > 0 ? config.roles : BUILTIN_ROLES;
+  const applyTo: ApplyTo = config?.applyTo === 'shared-only' ? 'shared-only' : 'all';
+
+  const perSkill: ResolvedReviewPasses[] = skills.map((skill) => {
+    const fromPerSkill = config?.perSkill?.[skill.slug] ?? {};
+    const fromFrontmatter =
+      rawSkillMd[skill.slug] !== undefined
+        ? extractSkillReviewPassesOverride(rawSkillMd[skill.slug] ?? '') ?? {}
+        : {};
+
+    // 3. shared-only scope clamps non-shared skills to count = 1.
+    //    Apply BEFORE precedence merging so even a perSkill override can't
+    //    re-enable multi-pass for a dedicated skill in shared-only mode.
+    const sharedOnlyClamp: { count?: number } =
+      applyTo === 'shared-only' && skill.frontmatter.review_mode !== 'shared'
+        ? { count: 1 }
+        : {};
+
+    // Precedence: perSkill → frontmatter → repoDefault → builtin
+    const merged: ReviewPassesEntry = {
+      count:
+        sharedOnlyClamp.count ??
+        fromPerSkill.count ??
+        fromFrontmatter.count ??
+        repoDefault.count ??
+        BUILTIN_DEFAULT.count,
+      mode:
+        fromPerSkill.mode ??
+        fromFrontmatter.mode ??
+        repoDefault.mode ??
+        BUILTIN_DEFAULT.mode,
+    };
+
+    // Provenance — which precedence layer SUPPLIED count.
+    const source: ResolvedReviewPasses['source'] =
+      sharedOnlyClamp.count !== undefined
+        ? 'repoDefault' // applyTo lives at the repo layer
+        : fromPerSkill.count !== undefined
+          ? 'perSkill'
+          : fromFrontmatter.count !== undefined
+            ? 'frontmatter'
+            : repoDefault.count !== undefined
+              ? 'repoDefault'
+              : 'builtin';
+
+    return {
+      slug: skill.slug,
+      count: clampCount(merged.count),
+      mode: merged.mode,
+      roles,
+      source,
+    };
+  });
+
+  return { perSkill, roles, applyTo };
+}
+
+/**
+ * Returns the role for a given pass index, recycling when `roles.length` is
+ * smaller than the pass count. Pass 1 → roles[0], pass 2 → roles[1], etc.
+ * Empty roles array → synthesized `Pass N` / requested model fallback.
+ *
+ * The orchestrator calls this for every (skill, passIndex) combination.
+ */
+export function roleForPass(
+  roles: ReviewRole[],
+  passIndex: number,
+  fallbackModel: string,
+): ReviewRole {
+  if (roles.length === 0) {
+    return { name: `Pass ${passIndex + 1}`, model: fallbackModel };
+  }
+  const i = passIndex % roles.length;
+  return roles[i] as ReviewRole;
+}
+
+/**
+ * Truthy when ANY resolved skill needs more than one pass. Used by the
+ * orchestrator to decide whether to invoke the aggregator at all (single-pass
+ * results render via the D.2.0 path verbatim).
+ */
+export function anyMultiPass(resolved: ResolvedReviewPasses[]): boolean {
+  return resolved.some((r) => r.count > 1);
+}
+
+/**
+ * Total pass count across every skill — the cost-gate input. Used by
+ * `./budget-plan.ts`'s Layer-1 estimator.
+ */
+export function totalPassCount(resolved: ResolvedReviewPasses[]): number {
+  return resolved.reduce((sum, r) => sum + r.count, 0);
+}

--- a/src/core/review-writeback.ts
+++ b/src/core/review-writeback.ts
@@ -318,9 +318,30 @@ export interface PassAttribution {
   note?: string;
 }
 
+/**
+ * SPEC §6.10.1 consensus marker, derived from a finding's per-pass attributions
+ * by the aggregator's `deriveConsensus`. Defined here — the canonical home of
+ * the unified-finding shape — so it rides on `MultiPassReview.findings`.
+ *
+ * - `1-of-N` — single pass produced this finding; no consensus reached.
+ *   §6.10.2 MUST NOT fire auto-fix on these.
+ * - `2-of-2` — two passes independently produced an equivalent finding.
+ *   Qualifies for auto-fix per §6.10.2.
+ * - `arbitrated` — passes disagreed; an arbiter resolved the dispute. Today's
+ *   cross-check shape treats `arbitrated` as NOT-qualifying (conservative).
+ */
+export type Consensus = '1-of-N' | '2-of-2' | 'arbitrated';
+
 export interface UnifiedFinding extends Finding {
   /** One PassAttribution per pass involved with this finding. Order: by passNumber. */
   attributions: PassAttribution[];
+  /**
+   * SPEC §6.10.1 consensus verdict. Stamped by the aggregator's `finalize()`
+   * from `deriveConsensus(attributions)`. Optional: single-pass / non-aggregated
+   * findings omit it; consumers treat absence as '1-of-N' (the auto-fix gate
+   * default — see clud-bug-app/lib/auto-fix-policy.ts).
+   */
+  consensus?: Consensus;
 }
 
 /** Effective resolution verdict the multi-pass orchestrator emits. */

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -400,7 +400,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.11
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.12
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -400,7 +400,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.11
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.12
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -704,7 +704,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.11
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.12
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/core/budget-plan.test.js
+++ b/test/core/budget-plan.test.js
@@ -1,0 +1,219 @@
+// Tests for src/core/budget-plan.ts — ported from clud-bug-app's
+// test/budget-gate.test.ts. Behavior pinned identically; only the import
+// path differs. `__setModelCeilingForTests` is exported from budget-plan and
+// the override test path is preserved verbatim.
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  __setModelCeilingForTests,
+  DEFAULT_PER_PR_CAP_USD,
+  DEFAULT_VERIFIER_PER_PR_CAP_USD,
+  estimateBudget,
+  estimateVerifierBudget,
+  perCallCeiling,
+} from '../../src/core/budget-plan.js';
+
+// Tests focus on:
+//   - Per-PR cap blocks an obviously expensive plan
+//   - billingExempt bypasses the cap entirely
+//   - empty resolved (single-pass D.2.0 path) always allows
+//   - unknown models fall back to the conservative ceiling
+//   - per-call ceiling is max(ceilings of involved models)
+
+function pass(slug, count) {
+  return {
+    slug,
+    count,
+    mode: 'cross-check',
+    roles: [],
+    source: 'repoDefault',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// perCallCeiling
+// ---------------------------------------------------------------------------
+
+describe('perCallCeiling', () => {
+  it('returns max across known models', () => {
+    const ceiling = perCallCeiling([
+      'anthropic/claude-sonnet-4.6',
+      'anthropic/claude-opus-4.7',
+    ]);
+    // opus 4.7 = 0.5
+    expect(ceiling).toBe(0.5);
+  });
+
+  it('falls back to DEFAULT for empty list', () => {
+    expect(perCallCeiling([])).toBe(0.5);
+  });
+
+  it('falls back to DEFAULT for unknown models (conservative)', () => {
+    expect(perCallCeiling(['provider/unknown-model'])).toBe(0.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// estimateBudget — allow / deny
+// ---------------------------------------------------------------------------
+
+describe('estimateBudget', () => {
+  it('allows the single-pass D.2.0 path (empty resolved)', () => {
+    const verdict = estimateBudget({
+      resolved: [],
+      roleModels: ['anthropic/claude-sonnet-4.6'],
+    });
+    expect(verdict.verdict).toBe('allow');
+    expect(verdict.estimate.estimatedCalls).toBe(0);
+    expect(verdict.estimate.estimatedCostUsd).toBe(0);
+  });
+
+  it('allows a normal multi-pass plan under the cap', () => {
+    const verdict = estimateBudget({
+      resolved: [pass('a', 1), pass('b', 2), pass('c', 1)],
+      roleModels: ['anthropic/claude-sonnet-4.6'],
+    });
+    expect(verdict.verdict).toBe('allow');
+    // Orchestrator sends all skills in ONE prompt per pass, so call count
+    // is max(counts), not sum(counts). max(1,2,1) = 2.
+    expect(verdict.estimate.estimatedCalls).toBe(2);
+    // 2 × $0.08 = $0.16, well below $5
+    expect(verdict.estimate.estimatedCostUsd).toBeCloseTo(0.16, 2);
+  });
+
+  it('denies when estimated cost exceeds the cap', () => {
+    // 3 passes × $0.50/call opus = $1.50. With a custom $1 cap → deny.
+    // (Default $5 cap with the new max-based math is not reachable via
+    // the count: 3 HARD CAP; this case validates the deny path explicitly.)
+    const verdict = estimateBudget({
+      resolved: Array.from({ length: 20 }, (_, i) => pass(`s${i}`, 3)),
+      roleModels: ['anthropic/claude-opus-4.7'],
+      perPrCapUsd: 1,
+    });
+    expect(verdict.verdict).toBe('deny');
+    if (verdict.verdict === 'deny') {
+      expect(verdict.reason).toMatch(/clud-bug paused this review/);
+      expect(verdict.reason).toMatch(/reviewPasses\.count/);
+      expect(verdict.estimate.estimatedCalls).toBe(3);
+    }
+  });
+
+  it('billingExempt = true bypasses the cap', () => {
+    const verdict = estimateBudget({
+      resolved: Array.from({ length: 20 }, (_, i) => pass(`s${i}`, 3)),
+      roleModels: ['anthropic/claude-opus-4.7'],
+      billingExempt: true,
+    });
+    expect(verdict.verdict).toBe('allow');
+  });
+
+  it('respects a custom perPrCapUsd', () => {
+    const verdict = estimateBudget({
+      resolved: [pass('a', 2)],
+      roleModels: ['anthropic/claude-sonnet-4.6'],
+      // 2 × $0.08 = $0.16
+      perPrCapUsd: 0.1,
+    });
+    expect(verdict.verdict).toBe('deny');
+    if (verdict.verdict === 'deny') {
+      expect(verdict.estimate.capUsd).toBe(0.1);
+    }
+  });
+
+  it('reports the default cap when none provided', () => {
+    const verdict = estimateBudget({
+      resolved: [pass('a', 1)],
+      roleModels: ['anthropic/claude-sonnet-4.6'],
+    });
+    expect(verdict.estimate.capUsd).toBe(DEFAULT_PER_PR_CAP_USD);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Model ceiling override (D.4 hook)
+// ---------------------------------------------------------------------------
+
+describe('__setModelCeilingForTests', () => {
+  afterEach(() => {
+    __setModelCeilingForTests('test/super-cheap-model', null);
+  });
+
+  it('lets future D.4 wiring register a new model ceiling', () => {
+    __setModelCeilingForTests('test/super-cheap-model', 0.001);
+    expect(perCallCeiling(['test/super-cheap-model'])).toBe(0.001);
+    __setModelCeilingForTests('test/super-cheap-model', null);
+    // Fall back to DEFAULT after removal.
+    expect(perCallCeiling(['test/super-cheap-model'])).toBe(0.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D.2.6 verifier budget — estimateVerifierBudget
+// ---------------------------------------------------------------------------
+
+describe('estimateVerifierBudget', () => {
+  it('allows zero-thread fix-pushes (no work, no cost)', () => {
+    const verdict = estimateVerifierBudget({ threadCount: 0 });
+    expect(verdict.verdict).toBe('allow');
+    expect(verdict.estimate.estimatedCalls).toBe(0);
+    expect(verdict.estimate.estimatedCostUsd).toBe(0);
+  });
+
+  it('allows the plan-spec ceiling (5 findings × 3 fix-pushes ≈ 15 calls)', () => {
+    // 5 threads × 1 pass = 5 calls × $0.01 = $0.05, under $0.60 cap.
+    const verdict = estimateVerifierBudget({ threadCount: 5 });
+    expect(verdict.verdict).toBe('allow');
+    expect(verdict.estimate.estimatedCalls).toBe(5);
+    expect(verdict.estimate.estimatedCostUsd).toBeCloseTo(0.05, 5);
+    expect(verdict.estimate.capUsd).toBe(DEFAULT_VERIFIER_PER_PR_CAP_USD);
+  });
+
+  it('scales calls by passesPerThread for D.2.5 multi-pass installs', () => {
+    // 5 threads × 3 passes = 15 calls × $0.01 = $0.15, still under $0.60 cap.
+    const verdict = estimateVerifierBudget({
+      threadCount: 5,
+      passesPerThread: 3,
+    });
+    expect(verdict.estimate.estimatedCalls).toBe(15);
+    expect(verdict.verdict).toBe('allow');
+  });
+
+  it('denies when the planned calls exceed the cap', () => {
+    // 100 threads × 1 pass = 100 calls × $0.01 = $1.00 > $0.60.
+    const verdict = estimateVerifierBudget({ threadCount: 100 });
+    expect(verdict.verdict).toBe('deny');
+    if (verdict.verdict === 'deny') {
+      expect(verdict.reason).toMatch(/paused D\.2\.6 fix-verification/);
+      expect(verdict.reason).toMatch(/autoResolve\.max_threads_per_fix_push/);
+    }
+  });
+
+  it('billingExempt = true bypasses the cap', () => {
+    const verdict = estimateVerifierBudget({
+      threadCount: 1000,
+      billingExempt: true,
+    });
+    expect(verdict.verdict).toBe('allow');
+  });
+
+  it('honors a custom perPrCapUsd override', () => {
+    const verdict = estimateVerifierBudget({
+      threadCount: 10, // 10 × $0.01 = $0.10
+      perPrCapUsd: 0.05,
+    });
+    expect(verdict.verdict).toBe('deny');
+    if (verdict.verdict === 'deny') {
+      expect(verdict.estimate.capUsd).toBe(0.05);
+    }
+  });
+
+  it('clamps passesPerThread to a minimum of 1 (defensive)', () => {
+    // passesPerThread = 0 would zero out cost — defensively floor at 1.
+    const verdict = estimateVerifierBudget({
+      threadCount: 5,
+      passesPerThread: 0,
+    });
+    expect(verdict.estimate.estimatedCalls).toBe(5);
+  });
+});

--- a/test/core/multi-pass-aggregate.test.js
+++ b/test/core/multi-pass-aggregate.test.js
@@ -1,0 +1,671 @@
+// Tests for src/core/multi-pass-aggregate.ts — ported from clud-bug-app's
+// test/multi-pass-aggregator.test.ts. Behavior pinned identically; only the
+// import paths differ (`Finding`/`Review`/`buildReviewFromFindings` come from
+// core's review-schema-zod; the result types live in review-writeback and are
+// not imported by the JS test). Every assertion is preserved.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  aggregatePasses,
+  deriveConsensus,
+  resolveVerdict,
+} from '../../src/core/multi-pass-aggregate.js';
+import { buildReviewFromFindings } from '../../src/core/review-schema-zod.js';
+
+// Tests focus on:
+//   - cross-check: pass-1 verdicts attach as additional attributions; independent findings append
+//   - consensus: tuple-key matching (file, line, skill) detects "same" findings; intersection labeled `agreed`
+//   - independent: no merging — every pass's findings appear in order with provenance
+//   - verdict resolution rules per mode (strict / consensus / independent)
+//   - summary counts + skills_referenced derived from aggregated findings
+//   - severity promotion in consensus (e.g. minor → critical when later pass disagrees on severity)
+
+const ROLE_BEETLE = {
+  name: 'Beetle',
+  model: 'anthropic/claude-sonnet-4.6',
+};
+const ROLE_WASP = {
+  name: 'Wasp',
+  model: 'anthropic/claude-opus-4.7',
+};
+const ROLE_MANTIS = {
+  name: 'Mantis',
+  model: 'anthropic/claude-opus-4.7',
+};
+
+function f(severity, skill, file, line, summary, reasoning) {
+  return { severity, skill, file, line, summary, reasoning };
+}
+
+function emptyReview() {
+  return buildReviewFromFindings({ findings: [], status_header: 'clean' });
+}
+
+function reviewWith(findings) {
+  return buildReviewFromFindings({ findings, status_header: 'clean' });
+}
+
+// ---------------------------------------------------------------------------
+// Cross-check mode
+// ---------------------------------------------------------------------------
+
+describe('aggregatePasses — cross-check', () => {
+  it('attaches Pass 2 verdicts to Pass 1 findings, appends independent findings', () => {
+    const pass1 = reviewWith([
+      f('critical', 'race-conditions', 'auth.ts', 42, 'Race condition'),
+      f('minor', 'magic-numbers', 'utils.ts', 18, 'Magic number 7'),
+    ]);
+    const pass2CC = {
+      verdicts: [
+        { pass1Index: 0, verdict: 'agreed' },
+        {
+          pass1Index: 1,
+          verdict: 'disagreed',
+          rationale: 'constant is documented above',
+        },
+      ],
+      independentFindings: [
+        f('critical', 'secrets', 'auth.ts', 67, 'Token logged'),
+      ],
+    };
+
+    const agg = aggregatePasses({
+      mode: 'cross-check',
+      firstPass: pass1,
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [
+        { passNumber: 2, role: ROLE_WASP, crossCheck: pass2CC },
+      ],
+    });
+
+    expect(agg.findings).toHaveLength(3);
+
+    // Pass 1 findings — Pass 1 attribution + Pass 2 verdict attribution.
+    const race = agg.findings[0];
+    expect(race.summary).toBe('Race condition');
+    expect(race.attributions).toHaveLength(2);
+    expect(race.attributions[0]).toMatchObject({
+      passNumber: 1,
+      roleName: 'Beetle',
+      source: 'first',
+    });
+    expect(race.attributions[1]).toMatchObject({
+      passNumber: 2,
+      roleName: 'Wasp',
+      source: 'agreed',
+    });
+
+    const magic = agg.findings[1];
+    expect(magic.attributions[1]).toMatchObject({
+      source: 'disagreed',
+      note: 'constant is documented above',
+    });
+
+    // Independent finding — only Pass 2 attribution.
+    const indep = agg.findings[2];
+    expect(indep.summary).toBe('Token logged');
+    expect(indep.attributions).toHaveLength(1);
+    expect(indep.attributions[0]).toMatchObject({
+      passNumber: 2,
+      source: 'independent',
+    });
+
+    expect(agg.passCount).toBe(2);
+    expect(agg.mode).toBe('cross-check');
+    expect(agg.roles).toEqual([
+      { passNumber: 1, roleName: 'Beetle', model: ROLE_BEETLE.model },
+      { passNumber: 2, roleName: 'Wasp', model: ROLE_WASP.model },
+    ]);
+  });
+
+  it('ignores out-of-range pass1Index without crashing', () => {
+    const pass1 = reviewWith([f('critical', 's', 'a.ts', 1, 'A')]);
+    const agg = aggregatePasses({
+      mode: 'cross-check',
+      firstPass: pass1,
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [
+        {
+          passNumber: 2,
+          role: ROLE_WASP,
+          crossCheck: {
+            verdicts: [{ pass1Index: 99, verdict: 'agreed' }],
+            independentFindings: [],
+          },
+        },
+      ],
+    });
+    expect(agg.findings).toHaveLength(1);
+    expect(agg.findings[0]?.attributions).toHaveLength(1);
+  });
+
+  it('handles 3 passes — both Pass 2 and Pass 3 attach verdicts to Pass 1', () => {
+    const pass1 = reviewWith([f('critical', 's', 'a.ts', 1, 'A')]);
+    const agg = aggregatePasses({
+      mode: 'cross-check',
+      firstPass: pass1,
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [
+        {
+          passNumber: 2,
+          role: ROLE_WASP,
+          crossCheck: {
+            verdicts: [{ pass1Index: 0, verdict: 'agreed' }],
+            independentFindings: [],
+          },
+        },
+        {
+          passNumber: 3,
+          role: ROLE_MANTIS,
+          crossCheck: {
+            verdicts: [
+              { pass1Index: 0, verdict: 'disagreed', rationale: 'on second look' },
+            ],
+            independentFindings: [],
+          },
+        },
+      ],
+    });
+    expect(agg.findings[0]?.attributions).toHaveLength(3);
+    expect(agg.findings[0]?.attributions[1]?.source).toBe('agreed');
+    expect(agg.findings[0]?.attributions[2]?.source).toBe('disagreed');
+    expect(agg.passCount).toBe(3);
+  });
+
+  it('skips subsequent passes with missing crossCheck data', () => {
+    const pass1 = reviewWith([f('critical', 's', 'a.ts', 1, 'A')]);
+    const agg = aggregatePasses({
+      mode: 'cross-check',
+      firstPass: pass1,
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [{ passNumber: 2, role: ROLE_WASP }],
+    });
+    expect(agg.findings).toHaveLength(1);
+    // Pass 1 attribution only.
+    expect(agg.findings[0]?.attributions).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Consensus mode
+// ---------------------------------------------------------------------------
+
+describe('aggregatePasses — consensus', () => {
+  it('detects same (file, line, skill) tuples and labels them agreed', () => {
+    const pass1 = reviewWith([
+      f('critical', 'race', 'auth.ts', 42, 'Race condition'),
+      f('minor', 'naming', 'utils.ts', 5, 'Bad name'),
+    ]);
+    const pass2 = reviewWith([
+      f('critical', 'race', 'auth.ts', 42, 'A race here'), // same tuple
+      f('critical', 'secrets', 'auth.ts', 67, 'Token logged'), // new tuple
+    ]);
+
+    const agg = aggregatePasses({
+      mode: 'consensus',
+      firstPass: pass1,
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [
+        { passNumber: 2, role: ROLE_WASP, review: pass2 },
+      ],
+    });
+
+    expect(agg.findings).toHaveLength(3);
+    // Pass 1's first finding now has Pass 2 attribution as `agreed`.
+    expect(agg.findings[0]?.attributions).toHaveLength(2);
+    expect(agg.findings[0]?.attributions[1]).toMatchObject({
+      source: 'agreed',
+      passNumber: 2,
+    });
+    // Pass 1's second finding has only Pass 1's attribution.
+    expect(agg.findings[1]?.attributions).toHaveLength(1);
+    // Pass 2's new finding is at index 2.
+    expect(agg.findings[2]?.summary).toBe('Token logged');
+    expect(agg.findings[2]?.attributions[0]).toMatchObject({
+      passNumber: 2,
+      source: 'independent',
+    });
+  });
+
+  it('treats file-level findings (no line) as same when (file, *, skill) match', () => {
+    const pass1 = reviewWith([
+      f('preexisting', 'tests', 'baz.ts', undefined, 'Lacks tests'),
+    ]);
+    const pass2 = reviewWith([
+      f('preexisting', 'tests', 'baz.ts', undefined, 'No tests for this file'),
+    ]);
+    const agg = aggregatePasses({
+      mode: 'consensus',
+      firstPass: pass1,
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [
+        { passNumber: 2, role: ROLE_WASP, review: pass2 },
+      ],
+    });
+    expect(agg.findings).toHaveLength(1);
+    expect(agg.findings[0]?.attributions).toHaveLength(2);
+    expect(agg.findings[0]?.attributions[1]?.source).toBe('agreed');
+  });
+
+  it('promotes severity to the more conservative value on agreement', () => {
+    const pass1 = reviewWith([
+      f('minor', 'naming', 'utils.ts', 5, 'minor-leveled'),
+    ]);
+    const pass2 = reviewWith([
+      f('critical', 'naming', 'utils.ts', 5, 'critical-leveled'),
+    ]);
+    const agg = aggregatePasses({
+      mode: 'consensus',
+      firstPass: pass1,
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [
+        { passNumber: 2, role: ROLE_WASP, review: pass2 },
+      ],
+    });
+    expect(agg.findings[0]?.severity).toBe('critical');
+  });
+
+  it('handles 3-pass consensus with mixed agreement', () => {
+    const pass1 = reviewWith([
+      f('critical', 'race', 'auth.ts', 42, 'race'),
+    ]);
+    const pass2 = reviewWith([
+      f('critical', 'race', 'auth.ts', 42, 'race'), // agrees
+      f('minor', 'docs', 'README.md', 1, 'fix typo'), // unique
+    ]);
+    const pass3 = reviewWith([
+      f('critical', 'race', 'auth.ts', 42, 'race'), // also agrees
+      f('critical', 'secrets', 'auth.ts', 67, 'token'), // unique
+    ]);
+    const agg = aggregatePasses({
+      mode: 'consensus',
+      firstPass: pass1,
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [
+        { passNumber: 2, role: ROLE_WASP, review: pass2 },
+        { passNumber: 3, role: ROLE_MANTIS, review: pass3 },
+      ],
+    });
+    expect(agg.findings).toHaveLength(3);
+    // race: Pass 1 first, Pass 2 + 3 agreed → 3 attributions.
+    expect(agg.findings[0]?.attributions).toHaveLength(3);
+    expect(agg.findings[0]?.attributions[1]?.source).toBe('agreed');
+    expect(agg.findings[0]?.attributions[2]?.source).toBe('agreed');
+    // docs typo unique to Pass 2.
+    expect(agg.findings[1]?.attributions).toHaveLength(1);
+    expect(agg.findings[1]?.attributions[0]?.passNumber).toBe(2);
+    // secrets unique to Pass 3.
+    expect(agg.findings[2]?.attributions[0]?.passNumber).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Independent mode
+// ---------------------------------------------------------------------------
+
+describe('aggregatePasses — independent', () => {
+  it('emits every finding side-by-side with no merging', () => {
+    const pass1 = reviewWith([
+      f('critical', 'race', 'auth.ts', 42, 'race'),
+    ]);
+    const pass2 = reviewWith([
+      f('critical', 'race', 'auth.ts', 42, 'race again'), // SAME tuple as Pass 1
+      f('minor', 'docs', 'README.md', 1, 'typo'),
+    ]);
+    const agg = aggregatePasses({
+      mode: 'independent',
+      firstPass: pass1,
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [
+        { passNumber: 2, role: ROLE_WASP, review: pass2 },
+      ],
+    });
+    // No merging: same tuple appears twice, attributed to different passes.
+    expect(agg.findings).toHaveLength(3);
+    expect(agg.findings[0]?.attributions[0]?.passNumber).toBe(1);
+    expect(agg.findings[1]?.attributions[0]?.passNumber).toBe(2);
+    expect(agg.findings[1]?.attributions[0]?.source).toBe('independent');
+    expect(agg.findings[2]?.attributions[0]?.passNumber).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Derived counts + skills_referenced
+// ---------------------------------------------------------------------------
+
+describe('aggregatePasses — derived fields', () => {
+  it('derives summary_counts from aggregated findings', () => {
+    const pass1 = reviewWith([
+      f('critical', 'a', 'x.ts', 1, 's1'),
+      f('minor', 'b', 'x.ts', 2, 's2'),
+    ]);
+    const pass2 = reviewWith([
+      f('preexisting', 'c', 'y.ts', 1, 's3'),
+    ]);
+    const agg = aggregatePasses({
+      mode: 'independent',
+      firstPass: pass1,
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [
+        { passNumber: 2, role: ROLE_WASP, review: pass2 },
+      ],
+    });
+    expect(agg.summary_counts).toEqual({
+      critical: 1,
+      minor: 1,
+      preexisting: 1,
+      resolved_from_prior: 0,
+      still_open: 0,
+    });
+  });
+
+  it('derives skills_referenced in citation order', () => {
+    const pass1 = reviewWith([
+      f('critical', 'first-skill', 'x.ts', 1, 's'),
+      f('minor', 'second-skill', 'x.ts', 2, 's'),
+    ]);
+    const pass2 = reviewWith([
+      f('preexisting', 'second-skill', 'y.ts', 1, 's'),
+      f('preexisting', 'third-skill', 'z.ts', 1, 's'),
+    ]);
+    const agg = aggregatePasses({
+      mode: 'independent',
+      firstPass: pass1,
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [
+        { passNumber: 2, role: ROLE_WASP, review: pass2 },
+      ],
+    });
+    expect(agg.skills_referenced).toEqual([
+      'first-skill',
+      'second-skill',
+      'third-skill',
+    ]);
+  });
+
+  it('emits "clean" status when no findings exist', () => {
+    const agg = aggregatePasses({
+      mode: 'cross-check',
+      firstPass: emptyReview(),
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [],
+    });
+    expect(agg.status_header).toBe('clean');
+    expect(agg.verdict).toBe('clean');
+  });
+
+  it('emits "critical findings" when any critical present', () => {
+    const agg = aggregatePasses({
+      mode: 'cross-check',
+      firstPass: reviewWith([f('critical', 's', 'a.ts', 1, 'A')]),
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [],
+    });
+    expect(agg.status_header).toBe('critical findings');
+  });
+
+  it('emits "clean" when only minor/preexisting findings', () => {
+    const agg = aggregatePasses({
+      mode: 'cross-check',
+      firstPass: reviewWith([
+        f('minor', 's', 'a.ts', 1, 'A'),
+        f('preexisting', 's', 'b.ts', 1, 'B'),
+      ]),
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [],
+    });
+    expect(agg.status_header).toBe('clean');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Verdict resolution
+// ---------------------------------------------------------------------------
+
+describe('resolveVerdict', () => {
+  function unifiedCritical() {
+    return {
+      severity: 'critical',
+      skill: 's',
+      file: 'a.ts',
+      line: 1,
+      summary: 'x',
+      attributions: [
+        {
+          passNumber: 1,
+          roleName: 'Beetle',
+          model: 'm',
+          source: 'first',
+        },
+      ],
+      // Wave 4b — UnifiedFinding now carries SPEC §6.10.1 consensus.
+      // 'first'-only attribution derives to '1-of-N' per deriveConsensus.
+      consensus: '1-of-N',
+    };
+  }
+
+  it('returns clean when there are no findings', () => {
+    expect(resolveVerdict('cross-check', [], 2)).toBe('clean');
+    expect(resolveVerdict('consensus', [], 2)).toBe('clean');
+    expect(resolveVerdict('independent', [], 2)).toBe('clean');
+  });
+
+  it('returns review_only when there are no critical findings', () => {
+    const u = { ...unifiedCritical(), severity: 'minor' };
+    expect(resolveVerdict('cross-check', [u], 2)).toBe('review_only');
+    expect(resolveVerdict('consensus', [u], 2)).toBe('review_only');
+    expect(resolveVerdict('independent', [u], 2)).toBe('review_only');
+  });
+
+  it('cross-check: any critical → request_changes', () => {
+    const u = unifiedCritical();
+    expect(resolveVerdict('cross-check', [u], 2)).toBe('request_changes');
+  });
+
+  it('independent: any critical → request_changes (strict default)', () => {
+    const u = unifiedCritical();
+    expect(resolveVerdict('independent', [u], 2)).toBe('request_changes');
+  });
+
+  it('consensus: critical seen by only ONE pass → review_only', () => {
+    const u = unifiedCritical(); // 1 attribution (first)
+    expect(resolveVerdict('consensus', [u], 2)).toBe('review_only');
+  });
+
+  it('consensus: critical seen by 2+ passes → request_changes', () => {
+    const u = unifiedCritical();
+    u.attributions.push({
+      passNumber: 2,
+      roleName: 'Wasp',
+      model: 'm',
+      source: 'agreed',
+    });
+    expect(resolveVerdict('consensus', [u], 2)).toBe('request_changes');
+  });
+
+  it('consensus: critical raised by Pass 2 + confirmed by Pass 3 (Pass 1 missed) → request_changes', () => {
+    // Regression test for the verdict-counts-attributions fix.
+    // Before the fix, resolveVerdict counted only attributions with
+    // source `first | agreed`; the Pass-2-raises + Pass-3-confirms case
+    // produces `[independent, agreed]` and would silently fall through
+    // to `review_only`. The fix counts attributions.length directly.
+    const u = unifiedCritical();
+    u.attributions = [
+      { passNumber: 2, roleName: 'Wasp', model: 'm', source: 'independent' },
+      { passNumber: 3, roleName: 'Mantis', model: 'm', source: 'agreed' },
+    ];
+    expect(resolveVerdict('consensus', [u], 3)).toBe('request_changes');
+  });
+
+  it('consensus with passCount = 1 → falls back to strict', () => {
+    const u = unifiedCritical();
+    expect(resolveVerdict('consensus', [u], 1)).toBe('request_changes');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wave 4b — SPEC §6.10.1 consensus derivation
+// ---------------------------------------------------------------------------
+
+describe('deriveConsensus — SPEC §6.10.1', () => {
+  const beetle = (source) => ({
+    passNumber: 1,
+    roleName: 'Beetle',
+    model: 'm',
+    source,
+  });
+  const wasp = (source) => ({
+    passNumber: 2,
+    roleName: 'Wasp',
+    model: 'm',
+    source,
+  });
+
+  it("'first' alone → '1-of-N' (single-pass, no cross-validation)", () => {
+    expect(deriveConsensus([beetle('first')])).toBe('1-of-N');
+  });
+
+  it("'first' + 'agreed' → '2-of-2' (cross-check confirmed)", () => {
+    // Auto-fix gate qualifies on this combination per §6.10.2.
+    expect(deriveConsensus([beetle('first'), wasp('agreed')])).toBe('2-of-2');
+  });
+
+  it("'first' + 'disagreed' → 'arbitrated' (cross-check produced dissent)", () => {
+    // The finding survives even after dissent — that IS our arbitration
+    // model today. Auto-fix gate still refuses (no positive-arbitration
+    // plumbing yet) but downstream renderers can surface the dissent
+    // for human-reviewer visibility.
+    expect(deriveConsensus([beetle('first'), wasp('disagreed')])).toBe(
+      'arbitrated',
+    );
+  });
+
+  it("'first' + 'agreed' + 'disagreed' → '2-of-2' (agreed wins priority)", () => {
+    // 3-pass setup: if any pass agrees, we have consensus regardless of
+    // a separate dissent. Priority order is agreed > disagreed > default.
+    expect(
+      deriveConsensus([
+        beetle('first'),
+        wasp('agreed'),
+        { passNumber: 3, roleName: 'Mantis', model: 'm', source: 'disagreed' },
+      ]),
+    ).toBe('2-of-2');
+  });
+
+  it("'independent' alone → '1-of-N' (single-pass discovery)", () => {
+    expect(deriveConsensus([wasp('independent')])).toBe('1-of-N');
+  });
+
+  it('empty attributions → 1-of-N (defensive default)', () => {
+    // Should never happen in practice (every finding has at least one
+    // attribution) but the function MUST NOT throw on empty input.
+    expect(deriveConsensus([])).toBe('1-of-N');
+  });
+});
+
+describe('aggregator populates UnifiedFinding.consensus', () => {
+  it('cross-check: Pass-1-only finding gets 1-of-N; Pass-2-agreed gets 2-of-2', () => {
+    const passF1 = {
+      severity: 'critical',
+      skill: 's',
+      file: 'a.ts',
+      line: 1,
+      summary: 'x',
+    };
+    const passF2 = {
+      severity: 'critical',
+      skill: 's',
+      file: 'a.ts',
+      line: 2,
+      summary: 'y',
+    };
+    const firstPass = buildReviewFromFindings({
+      findings: [passF1, passF2],
+      status_header: 'critical findings',
+    });
+    const crossCheck = {
+      verdicts: [
+        { pass1Index: 0, verdict: 'agreed' },
+        // Index 1 → no verdict from Wasp → stays 1-of-N.
+      ],
+      independentFindings: [],
+    };
+
+    const agg = aggregatePasses({
+      mode: 'cross-check',
+      firstPass,
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [
+        {
+          passNumber: 2,
+          role: ROLE_WASP,
+          crossCheck,
+        },
+      ],
+    });
+
+    expect(agg.findings).toHaveLength(2);
+    // Pass-1 + Pass-2 agreed → consensus reached.
+    expect(agg.findings[0]?.consensus).toBe('2-of-2');
+    // Pass-1 only (Wasp didn't verdict on this one) → no consensus.
+    expect(agg.findings[1]?.consensus).toBe('1-of-N');
+  });
+
+  it("cross-check: 'disagreed' verdict produces 'arbitrated'", () => {
+    const passF = {
+      severity: 'minor',
+      skill: 's',
+      file: 'a.ts',
+      line: 5,
+      summary: 'maybe a bug',
+    };
+    const firstPass = buildReviewFromFindings({
+      findings: [passF],
+      status_header: 'clean',
+    });
+    const crossCheck = {
+      verdicts: [{ pass1Index: 0, verdict: 'disagreed', rationale: 'nope' }],
+      independentFindings: [],
+    };
+
+    const agg = aggregatePasses({
+      mode: 'cross-check',
+      firstPass,
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [{ passNumber: 2, role: ROLE_WASP, crossCheck }],
+    });
+
+    expect(agg.findings[0]?.consensus).toBe('arbitrated');
+  });
+
+  it('consensus mode: same-tuple match across passes → 2-of-2', () => {
+    const dup = {
+      severity: 'critical',
+      skill: 's',
+      file: 'a.ts',
+      line: 42,
+      summary: 'race condition',
+    };
+    const firstPass = buildReviewFromFindings({
+      findings: [dup],
+      status_header: 'critical findings',
+    });
+    const secondPass = buildReviewFromFindings({
+      findings: [dup],
+      status_header: 'critical findings',
+    });
+
+    const agg = aggregatePasses({
+      mode: 'consensus',
+      firstPass,
+      firstPassRole: ROLE_BEETLE,
+      subsequentPasses: [
+        { passNumber: 2, role: ROLE_WASP, review: secondPass },
+      ],
+    });
+
+    expect(agg.findings).toHaveLength(1);
+    expect(agg.findings[0]?.consensus).toBe('2-of-2');
+  });
+});

--- a/test/core/review-plan.test.js
+++ b/test/core/review-plan.test.js
@@ -1,0 +1,510 @@
+// Tests for src/core/review-plan.ts — ported from clud-bug-app's
+// test/multi-pass-config.test.ts. Behavior is pinned identically; only the
+// import path + the `skills` shape (decoupled from the App `LoadedSkill`)
+// differ. Test runner converted from the App's vitest setup to clud-bug's
+// vitest (`.test.js` importing the `.ts` source via the `.js` extension).
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  anyMultiPass,
+  BUILTIN_DEFAULT,
+  BUILTIN_ROLES,
+  extractSkillReviewPassesOverride,
+  MAX_PASSES,
+  readReviewPassesConfig,
+  resolveReviewPasses,
+  roleForPass,
+  totalPassCount,
+} from '../../src/core/review-plan.js';
+
+// Tests focus on:
+//   - precedence chain: perSkill > frontmatter > repoDefault > builtin
+//   - MAX_PASSES = 3 hard cap (silently clamps)
+//   - applyTo: shared-only correctly clamps dedicated skills to count = 1
+//   - SKILL.md frontmatter `review_passes` block parsing
+//   - .clud-bug.json's two layouts (flat vs default+perSkill)
+//   - role recycling when roles.length < pass count
+//   - source provenance label is honest
+
+// `resolveReviewPasses` only reads `slug` + `frontmatter.review_mode`. Build
+// the minimal `{ slug, frontmatter }` shape (core `SkillFrontmatter`) rather
+// than the App's full `LoadedSkill`.
+function makeSkill(slug, overrides = {}, raw) {
+  return {
+    slug,
+    frontmatter: {
+      name: slug,
+      description: `Test skill ${slug}`,
+      source: 'manual',
+      review_mode: overrides.review_mode ?? 'shared',
+      applies_to: overrides.applies_to,
+      ...overrides,
+    },
+    body: `# ${slug}\n\nrules`,
+    raw:
+      raw ??
+      `---\nname: ${slug}\ndescription: Test skill ${slug}\nsource: manual\nreview_mode: ${overrides.review_mode ?? 'shared'}\n---\n\n# ${slug}\n\nrules`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// readReviewPassesConfig
+// ---------------------------------------------------------------------------
+
+describe('readReviewPassesConfig', () => {
+  it('returns null when reviewPasses is absent', () => {
+    expect(readReviewPassesConfig({})).toBeNull();
+    expect(readReviewPassesConfig({ version: 1, installed: [] })).toBeNull();
+    expect(readReviewPassesConfig(null)).toBeNull();
+    expect(readReviewPassesConfig(undefined)).toBeNull();
+  });
+
+  it('reads the flat layout: count + mode + applyTo + roles', () => {
+    const config = readReviewPassesConfig({
+      reviewPasses: {
+        count: 2,
+        mode: 'cross-check',
+        applyTo: 'all',
+        roles: [
+          { name: 'Beetle', model: 'anthropic/claude-sonnet-4.6' },
+          { name: 'Wasp', model: 'anthropic/claude-opus-4.7' },
+        ],
+      },
+    });
+    expect(config).toMatchObject({
+      count: 2,
+      mode: 'cross-check',
+      applyTo: 'all',
+      roles: [
+        { name: 'Beetle', model: 'anthropic/claude-sonnet-4.6' },
+        { name: 'Wasp', model: 'anthropic/claude-opus-4.7' },
+      ],
+    });
+  });
+
+  it('reads the split layout: default + perSkill', () => {
+    const config = readReviewPassesConfig({
+      reviewPasses: {
+        default: { count: 1, mode: 'cross-check' },
+        perSkill: {
+          'security-audit': { count: 3 },
+          'brand-voice-review': { count: 1 },
+        },
+      },
+    });
+    expect(config?.default).toEqual({ count: 1, mode: 'cross-check' });
+    expect(config?.perSkill).toEqual({
+      'security-audit': { count: 3 },
+      'brand-voice-review': { count: 1 },
+    });
+  });
+
+  it('silently clamps count above MAX_PASSES', () => {
+    const config = readReviewPassesConfig({
+      reviewPasses: {
+        count: 99,
+        perSkill: { 'security-audit': { count: 7 } },
+      },
+    });
+    expect(config?.count).toBe(MAX_PASSES);
+    expect(config?.perSkill?.['security-audit']?.count).toBe(MAX_PASSES);
+  });
+
+  it('rejects invalid modes (silently drops them)', () => {
+    const config = readReviewPassesConfig({
+      reviewPasses: { count: 2, mode: 'banana' },
+    });
+    expect(config?.mode).toBeUndefined();
+  });
+
+  it('rejects invalid applyTo values (defaults to absent)', () => {
+    const config = readReviewPassesConfig({
+      reviewPasses: { applyTo: 'sometimes' },
+    });
+    expect(config?.applyTo).toBeUndefined();
+  });
+
+  it('drops malformed roles (missing name or model)', () => {
+    const config = readReviewPassesConfig({
+      reviewPasses: {
+        roles: [
+          { name: 'Beetle', model: 'anthropic/claude-sonnet-4.6' },
+          { name: '', model: 'x' }, // dropped
+          { model: 'foo' }, // dropped — no name
+          { name: 'Wasp', model: 'anthropic/claude-opus-4.7' },
+        ],
+      },
+    });
+    expect(config?.roles).toEqual([
+      { name: 'Beetle', model: 'anthropic/claude-sonnet-4.6' },
+      { name: 'Wasp', model: 'anthropic/claude-opus-4.7' },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractSkillReviewPassesOverride
+// ---------------------------------------------------------------------------
+
+describe('extractSkillReviewPassesOverride', () => {
+  it('returns null when the block is absent', () => {
+    const raw = `---
+name: security-audit
+description: Audit
+source: manual
+review_mode: dedicated
+---
+
+# audit
+`;
+    expect(extractSkillReviewPassesOverride(raw)).toBeNull();
+  });
+
+  it('parses count + mode from a nested review_passes block', () => {
+    const raw = `---
+name: security-audit
+description: Audit
+source: manual
+review_mode: dedicated
+review_passes:
+  count: 3
+  mode: consensus
+---
+
+body
+`;
+    expect(extractSkillReviewPassesOverride(raw)).toEqual({
+      count: 3,
+      mode: 'consensus',
+    });
+  });
+
+  it('clamps count above MAX_PASSES', () => {
+    const raw = `---
+name: x
+review_passes:
+  count: 99
+---
+`;
+    expect(extractSkillReviewPassesOverride(raw)?.count).toBe(MAX_PASSES);
+  });
+
+  it('returns null when the block is empty (no count / no mode)', () => {
+    const raw = `---
+name: x
+review_passes:
+---
+`;
+    expect(extractSkillReviewPassesOverride(raw)).toBeNull();
+  });
+
+  it('ignores invalid modes', () => {
+    const raw = `---
+name: x
+review_passes:
+  mode: banana
+  count: 2
+---
+`;
+    expect(extractSkillReviewPassesOverride(raw)).toEqual({ count: 2 });
+  });
+
+  it('tolerates quoted strings on mode', () => {
+    const raw = `---
+name: x
+review_passes:
+  mode: "consensus"
+  count: 2
+---
+`;
+    expect(extractSkillReviewPassesOverride(raw)?.mode).toBe('consensus');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveReviewPasses — precedence chain
+// ---------------------------------------------------------------------------
+
+describe('resolveReviewPasses — precedence', () => {
+  it('falls back to BUILTIN_DEFAULT when nothing supplies a value', () => {
+    const resolved = resolveReviewPasses({
+      skills: [makeSkill('skill-a')],
+      config: null,
+    });
+    expect(resolved.perSkill[0]).toMatchObject({
+      slug: 'skill-a',
+      count: BUILTIN_DEFAULT.count,
+      mode: BUILTIN_DEFAULT.mode,
+      source: 'builtin',
+    });
+    expect(resolved.roles).toEqual(BUILTIN_ROLES);
+    expect(resolved.applyTo).toBe('all');
+  });
+
+  it('uses .clud-bug.json default when no per-skill or frontmatter override', () => {
+    const resolved = resolveReviewPasses({
+      skills: [makeSkill('skill-a')],
+      config: {
+        default: { count: 2, mode: 'consensus' },
+      },
+    });
+    expect(resolved.perSkill[0]).toMatchObject({
+      count: 2,
+      mode: 'consensus',
+      source: 'repoDefault',
+    });
+  });
+
+  it('uses the flat layout (count/mode top-level) when default absent', () => {
+    const resolved = resolveReviewPasses({
+      skills: [makeSkill('skill-a')],
+      config: { count: 2, mode: 'cross-check' },
+    });
+    expect(resolved.perSkill[0]).toMatchObject({
+      count: 2,
+      mode: 'cross-check',
+      source: 'repoDefault',
+    });
+  });
+
+  it('explicit `default` wins over flat keys when both are present', () => {
+    const resolved = resolveReviewPasses({
+      skills: [makeSkill('skill-a')],
+      config: {
+        count: 1, // flat — should be overridden
+        default: { count: 3, mode: 'consensus' },
+      },
+    });
+    expect(resolved.perSkill[0]).toMatchObject({
+      count: 3,
+      mode: 'consensus',
+    });
+  });
+
+  it('SKILL.md frontmatter overrides repo default', () => {
+    const raw = `---
+name: skill-a
+description: x
+source: manual
+review_mode: shared
+review_passes:
+  count: 2
+  mode: consensus
+---
+body`;
+    const resolved = resolveReviewPasses({
+      skills: [makeSkill('skill-a', {}, raw)],
+      rawSkillMd: { 'skill-a': raw },
+      config: { default: { count: 1, mode: 'cross-check' } },
+    });
+    expect(resolved.perSkill[0]).toMatchObject({
+      count: 2,
+      mode: 'consensus',
+      source: 'frontmatter',
+    });
+  });
+
+  it('perSkill override wins over SKILL.md frontmatter', () => {
+    const raw = `---
+name: skill-a
+description: x
+source: manual
+review_mode: shared
+review_passes:
+  count: 2
+  mode: consensus
+---
+body`;
+    const resolved = resolveReviewPasses({
+      skills: [makeSkill('skill-a', {}, raw)],
+      rawSkillMd: { 'skill-a': raw },
+      config: {
+        default: { count: 1, mode: 'cross-check' },
+        perSkill: { 'skill-a': { count: 3, mode: 'independent' } },
+      },
+    });
+    expect(resolved.perSkill[0]).toMatchObject({
+      count: 3,
+      mode: 'independent',
+      source: 'perSkill',
+    });
+  });
+
+  it('full precedence chain: perSkill > frontmatter > repoDefault > builtin', () => {
+    // Skill A has only frontmatter override (count 2).
+    // Skill B has perSkill override (count 3).
+    // Skill C has nothing (falls back to repoDefault count 1).
+    // Skill D has no config at all (builtin count 1).
+    const rawA = `---
+name: skill-a
+description: x
+source: manual
+review_mode: shared
+review_passes:
+  count: 2
+---
+body`;
+    const resolved = resolveReviewPasses({
+      skills: [
+        makeSkill('skill-a', {}, rawA),
+        makeSkill('skill-b'),
+        makeSkill('skill-c'),
+        makeSkill('skill-d'),
+      ],
+      rawSkillMd: { 'skill-a': rawA },
+      config: {
+        default: { count: 1, mode: 'cross-check' },
+        perSkill: { 'skill-b': { count: 3 } },
+      },
+    });
+    expect(resolved.perSkill[0]).toMatchObject({
+      slug: 'skill-a',
+      count: 2,
+      source: 'frontmatter',
+    });
+    expect(resolved.perSkill[1]).toMatchObject({
+      slug: 'skill-b',
+      count: 3,
+      source: 'perSkill',
+    });
+    expect(resolved.perSkill[2]).toMatchObject({
+      slug: 'skill-c',
+      count: 1,
+      source: 'repoDefault',
+    });
+    expect(resolved.perSkill[3]).toMatchObject({
+      slug: 'skill-d',
+      count: 1,
+      source: 'repoDefault',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveReviewPasses — applyTo: shared-only
+// ---------------------------------------------------------------------------
+
+describe('resolveReviewPasses — applyTo: shared-only', () => {
+  it('clamps dedicated skills to count = 1', () => {
+    const resolved = resolveReviewPasses({
+      skills: [
+        makeSkill('shared-skill', { review_mode: 'shared' }),
+        makeSkill('dedicated-skill', { review_mode: 'dedicated' }),
+      ],
+      config: {
+        applyTo: 'shared-only',
+        default: { count: 3, mode: 'consensus' },
+      },
+    });
+    expect(resolved.perSkill[0]).toMatchObject({
+      slug: 'shared-skill',
+      count: 3,
+    });
+    expect(resolved.perSkill[1]).toMatchObject({
+      slug: 'dedicated-skill',
+      count: 1, // clamped, not 3
+    });
+    expect(resolved.applyTo).toBe('shared-only');
+  });
+
+  it('perSkill override cannot bypass shared-only clamp', () => {
+    const resolved = resolveReviewPasses({
+      skills: [makeSkill('dedicated-skill', { review_mode: 'dedicated' })],
+      config: {
+        applyTo: 'shared-only',
+        default: { count: 1 },
+        perSkill: { 'dedicated-skill': { count: 3 } },
+      },
+    });
+    expect(resolved.perSkill[0]?.count).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MAX_PASSES enforcement at resolve time
+// ---------------------------------------------------------------------------
+
+describe('resolveReviewPasses — clamping', () => {
+  it('clamps perSkill > MAX_PASSES to MAX_PASSES', () => {
+    const resolved = resolveReviewPasses({
+      skills: [makeSkill('skill-a')],
+      config: {
+        perSkill: { 'skill-a': { count: 99 } },
+      },
+    });
+    expect(resolved.perSkill[0]?.count).toBe(MAX_PASSES);
+  });
+
+  it('clamps frontmatter > MAX_PASSES to MAX_PASSES', () => {
+    const raw = `---
+name: skill-a
+description: x
+review_mode: shared
+review_passes:
+  count: 99
+---
+body`;
+    const resolved = resolveReviewPasses({
+      skills: [makeSkill('skill-a', {}, raw)],
+      rawSkillMd: { 'skill-a': raw },
+      config: null,
+    });
+    expect(resolved.perSkill[0]?.count).toBe(MAX_PASSES);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Roles
+// ---------------------------------------------------------------------------
+
+describe('roleForPass', () => {
+  it('returns the i-th role when within range', () => {
+    expect(roleForPass(BUILTIN_ROLES, 0, 'fallback')).toEqual(BUILTIN_ROLES[0]);
+    expect(roleForPass(BUILTIN_ROLES, 1, 'fallback')).toEqual(BUILTIN_ROLES[1]);
+    expect(roleForPass(BUILTIN_ROLES, 2, 'fallback')).toEqual(BUILTIN_ROLES[2]);
+  });
+
+  it('recycles roles when pass index exceeds array length', () => {
+    const roles = [BUILTIN_ROLES[0]]; // single-role array
+    expect(roleForPass(roles, 0, 'fallback')).toEqual(roles[0]);
+    expect(roleForPass(roles, 1, 'fallback')).toEqual(roles[0]);
+    expect(roleForPass(roles, 5, 'fallback')).toEqual(roles[0]);
+  });
+
+  it('synthesizes Pass N name when roles is empty', () => {
+    const role = roleForPass([], 0, 'fallback/model');
+    expect(role.name).toBe('Pass 1');
+    expect(role.model).toBe('fallback/model');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+describe('anyMultiPass / totalPassCount', () => {
+  it('anyMultiPass returns true when at least one skill needs > 1', () => {
+    expect(
+      anyMultiPass([
+        { slug: 'a', count: 1, mode: 'cross-check', roles: [], source: 'builtin' },
+        { slug: 'b', count: 2, mode: 'cross-check', roles: [], source: 'perSkill' },
+      ]),
+    ).toBe(true);
+    expect(
+      anyMultiPass([
+        { slug: 'a', count: 1, mode: 'cross-check', roles: [], source: 'builtin' },
+      ]),
+    ).toBe(false);
+  });
+
+  it('totalPassCount sums every skill', () => {
+    expect(
+      totalPassCount([
+        { slug: 'a', count: 1, mode: 'cross-check', roles: [], source: 'builtin' },
+        { slug: 'b', count: 3, mode: 'consensus', roles: [], source: 'perSkill' },
+        { slug: 'c', count: 2, mode: 'cross-check', roles: [], source: 'frontmatter' },
+      ]),
+    ).toBe(6);
+  });
+});


### PR DESCRIPTION
## Wave 6b PR 0 — shared review engine extracted into `core` (rc.12)

The foundation for local mode running clud-bug's **full review brain**. Moves the review-planning logic out of `clud-bug-app/lib` (where local mode couldn't reach it) into the shared `clud-bug/core` package, so the hosted bot, the npm workflow, and local mode all run **one engine** — the Bug-9 single-source-of-truth principle applied to the engine.

### What moved (all pure logic, behavior-identical)
- **`core/review-plan.ts`** ← `multi-pass-config.ts`: `resolveReviewPasses` (per-skill passes/modes via the `.clud-bug.json` → SKILL.md `review_passes` → repo-default → builtin precedence chain; `MAX_PASSES=3`), `readReviewPassesConfig`, `roleForPass`. Decoupled from the App's `LoadedSkill` → a minimal `{ slug, frontmatter }`. Adds a `beetle|wasp|mantis` `tier` on `ReviewRole` (concrete model binding stays consumer-side).
- **`core/budget-plan.ts`** ← `budget-gate.ts`: `estimateBudget` (Layer-1 cost gate) + the verifier-budget gate.
- **`core/multi-pass-aggregate.ts`** ← `multi-pass-aggregator.ts`: `aggregatePasses` (cross-check/consensus/independent), `deriveConsensus`, `resolveVerdict`.

The App's three unit suites were **ported verbatim** (77 tests) to pin behavior-identity.

### Adversarial review — 1 finding, fixed
The review caught a **type-erasure regression**: the aggregator's local `UnifiedFindingWithConsensus` stamped `consensus` at runtime, but `aggregatePasses` returns `MultiPassReview` whose `findings` type omitted it — so the public type *erased* `consensus`, which would break PR 0b's type-safe consumption of the SPEC §6.10.2 auto-fix gate (`TS2339` on `finding.consensus`). Fixed by moving `consensus?: Consensus` onto core's canonical `UnifiedFinding`; proven RED→GREEN with a consumer-compile against the built `.d.ts`.

### Verification
- `npm run build` (tsc strict + `exactOptionalPropertyTypes`): clean
- `npm test`: **816 passed** (34 files; +77 ported from the App)
- `npm run test:fixtures`: 5/5
- Consumer-compile: `aggregatePasses(...).findings[i].consensus` reads off the public type ✓

**Additive** — no existing consumer behavior changes. PR 0b re-wires the live App onto this engine. rc.12 publish is a USER ACTION.

🤖 Generated with [Claude Code](https://claude.com/claude-code)