### PR TITLE
Wave 6b: planReview — the shared review-plan entry point (SPEC §11.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Wave 6b (PR 0) — shared review engine extracted into `core` (single source of 
   `beetle | wasp | mantis` `tier` on `ReviewRole` (concrete model binding stays consumer-side).
   Additive — no existing consumer behavior changes; `resolveReviewPasses` is decoupled from the
   App's `LoadedSkill` (takes a minimal `{ slug, frontmatter }`).
+- **`core/plan-review.ts` — `planReview`** (SPEC §11.5): the single shared entry point that
+  composes `resolveReviewPasses` + `estimateBudget` and applies trigger / diff-size tiering —
+  `trigger: 'commit'` (or a diff over `LARGE_DIFF_THRESHOLD_BYTES`) tiers down to a single fast
+  (`beetle`-tier) pass; otherwise the full multi-pass plan. Every consumer plans through this one
+  function, so the fast-vs-deep choice falls out of the tier system — never hand-picked per call.
 
 ## [0.7.0-rc.11] — 2026-06-28
 

--- a/docs/decisions-branches/wave-6b-plan-review.md
+++ b/docs/decisions-branches/wave-6b-plan-review.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-28 15:16 - Add planReview — the shared review-plan entry point (SPEC §11.5), trigger/diff tiered
+
+**Reasoning:** The single planning entry point §11.5 specifies: composes resolveReviewPasses + estimateBudget so every consumer (hosted bot, npm workflow, local mode) plans identically. Applies trigger tiering (commit -> a single fast beetle-tier pass; diff >= LARGE_DIFF_THRESHOLD_BYTES -> auto-tier) so the fast-vs-deep choice falls out of the tier system, never hand-picked per call — the answer to the CEO 'models based on diff' ask. Rides in the still-unpublished rc.12.
+
+**Alternatives considered:** Have each consumer compose resolveReviewPasses + estimateBudget itself — rejected: divergent planning, no single conformant contract.
+
+**Implications:**
+- Consumed by the App re-wire (PR 0b) and the review-prompt verb (PR C). Adversarial review caught + fixed an off-by-one (>= threshold) and a tiered-plan cost overestimate (only the running tier is billed); both now have regression tests. 825 tests green.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (53 decisions)
+## 2026-06 (54 decisions)
 
-- **2026-06-28** — Extract review engine (review-plan/budget-plan/multi-pass-aggregate) into clud-bug/core — rc.12 *(wave-6b-core-engine)* — [decisions-branches/wave-6b-core-engine.md](decisions-branches/wave-6b-core-engine.md)
-- *... 51 more decisions ...*
+- **2026-06-28** — Add planReview — the shared review-plan entry point (SPEC §11.5), trigger/diff tiered *(wave-6b-plan-review)* — [decisions-branches/wave-6b-plan-review.md](decisions-branches/wave-6b-plan-review.md)
+- *... 52 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -265,6 +265,14 @@ export {
   type VerifierBudgetVerdict,
 } from './budget-plan.js';
 export {
+  planReview,
+  LARGE_DIFF_THRESHOLD_BYTES,
+  type PlanReviewInput,
+  type ReviewPlan,
+  type ReviewTrigger,
+  type TierDownReason,
+} from './plan-review.js';
+export {
   aggregatePasses,
   deriveConsensus,
   resolveVerdict,

--- a/src/core/plan-review.ts
+++ b/src/core/plan-review.ts
@@ -1,0 +1,132 @@
+// The single shared review planner (SPEC §11.5). Composes the per-skill pass
+// resolver (`review-plan.ts`) and the Layer-1 budget gate (`budget-plan.ts`),
+// then applies trigger / diff-size tiering. Every consumer — the hosted bot,
+// the npm workflow, and local mode — runs THIS function so they plan
+// identically; only the tier → concrete-model binding differs per consumer.
+//
+// Lives in its own module (not in `review-plan.ts`) because it imports
+// `estimateBudget`, and `budget-plan.ts` already imports from `review-plan.ts`
+// — keeping `planReview` here avoids a review-plan ↔ budget-plan cycle.
+
+import {
+  resolveReviewPasses,
+  totalPassCount,
+  type ReviewPlanSkill,
+  type ReviewPassesConfig,
+  type ResolvedReviewPasses,
+  type ReviewRole,
+  type ApplyTo,
+} from './review-plan.js';
+import { estimateBudget, type BudgetVerdict } from './budget-plan.js';
+
+/** Trigger context that selects plan depth (SPEC §11.5). */
+export type ReviewTrigger = 'commit' | 'push' | 'pr';
+
+/** Why a plan was tiered down from its fully-resolved passes. */
+export type TierDownReason = 'commit' | 'large-diff';
+
+/**
+ * Diff size (bytes) at/above which the planner auto-tiers down to a single
+ * fast pass to protect cost + latency. A very large diff rarely benefits from
+ * multi-pass depth as much as it costs.
+ */
+export const LARGE_DIFF_THRESHOLD_BYTES = 50_000;
+
+export interface PlanReviewInput {
+  /** Loaded skills — the caller does the consumer-specific I/O to load them. */
+  skills: ReviewPlanSkill[];
+  /** Parsed `.clud-bug.json` `reviewPasses` block (may be null). */
+  config: ReviewPassesConfig | null;
+  /** Raw SKILL.md text per slug, for the frontmatter `review_passes` override. */
+  rawSkillMd?: Record<string, string>;
+  /** Trigger context. Defaults to `pr` (the full plan). */
+  trigger?: ReviewTrigger;
+  /** Diff size under review, in bytes — enables large-diff auto-tiering. */
+  diffSizeBytes?: number;
+  /** Optional per-PR USD cap forwarded to the budget gate. */
+  perPrCapUsd?: number;
+  /** Billing-exempt installs bypass the budget cap. */
+  billingExempt?: boolean;
+}
+
+export interface ReviewPlan {
+  /** Effective per-skill passes (after any tier-down). */
+  perSkill: ResolvedReviewPasses[];
+  /** Role tiers in pass order — the consumer binds each tier → a concrete model. */
+  roles: ReviewRole[];
+  /** Multi-pass apply scope. */
+  applyTo: ApplyTo;
+  /** Layer-1 budget verdict over the effective (post-tiering) plan. */
+  budget: BudgetVerdict;
+  /** The trigger this plan was computed for. */
+  trigger: ReviewTrigger;
+  /** Present when the resolved passes were tiered down, with the reason. */
+  tieredDown?: TierDownReason;
+  /** One-line human summary. */
+  summary: string;
+}
+
+/**
+ * Plan a review. Tiering (a commit-time review runs on every commit, and a very
+ * large diff shouldn't pay for full multi-pass depth):
+ *   - `trigger: 'commit'`                           → a single fast pass per skill.
+ *   - `diffSizeBytes` >= `LARGE_DIFF_THRESHOLD_BYTES` → a single fast pass per skill.
+ *   - otherwise (push/pr, normal diff)               → the fully-resolved plan.
+ * `commit` takes precedence over diff size.
+ *
+ * Tiering to one pass means pass 1 / role[0] (the `beetle` fast tier) runs — so
+ * "fast model for commits" falls out of the tier system, never hand-picked.
+ */
+export function planReview(input: PlanReviewInput): ReviewPlan {
+  const trigger: ReviewTrigger = input.trigger ?? 'pr';
+
+  const resolved = resolveReviewPasses({
+    skills: input.skills,
+    config: input.config,
+    ...(input.rawSkillMd !== undefined ? { rawSkillMd: input.rawSkillMd } : {}),
+  });
+
+  let tieredDown: TierDownReason | undefined;
+  if (trigger === 'commit') {
+    tieredDown = 'commit';
+  } else if (
+    input.diffSizeBytes !== undefined &&
+    input.diffSizeBytes >= LARGE_DIFF_THRESHOLD_BYTES
+  ) {
+    tieredDown = 'large-diff';
+  }
+
+  const perSkill: ResolvedReviewPasses[] = tieredDown
+    ? resolved.perSkill.map((p) => ({ ...p, count: 1 }))
+    : resolved.perSkill;
+
+  // Cost only the passes that actually run: a tiered plan runs a single
+  // (role[0] / beetle) pass, so don't bill the skipped deeper tiers.
+  const roleModels = (tieredDown ? resolved.roles.slice(0, 1) : resolved.roles).map(
+    (r) => r.model,
+  );
+  const budget = estimateBudget({
+    resolved: perSkill,
+    roleModels,
+    ...(input.perPrCapUsd !== undefined ? { perPrCapUsd: input.perPrCapUsd } : {}),
+    ...(input.billingExempt !== undefined ? { billingExempt: input.billingExempt } : {}),
+  });
+
+  const passes = totalPassCount(perSkill);
+  const tierNote = tieredDown ? `, tiered down (${tieredDown})` : '';
+  const budgetNote =
+    budget.verdict === 'deny'
+      ? `; budget exceeded ($${budget.estimate.estimatedCostUsd.toFixed(2)} > $${budget.estimate.capUsd.toFixed(2)})`
+      : `; est $${budget.estimate.estimatedCostUsd.toFixed(2)}`;
+  const summary = `${passes} pass(es) across ${perSkill.length} skill(s) [${trigger}]${tierNote}${budgetNote}`;
+
+  return {
+    perSkill,
+    roles: resolved.roles,
+    applyTo: resolved.applyTo,
+    budget,
+    trigger,
+    ...(tieredDown !== undefined ? { tieredDown } : {}),
+    summary,
+  };
+}

--- a/test/core/plan-review.test.js
+++ b/test/core/plan-review.test.js
@@ -1,0 +1,106 @@
+// Tests for src/core/plan-review.ts — the shared `planReview` entry point
+// (SPEC §11.5). It composes resolveReviewPasses + estimateBudget and applies the
+// trigger / diff-size tiering (commit → a single fast pass; large diff → auto-tier).
+
+import { describe, expect, it } from 'vitest';
+
+import { planReview, LARGE_DIFF_THRESHOLD_BYTES } from '../../src/core/plan-review.js';
+
+// Minimal `{ slug, frontmatter }` (core SkillFrontmatter) — planReview only
+// forwards these to resolveReviewPasses, which reads slug + review_mode.
+function makeSkill(slug, review_mode = 'shared') {
+  return {
+    slug,
+    frontmatter: { name: slug, description: `Test ${slug}`, source: 'manual', review_mode },
+  };
+}
+
+const SKILLS = [makeSkill('a'), makeSkill('b')];
+// Repo-default 3 passes so the tier-down (3 → 1) is observable.
+const CONFIG = { count: 3, mode: 'consensus' };
+
+describe('planReview', () => {
+  it('returns a full plan by default (no trigger): counts from the resolver, plus budget + roles + summary', () => {
+    const plan = planReview({ skills: SKILLS, config: CONFIG });
+    expect(plan.perSkill.map((p) => p.count)).toEqual([3, 3]);
+    expect(plan.trigger).toBe('pr');
+    expect(plan.tieredDown).toBeUndefined();
+    expect(plan.budget.verdict).toBeDefined();
+    expect(plan.budget.estimate.estimatedCalls).toBeGreaterThan(0);
+    expect(plan.roles.length).toBeGreaterThan(0);
+    expect(typeof plan.summary).toBe('string');
+  });
+
+  it('tiers down to a single fast pass on a commit trigger', () => {
+    const full = planReview({ skills: SKILLS, config: CONFIG });
+    const plan = planReview({ skills: SKILLS, config: CONFIG, trigger: 'commit' });
+    expect(plan.perSkill.every((p) => p.count === 1)).toBe(true);
+    expect(plan.tieredDown).toBe('commit');
+    // fewer planned calls than the full plan → cheaper, the whole point.
+    expect(plan.budget.estimate.estimatedCalls).toBeLessThan(full.budget.estimate.estimatedCalls);
+    expect(plan.summary).toMatch(/tier/i);
+  });
+
+  it('auto-tiers down on a large diff (push trigger)', () => {
+    const plan = planReview({
+      skills: SKILLS,
+      config: CONFIG,
+      trigger: 'push',
+      diffSizeBytes: LARGE_DIFF_THRESHOLD_BYTES + 1,
+    });
+    expect(plan.perSkill.every((p) => p.count === 1)).toBe(true);
+    expect(plan.tieredDown).toBe('large-diff');
+  });
+
+  it('keeps the full plan on push with a small diff', () => {
+    const plan = planReview({ skills: SKILLS, config: CONFIG, trigger: 'push', diffSizeBytes: 100 });
+    expect(plan.perSkill.map((p) => p.count)).toEqual([3, 3]);
+    expect(plan.tieredDown).toBeUndefined();
+  });
+
+  it('commit tiering takes precedence over diff size', () => {
+    const plan = planReview({
+      skills: SKILLS,
+      config: CONFIG,
+      trigger: 'commit',
+      diffSizeBytes: 100,
+    });
+    expect(plan.perSkill.every((p) => p.count === 1)).toBe(true);
+    expect(plan.tieredDown).toBe('commit');
+  });
+
+  it('tiers down when diffSizeBytes equals the threshold (>= boundary)', () => {
+    const plan = planReview({
+      skills: SKILLS,
+      config: CONFIG,
+      trigger: 'push',
+      diffSizeBytes: LARGE_DIFF_THRESHOLD_BYTES,
+    });
+    expect(plan.tieredDown).toBe('large-diff');
+    expect(plan.perSkill.every((p) => p.count === 1)).toBe(true);
+  });
+
+  it('costs a tiered plan at only the fast tier (does not bill the skipped deeper tiers)', () => {
+    const full = planReview({ skills: SKILLS, config: CONFIG });
+    const tiered = planReview({ skills: SKILLS, config: CONFIG, trigger: 'commit' });
+    // Tiering runs only role[0] (beetle), so the per-call ceiling must drop —
+    // not stay pinned at the max across the (unused) deeper tiers.
+    expect(tiered.budget.estimate.perCallCeilingUsd).toBeLessThan(
+      full.budget.estimate.perCallCeilingUsd,
+    );
+  });
+
+  it('handles an empty skills array gracefully', () => {
+    const plan = planReview({ skills: [], config: CONFIG });
+    expect(plan.perSkill).toEqual([]);
+    expect(plan.budget.estimate.estimatedCalls).toBe(0);
+    expect(plan.budget.verdict).toBe('allow');
+    expect(plan.summary).toMatch(/0 pass/);
+  });
+
+  it('reports budget-exceeded detail in the summary when the verdict is deny', () => {
+    const plan = planReview({ skills: SKILLS, config: CONFIG, perPrCapUsd: 0.000001 });
+    expect(plan.budget.verdict).toBe('deny');
+    expect(plan.summary).toMatch(/budget exceeded/i);
+  });
+});


### PR DESCRIPTION
## `planReview` — the single shared planning entry point (SPEC §11.5)

Builds on PR #185's engine extraction: `core/plan-review.ts` composes `resolveReviewPasses` + `estimateBudget` into the one function every consumer (hosted bot, npm workflow, local mode) plans through — so they plan **identically**, and the SPEC §11.5 contract is now real in code.

### Trigger / diff tiering (the "models based on diff" ask)
- `trigger: 'commit'` → a **single fast (`beetle`-tier) pass** per skill (commit-time runs on every commit; don't pay for full depth).
- `diffSizeBytes >= LARGE_DIFF_THRESHOLD_BYTES` → auto-tier to a single fast pass.
- otherwise (push/pr, normal diff) → the fully-resolved multi-pass plan.

The fast-vs-deep choice falls out of the **tier system** — never hand-picked per call.

### Adversarial review — 2 findings fixed (with regression tests)
- **Off-by-one**: the threshold predicate was `>` while the contract says "at/above" → `>=` (a diff of exactly the threshold now tiers). The boundary test made the bug visible.
- **Tiered-plan cost overestimate**: after tiering to a single beetle pass, `roleModels` still included wasp/mantis, so `perCallCeiling` reported ~6× the real cost — contradicting the point of tiering. Now only the running tier is billed.
- Added gap-filling tests: threshold boundary, empty skills, deny-budget summary path.

### Verification
- `npm run build` (tsc strict): clean
- `npm test`: **825 passed** (35 files; +9 plan-review)
- `npm run test:fixtures`: 5/5

Rides in the unpublished rc.12 (no version bump). Consumed by PR 0b (App re-wire) + PR C (`review-prompt` verb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)