### PR TITLE
Wave 6b: clud-bug review-prompt — the plan-aware local-review recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ Wave 6b (PR 0) — shared review engine extracted into `core` (single source of 
   `trigger: 'commit'` (or a diff over `LARGE_DIFF_THRESHOLD_BYTES`) tiers down to a single fast
   (`beetle`-tier) pass; otherwise the full multi-pass plan. Every consumer plans through this one
   function, so the fast-vs-deep choice falls out of the tier system — never hand-picked per call.
+- **`clud-bug review-prompt [--trigger commit|push|pr]`** — emits the local-review *recipe*:
+  the structured prompt a Claude Code agent (or a `type: agent` hook) runs to review the current
+  diff on the session's own subscription. It loads the repo's skills + `.clud-bug.json`, plans via
+  `planReview`, and renders a plan-aware recipe — a single fast pass on `commit`, the full
+  multi-pass fan-out (with the resolved tiers + aggregation mode) on `push`/`pr`. The dynamic,
+  engine-driven counterpart of the rc.11 static `/clud-bug-review` slash command.
 
 ## [0.7.0-rc.11] — 2026-06-28
 

--- a/docs/decisions-branches/wave-6b-review-prompt.md
+++ b/docs/decisions-branches/wave-6b-review-prompt.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-28 16:22 - Add clud-bug review-prompt verb — the plan-aware local-review recipe (PR C keystone)
+
+**Reasoning:** Turns the shared engine into the native commit-review recipe the in-session subagent runs: loads the repo's skills + .clud-bug.json, plans via planReview, and renders a plan-aware recipe — a single fast (beetle-tier) pass on commit, the full multi-pass fan-out (resolved tiers + aggregation mode) on push/pr. The dynamic, engine-driven counterpart of the rc.11 static /clud-bug-review slash command. Rides the unpublished rc.12.
+
+**Alternatives considered:** Keep the static recipe only — rejected: it can't reflect the engine's per-repo plan (tiers, pass count, budget, trigger).
+
+**Implications:**
+- Consumed by PR C's --with-hooks (renders this recipe into the type:agent hook prompt). 2-lens adversarial review caught + fixed: rawSkillMd not forwarded (dead SKILL.md override layer), origin/HEAD diff fallback (empty-diff false-clean in CI), cross-check incoherence, summary pass-count contradiction, silent --trigger typo->commit, global-mode-from-first-skill. Deferred: filtering meta skills (clud-bug-collaboration) from the review-skill load — needs a frontmatter signal. 831 tests green.
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -73,6 +73,7 @@ clud-bug
 │   ├── release-discipline.test.js
 │   ├── render-review.test.js
 │   ├── render.test.js
+│   ├── review-prompt.test.js
 │   ├── review-schema-zod.test.js
 │   ├── review-writeback.test.js
 │   ├── skill-usage-aggregation.test.js

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (54 decisions)
+## 2026-06 (55 decisions)
 
-- **2026-06-28** — Add planReview — the shared review-plan entry point (SPEC §11.5), trigger/diff tiered *(wave-6b-plan-review)* — [decisions-branches/wave-6b-plan-review.md](decisions-branches/wave-6b-plan-review.md)
-- *... 52 more decisions ...*
+- **2026-06-28** — Add clud-bug review-prompt verb — the plan-aware local-review recipe (PR C keystone) *(wave-6b-review-prompt)* — [decisions-branches/wave-6b-review-prompt.md](decisions-branches/wave-6b-review-prompt.md)
+- *... 53 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -31,6 +31,7 @@ import {
 import { computeAuditFileSet } from './audit.js';
 import { renderAuditHeader } from '../core/audit.js';
 import { runUpdate } from './update.js';
+import { runReviewPrompt } from './review-prompt.js';
 import { getPendingWorkflowEdits, makeBranchName, git as gitCmd } from './edit-workflow.js';
 import { applyToRepo as applyAgentDocs } from './agents-md.js';
 import { detectRepo, detectDefaultBranch, getProtectionState, enableConversationResolution } from './branch-protection.js';
@@ -95,6 +96,8 @@ function parseArgs(argv) {
     else if (a === '--with-local-review') args.withLocalReview = true;
     else if (a === '--dry-run') args.dryRun = true;
     else if (a === '--branch') args.branch = argv[++i];
+    else if (a === '--trigger') args.trigger = argv[++i];
+    else if (a === '--diff-size') args.diffSizeBytes = Number(argv[++i]);
     else args._.push(a);
   }
   return args;
@@ -185,6 +188,11 @@ Commands:
                         Required env vars: GH_TOKEN, ANTHROPIC_API_KEY,
                         REPO ("owner/name"), PR_NUMBER. Output: JSON
                         \`{actions, verifierCallCount, shouldRequestChanges}\`.
+  review-prompt         Emit the local-review recipe — the structured prompt a
+                        Claude Code agent/hook runs to review the current diff on
+                        the session's own subscription. Plans via the shared
+                        engine: --trigger commit (default) → a fast single pass;
+                        push/pr → the full multi-pass plan. Prints to stdout.
 
 Options:
   --offline             Skip skills.sh; pin only the bundled baseline specimens.
@@ -206,6 +214,7 @@ Options:
   --dry-run             Print the canonical-v1 diff without PATCH-ing
                         (configure-github only).
   --branch <name>       Target branch for configure-github (default: main).
+  --trigger <ctx>       review-prompt context: commit (default) | push | pr.
   --repo <owner/name>   Restrict \`usage\` to a single repo. Default: all repos
                         with clud-bug-review.yml in the gh user's auth scope.
   --pr <N>              Restrict \`usage\` to a single PR.
@@ -249,6 +258,7 @@ async function main() {
     case 'select-review-event': return runSelectReviewEvent(args);
     case 'post-inline-threads': return runPostInlineThreads(args);
     case 'resolve-threads': return runResolveThreads(args);
+    case 'review-prompt': return runReviewPrompt(args);
     default:
       process.stderr.write(`Unknown command: ${cmd || '(none)'}\n\n${HELP}`);
       process.exit(2);

--- a/src/cli/review-prompt.ts
+++ b/src/cli/review-prompt.ts
@@ -1,0 +1,206 @@
+// `clud-bug review-prompt` — emits the local-review RECIPE: a highly-structured
+// prompt the in-session Claude Code agent (or a `type: agent` hook) runs to
+// review the current diff, on the session's own subscription. It is the dynamic,
+// planReview-driven counterpart of the rc.11 static slash-command prompt: the
+// recipe is rendered FROM the shared engine (`core/planReview`), so a commit
+// gets a single fast pass and a PR gets the full multi-pass plan — clud-bug
+// writes the recipe, Claude Code's subagent is the runtime.
+
+import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
+
+import {
+  planReview,
+  roleForPass,
+  readReviewPassesConfig,
+  parseFrontmatter,
+  type ReviewPlan,
+  type ReviewPlanSkill,
+  type ReviewTrigger,
+  type ReviewPassMode,
+} from '../core/index.js';
+import { readManifest } from './skills.js';
+
+/** Marker that identifies a clud-bug local-review recipe (idempotency + hook detection). */
+export const CLUD_BUG_RECIPE_MARKER = 'clud-bug-local-review';
+
+const MODE_AGGREGATION: Record<ReviewPassMode, string> = {
+  'cross-check':
+    "Pass 1 reviews the diff against all the skills; each later pass re-reviews AND checks pass 1's findings (agree / disagree), adding any new ones it finds.",
+  consensus:
+    'Run all passes independently against all the skills, then keep only findings that two or more passes agree on.',
+  independent:
+    'Run all passes independently against all the skills, then take the union of their findings, each attributed to its pass.',
+};
+
+const TRIGGER_INTRO: Record<ReviewTrigger, string> = {
+  commit: 'a fast review of the commit you just made',
+  push: 'a review of the branch you are about to push',
+  pr: "a review of this branch's open PR",
+};
+
+/**
+ * Render the local-review recipe from a resolved plan. Pure — all I/O (loading
+ * skills + config) happens in `runReviewPrompt`; this turns a `ReviewPlan` into
+ * the prompt text. The number of passes, the aggregation mode, the role tiers,
+ * and the skills all come from the plan, so the recipe scales from a single
+ * fast commit pass up to the full multi-pass PR review without branching here.
+ */
+export function renderReviewRecipe(input: { plan: ReviewPlan; trigger: ReviewTrigger }): string {
+  const { plan, trigger } = input;
+  const slugs = plan.perSkill.map((p) => p.slug);
+  const maxPasses = plan.perSkill.length
+    ? Math.max(...plan.perSkill.map((p) => p.count))
+    : 1;
+  // Use the aggregation mode of the skill that drives the pass depth, not just
+  // the first skill (which may be configured for a single pass).
+  const mode: ReviewPassMode =
+    plan.perSkill.find((p) => p.count === maxPasses)?.mode ?? 'cross-check';
+
+  const diffStep =
+    trigger === 'commit'
+      ? 'The commit you just made:\n\n```bash\ngit show --no-color --format=medium HEAD\n```'
+      : 'If an open PR exists for this branch, review it; otherwise diff the branch against its base:\n\n' +
+        '```bash\n' +
+        'PR=$(gh pr list --head "$(git branch --show-current)" --state open --json number --jq \'.[0].number\')\n' +
+        'if [ -n "$PR" ]; then\n' +
+        '  gh pr diff "$PR"\n' +
+        'else\n' +
+        '  git remote set-head origin --auto >/dev/null 2>&1 || true  # make sure origin/HEAD resolves\n' +
+        '  git diff --no-color origin/HEAD...HEAD\n' +
+        'fi\n' +
+        '```';
+
+  const skillsList =
+    slugs.length > 0
+      ? slugs.map((s) => `  - \`.claude/skills/${s}/SKILL.md\``).join('\n')
+      : '  - (no skills resolved — apply the baseline discipline below)';
+
+  let reviewStep: string;
+  if (maxPasses <= 1) {
+    reviewStep =
+      'Review the diff against every loaded skill in a single pass. For each REAL issue, ' +
+      'record `file`, `line`, `severity` (`critical` | `minor` | `preexisting`), the `skill` ' +
+      'that motivated it, and a one-line `summary` with the quoted offending line. Finding ' +
+      'nothing is the normal outcome — be precise, not exhaustive.';
+  } else {
+    const passLines = Array.from({ length: maxPasses }, (_, i) => {
+      const role = roleForPass(plan.roles, i, 'Reviewer');
+      const tier = role.tier ? ` · ${role.tier} tier` : '';
+      return `  ${i + 1}. **${role.name}**${tier}`;
+    }).join('\n');
+    reviewStep =
+      `Dispatch ${maxPasses} reviewer sub-agents — a ${maxPasses}-pass **${mode}** review on this ` +
+      `session's subscription (bind each tier to a Claude Code model: a fast model for \`beetle\`, ` +
+      `a strong model for \`wasp\`/\`mantis\`):\n\n${passLines}\n\n${MODE_AGGREGATION[mode]}`;
+  }
+
+  const surface =
+    trigger === 'commit'
+      ? 'Surface the findings back into this session so the agent can fix them immediately. ' +
+        'If the commit is clean, report a single line: `clud-bug: commit <short-sha> — clean.`'
+      : 'Surface the findings into the session, and — if an open PR exists — post or edit (in ' +
+        'place, by integer comment id) the clud-bug summary comment on it.';
+
+  return `<!-- ${CLUD_BUG_RECIPE_MARKER} v1 -->
+You are **clud-bug**, running ${TRIGGER_INTRO[trigger]} inside this Claude Code session, on
+this session's own model tokens — no hosted App, no extra auth (you already have \`git\`,
+\`gh\`, and file access).
+
+## The plan
+clud-bug resolved this review from the repo's skills + \`.clud-bug.json\`:
+**${plan.summary}**
+
+## 1. Get the diff
+${diffStep}
+
+## 2. Load the review skills
+Read each skill's discipline from the checkout:
+${skillsList}
+
+Apply them strictly — at minimum **critical-issues-only** (flag only correctness, security,
+or performance bugs — skip nits), **evidence-based-review** (quote the exact line you flag),
+and **respect-existing-conventions** (don't fight the codebase's patterns).
+
+## 3. Review
+${reviewStep}
+
+## 4. Report
+Render the body in clud-bug's standard shape (§1.8.1) — omit any empty section:
+
+\`\`\`
+## 🐛 Clud Bug review — <clean | critical findings>
+
+**This round:** N critical · N minor · N resolved from prior · N still open
+
+Found: N 🔴 / N 🟡 / N 🟣
+
+<per-finding: 🔴 [skill]: <summary> (file:line) — with the quoted line + a one-line fix>
+
+Skills referenced: [<the skills you applied>]
+
+<!-- written-by: @<login> (clud-bug local-mode) -->
+\`\`\`
+
+${surface}
+
+Keep it tight — this is the local safety net; the deeper review still happens at PR time.
+`;
+}
+
+interface ReviewPromptArgs {
+  trigger?: string;
+  cwd?: string;
+  diffSizeBytes?: number;
+  _?: string[];
+}
+
+/**
+ * `clud-bug review-prompt [--trigger commit|push|pr]` — load the repo's skills +
+ * config, plan the review through `core/planReview`, and print the recipe to
+ * stdout. Defaults to the `commit` trigger (the primary hook consumer).
+ */
+export async function runReviewPrompt(args: ReviewPromptArgs): Promise<void> {
+  const cwd = args.cwd ?? process.cwd();
+  const trigger = normalizeTrigger(args.trigger);
+
+  const skillsDir = join(cwd, '.claude', 'skills');
+  const manifest = await readManifest(skillsDir);
+
+  // Load each installed skill's frontmatter (for `review_mode`), tolerating a
+  // skill whose SKILL.md is missing or unparseable (skip it, don't crash).
+  const skills: ReviewPlanSkill[] = [];
+  // Keep the raw SKILL.md text so `planReview` can honor a skill author's
+  // `review_passes:` frontmatter override (precedence layer 2) — without this
+  // that layer is silently dead in local mode.
+  const rawSkillMd: Record<string, string> = {};
+  for (const entry of manifest.installed) {
+    try {
+      const raw = await readFile(join(skillsDir, entry.slug, 'SKILL.md'), 'utf8');
+      skills.push({ slug: entry.slug, frontmatter: parseFrontmatter(raw) });
+      rawSkillMd[entry.slug] = raw;
+    } catch {
+      // Skill body unreadable/unparseable — omit from the plan.
+    }
+  }
+
+  const config = readReviewPassesConfig(manifest);
+  const plan = planReview({
+    skills,
+    config,
+    trigger,
+    rawSkillMd,
+    ...(args.diffSizeBytes !== undefined ? { diffSizeBytes: args.diffSizeBytes } : {}),
+  });
+
+  process.stdout.write(renderReviewRecipe({ plan, trigger }) + '\n');
+}
+
+function normalizeTrigger(raw: string | undefined): ReviewTrigger {
+  if (raw === undefined || raw === 'commit') return 'commit';
+  if (raw === 'push' || raw === 'pr') return raw;
+  process.stderr.write(
+    `clud-bug review-prompt: unrecognized --trigger "${raw}" (expected commit|push|pr); using commit.\n`,
+  );
+  return 'commit';
+}

--- a/src/core/plan-review.ts
+++ b/src/core/plan-review.ts
@@ -10,7 +10,6 @@
 
 import {
   resolveReviewPasses,
-  totalPassCount,
   type ReviewPlanSkill,
   type ReviewPassesConfig,
   type ResolvedReviewPasses,
@@ -112,13 +111,18 @@ export function planReview(input: PlanReviewInput): ReviewPlan {
     ...(input.billingExempt !== undefined ? { billingExempt: input.billingExempt } : {}),
   });
 
-  const passes = totalPassCount(perSkill);
+  // Report the per-skill pass DEPTH (max), not the summed call count — the
+  // recipe branches on this same depth, so "1-pass" here agrees with "single
+  // pass" there. (Total call count drives the budget below, not the summary.)
+  const passesPerSkill = perSkill.length
+    ? Math.max(...perSkill.map((p) => p.count))
+    : 0;
   const tierNote = tieredDown ? `, tiered down (${tieredDown})` : '';
   const budgetNote =
     budget.verdict === 'deny'
       ? `; budget exceeded ($${budget.estimate.estimatedCostUsd.toFixed(2)} > $${budget.estimate.capUsd.toFixed(2)})`
       : `; est $${budget.estimate.estimatedCostUsd.toFixed(2)}`;
-  const summary = `${passes} pass(es) across ${perSkill.length} skill(s) [${trigger}]${tierNote}${budgetNote}`;
+  const summary = `${passesPerSkill}-pass review across ${perSkill.length} skill(s) [${trigger}]${tierNote}${budgetNote}`;
 
   return {
     perSkill,

--- a/test/core/plan-review.test.js
+++ b/test/core/plan-review.test.js
@@ -95,7 +95,7 @@ describe('planReview', () => {
     expect(plan.perSkill).toEqual([]);
     expect(plan.budget.estimate.estimatedCalls).toBe(0);
     expect(plan.budget.verdict).toBe('allow');
-    expect(plan.summary).toMatch(/0 pass/);
+    expect(plan.summary).toMatch(/0-pass/);
   });
 
   it('reports budget-exceeded detail in the summary when the verdict is deny', () => {

--- a/test/review-prompt.test.js
+++ b/test/review-prompt.test.js
@@ -1,0 +1,149 @@
+// Tests for src/cli/review-prompt.ts — `renderReviewRecipe`, the plan-aware
+// local-review recipe the `clud-bug review-prompt` verb emits (the dynamic,
+// planReview-driven counterpart of the rc.11 static slash-command prompt).
+
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+import { planReview } from '../src/core/plan-review.js';
+import { renderReviewRecipe, CLUD_BUG_RECIPE_MARKER } from '../src/cli/review-prompt.js';
+
+const CLI = join(dirname(dirname(fileURLToPath(import.meta.url))), 'bin', 'clud-bug.js');
+
+function makeSkill(slug, review_mode = 'shared') {
+  return {
+    slug,
+    frontmatter: { name: slug, description: `Test ${slug}`, source: 'manual', review_mode },
+  };
+}
+
+const SKILLS = [
+  makeSkill('critical-issues-only'),
+  makeSkill('evidence-based-review'),
+  makeSkill('respect-existing-conventions'),
+];
+const MULTIPASS_CONFIG = { count: 3, mode: 'consensus' };
+
+describe('renderReviewRecipe', () => {
+  it('emits a commit recipe: marker, single fast pass, reviews HEAD, lists the skills, §1.8.1 format', () => {
+    const plan = planReview({ skills: SKILLS, config: MULTIPASS_CONFIG, trigger: 'commit' });
+    const recipe = renderReviewRecipe({ plan, trigger: 'commit' });
+
+    expect(recipe).toContain(CLUD_BUG_RECIPE_MARKER);
+    // commit → reviews the just-made commit's diff
+    expect(recipe).toMatch(/git show[^\n]*HEAD/);
+    // every resolved skill is named so the agent loads it
+    for (const s of SKILLS) expect(recipe).toContain(s.slug);
+    // commit tiers down to ONE pass — no multi-agent fan-out language
+    expect(recipe).not.toMatch(/dispatch \d+ reviewer/i);
+    // the clud-bug §1.8.1 review body shape
+    expect(recipe).toMatch(/Clud Bug review/i);
+  });
+
+  it('emits a multi-pass recipe on a pr trigger: fan-out to N sub-agents + the aggregation mode + the tiers', () => {
+    const plan = planReview({ skills: SKILLS, config: MULTIPASS_CONFIG, trigger: 'pr' });
+    const recipe = renderReviewRecipe({ plan, trigger: 'pr' });
+
+    // pr keeps the full 3-pass plan → instructs dispatching reviewer sub-agents
+    expect(recipe).toMatch(/dispatch 3 reviewer/i);
+    // names the aggregation mode resolved by the plan
+    expect(recipe).toMatch(/consensus/i);
+    // names the role tiers (Beetle/Wasp/Mantis) so each pass binds a model
+    expect(recipe).toMatch(/beetle/i);
+    expect(recipe).toMatch(/wasp/i);
+    // pr reviews the branch against its base (not a single commit)
+    expect(recipe).toMatch(/gh pr diff|origin\//);
+  });
+
+  it('carries the plan summary so the operator sees what was resolved', () => {
+    const plan = planReview({ skills: SKILLS, config: MULTIPASS_CONFIG, trigger: 'commit' });
+    const recipe = renderReviewRecipe({ plan, trigger: 'commit' });
+    expect(recipe).toContain(plan.summary);
+  });
+});
+
+describe('review-prompt verb (integration)', () => {
+  it('loads the manifest + skill frontmatter and prints a recipe', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'clud-bug-rp-'));
+    const skillsDir = join(dir, '.claude', 'skills');
+    await mkdir(join(skillsDir, 'critical-issues-only'), { recursive: true });
+    await writeFile(
+      join(skillsDir, '.clud-bug.json'),
+      JSON.stringify({
+        version: 1,
+        installed: [
+          {
+            slug: 'critical-issues-only',
+            name: 'critical-issues-only',
+            source: 'manual',
+            kind: 'baseline',
+            description: 'x',
+          },
+        ],
+      }),
+    );
+    await writeFile(
+      join(skillsDir, 'critical-issues-only', 'SKILL.md'),
+      '---\nname: critical-issues-only\ndescription: x\nsource: manual\nreview_mode: shared\n---\n\nrules',
+    );
+
+    const r = spawnSync(process.execPath, [CLI, 'review-prompt', '--trigger', 'commit'], {
+      cwd: dir,
+      encoding: 'utf8',
+      timeout: 30000,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain(CLUD_BUG_RECIPE_MARKER);
+    expect(r.stdout).toMatch(/git show[^\n]*HEAD/);
+    expect(r.stdout).toContain('critical-issues-only');
+  });
+
+  it('honors a SKILL.md review_passes override on a pr trigger (rawSkillMd forwarded)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'clud-bug-rp2-'));
+    const skillsDir = join(dir, '.claude', 'skills');
+    await mkdir(join(skillsDir, 'deep-skill'), { recursive: true });
+    await writeFile(
+      join(skillsDir, '.clud-bug.json'),
+      JSON.stringify({
+        version: 1,
+        installed: [
+          { slug: 'deep-skill', name: 'deep-skill', source: 'manual', kind: 'baseline', description: 'x' },
+        ],
+      }),
+    );
+    // The skill author asks for a 3-pass consensus review via SKILL.md frontmatter
+    // (precedence layer 2) — this only lands if runReviewPrompt forwards rawSkillMd.
+    await writeFile(
+      join(skillsDir, 'deep-skill', 'SKILL.md'),
+      '---\nname: deep-skill\ndescription: x\nsource: manual\nreview_mode: shared\nreview_passes:\n  count: 3\n  mode: consensus\n---\n\nrules',
+    );
+
+    const r = spawnSync(process.execPath, [CLI, 'review-prompt', '--trigger', 'pr'], {
+      cwd: dir,
+      encoding: 'utf8',
+      timeout: 30000,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Dispatch 3 reviewer/i);
+  });
+
+  it('warns on an unrecognized --trigger and falls back to a commit recipe', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'clud-bug-rp3-'));
+    const skillsDir = join(dir, '.claude', 'skills');
+    await mkdir(skillsDir, { recursive: true });
+    await writeFile(join(skillsDir, '.clud-bug.json'), JSON.stringify({ version: 1, installed: [] }));
+
+    const r = spawnSync(process.execPath, [CLI, 'review-prompt', '--trigger', 'bogus'], {
+      cwd: dir,
+      encoding: 'utf8',
+      timeout: 30000,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stderr).toMatch(/unrecognized --trigger/i);
+    expect(r.stdout).toMatch(/git show[^\n]*HEAD/);
+  });
+});


### PR DESCRIPTION
## `clud-bug review-prompt [--trigger commit|push|pr]`

The keystone that turns the shared engine into the **native commit-review recipe** the in-session Claude Code subagent (or a `type: agent` hook) runs — on the session's own subscription. It loads the repo's skills + `.clud-bug.json`, plans via `planReview`, and renders a **plan-aware recipe**:
- `--trigger commit` (default) → a single fast (`beetle`-tier) pass.
- `--trigger push|pr` → the full multi-pass fan-out, with the resolved tiers + aggregation mode.

It's the dynamic, engine-driven counterpart of the rc.11 static `/clud-bug-review` slash command — the recipe now reflects the engine's per-repo plan, never a hand-picked depth.

### Adversarial review — 2 lenses, 6 fixes (2 critical)
- **CRITICAL — `rawSkillMd` not forwarded**: the SKILL.md `review_passes:` override (precedence layer 2) was silently dead in local mode. Now forwarded + regression-tested (a `review_passes: count 3` skill → a 3-pass fan-out).
- **CRITICAL — `origin/HEAD` diff fallback**: unset in CI/fetch → empty diff → false "clean". Now `git remote set-head origin --auto` + `origin/HEAD...HEAD`.
- cross-check aggregation made coherent with the fan-out; the plan summary now reports per-skill **depth** (so "1-pass" agrees with "single pass"); `--trigger` typo now warns instead of silently downgrading; aggregation mode taken from the depth-driving skill, not `perSkill[0]`.

### Verification
- `npm run build` (tsc strict): clean
- `npm test`: **831 passed** (36 files; +7 review-prompt, incl. a verb integration test)
- `npm run test:fixtures`: 5/5
- Functional smoke: commit recipe (1 fast pass, `est $0.08`) + pr recipe (multi-pass fan-out with tiers) both render correctly.

### Deferred follow-up
Filtering meta/process skills (e.g. `clud-bug-collaboration`) out of the "load the review skills" list — there's no clean frontmatter signal today (it defaults to `review_mode: shared` like a real lens); needs a deliberate schema decision (or matching whatever the hosted bot does). Bounded impact: the recipe still names the 3 real review disciplines as the minimum.

Rides the unpublished rc.12. Consumed by PR C (`--with-hooks` renders this into the hook prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)