### PR TITLE
Wave 6b: clud-bug init --with-hooks — native commit-review hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ Wave 6b (PR 0) — shared review engine extracted into `core` (single source of 
   `planReview`, and renders a plan-aware recipe — a single fast pass on `commit`, the full
   multi-pass fan-out (with the resolved tiers + aggregation mode) on `push`/`pr`. The dynamic,
   engine-driven counterpart of the rc.11 static `/clud-bug-review` slash command.
+- **`clud-bug init --with-hooks`** (off by default) — scaffolds a native Claude Code `type: agent`
+  commit-review hook into `.claude/settings.json` (merged non-clobbering, preserving existing
+  settings + hooks). On every `git commit` the agent makes, a **backgrounded** (`async`) review
+  subagent runs on the session's **own subscription** — its prompt simply runs `clud-bug
+  review-prompt` and follows the engine recipe, so it's always current. Implies `--with-local-review`;
+  `clud-bug update` refreshes our marked hook in place. (`type: agent` is experimental; a `type:
+  command` + `additionalContext` fallback reaches the same outcome on stable primitives.)
 
 ## [0.7.0-rc.11] — 2026-06-28
 

--- a/docs/decisions-branches/wave-6b-hooks.md
+++ b/docs/decisions-branches/wave-6b-hooks.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-28 16:40 - Add clud-bug init --with-hooks — native type:agent commit-review hook (Wave 6b PR C)
+
+**Reasoning:** The final local-mode piece: scaffolds a native Claude Code type:agent PostToolUse hook into .claude/settings.json that, on every git commit the agent makes, spawns a BACKGROUNDED clud-bug review subagent on the session's OWN subscription (no API key). The hook prompt runs 'clud-bug review-prompt' and follows the engine recipe — dynamic, always current. Implies --with-local-review; clud-bug update refreshes our marked hook; off by default. Both non-negotiables met by construction (native Claude Code primitives + subscription-only).
+
+**Alternatives considered:** Bake the static recipe into the hook (the earlier WIP MVP) — rejected per CEO: ship the hook ONLY in its planReview-driven form, so it reflects the repo's resolved plan and never goes stale.
+
+**Implications:**
+- type:agent is experimental (type:command + additionalContext fallback documented). Adversarial + self review caught + fixed: clobbering a malformed settings.json (now read-then-parse + skip), and dropping a user hook co-located in our entry (now preserved). Next: dogfood — install --with-hooks in clud-bug itself (needs a fresh session to load the hook). 841 tests green.
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -64,6 +64,7 @@ clud-bug
 │   ├── diff-findings.test.js
 │   ├── edit-workflow.test.js
 │   ├── formal-review.test.js
+│   ├── hooks.test.js
 │   ├── init-local-review.test.js
 │   ├── init-with-skdd.test.js
 │   ├── inline-threads.test.js

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (55 decisions)
+## 2026-06 (56 decisions)
 
-- **2026-06-28** — Add clud-bug review-prompt verb — the plan-aware local-review recipe (PR C keystone) *(wave-6b-review-prompt)* — [decisions-branches/wave-6b-review-prompt.md](decisions-branches/wave-6b-review-prompt.md)
-- *... 53 more decisions ...*
+- **2026-06-28** — Add clud-bug init --with-hooks — native type:agent commit-review hook (Wave 6b PR C) *(wave-6b-hooks)* — [decisions-branches/wave-6b-hooks.md](decisions-branches/wave-6b-hooks.md)
+- *... 54 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/src/cli/hooks.ts
+++ b/src/cli/hooks.ts
@@ -1,0 +1,115 @@
+// Wave 6b — Claude Code `type: agent` commit-review hook scaffolding.
+//
+// `clud-bug init --with-hooks` writes a native Claude Code hook that, on every
+// `git commit` the agent makes, spawns a clud-bug review SUBAGENT in the same
+// session — so it runs on the session's subscription (no API key), in the
+// background (the commit never blocks), and surfaces findings back to the agent.
+//
+// The model (see the Wave 6b plan): clud-bug supplies the *recipe* (the
+// agent-hook `prompt`); Claude Code runs it as a subagent. This is the dynamic,
+// always-on counterpart to the `/clud-bug-review` slash command.
+//
+// `type: agent` hooks are documented as experimental; the same outcome is
+// reachable via a `type: command` hook + `additionalContext` if the API shifts.
+
+/** Stable marker embedded in our hook's prompt so re-runs replace it in place. */
+export const CLUD_BUG_HOOK_MARKER = 'clud-bug-local-review';
+
+/**
+ * The `prompt` of the Claude Code `type: agent` commit-review hook. Rather than
+ * baking a static recipe (which would drift from the repo's skills/config), it
+ * tells the subagent to run `clud-bug review-prompt` — the engine-driven verb
+ * that emits a recipe tailored to THIS repo's resolved plan — and follow it.
+ * The recipe is therefore generated fresh at commit time, always current.
+ */
+export const COMMIT_REVIEW_PROMPT = `<!-- ${CLUD_BUG_HOOK_MARKER} v1 -->
+You are clud-bug's local commit review, running as a background subagent on this
+session's own subscription (no extra auth — you have git, gh, and file access).
+
+Step 1 — get your review recipe from clud-bug's engine:
+
+    npx clud-bug review-prompt --trigger commit
+
+That prints a structured review recipe tailored to THIS repo's skills + config (a
+fast single pass for a commit). If \`npx clud-bug\` isn't available, run the repo's
+installed clud-bug CLI instead.
+
+Step 2 — follow that recipe exactly: review the commit that was just made against
+the skills it names, and surface any findings back into the session so they can be
+fixed. A clean commit needs only a one-line note.
+
+Keep it tight — this is the commit-time safety net; the deeper review runs at PR time.`;
+
+/** One Claude Code hook entry: a tool matcher plus its hook list. */
+export interface HookMatcherEntry {
+  matcher?: string;
+  hooks: Array<Record<string, unknown>>;
+}
+
+/** Minimal shape of the `.claude/settings.json` we read + merge into. */
+export interface ClaudeSettings {
+  hooks?: Record<string, HookMatcherEntry[]>;
+  [key: string]: unknown;
+}
+
+/**
+ * Builds the PostToolUse entry that spawns the commit-review subagent: a native
+ * `type: agent` hook that is backgrounded (`async`), surfaces findings
+ * (`asyncRewake`), and fires only on `git commit` (`if`).
+ */
+export function buildLocalReviewHook(recipe: string): HookMatcherEntry {
+  return {
+    matcher: 'Bash',
+    hooks: [
+      {
+        type: 'agent',
+        if: 'Bash(git commit *)',
+        async: true,
+        asyncRewake: true,
+        timeout: 180,
+        prompt: recipe,
+      },
+    ],
+  };
+}
+
+function isOurHook(h: Record<string, unknown> | undefined): boolean {
+  return typeof h?.['prompt'] === 'string' && (h['prompt'] as string).includes(CLUD_BUG_HOOK_MARKER);
+}
+
+function isCludBugReviewEntry(entry: HookMatcherEntry | undefined): boolean {
+  return !!entry && Array.isArray(entry.hooks) && entry.hooks.some(isOurHook);
+}
+
+/**
+ * Merges the clud-bug commit-review hook into an existing `.claude/settings.json`
+ * object. **Idempotent** (replaces any prior clud-bug entry rather than
+ * duplicating) and **non-clobbering** (preserves every other top-level key,
+ * every other event, and every other hook). Tolerates a missing/malformed
+ * `existing` value.
+ */
+export function mergeLocalReviewHook(existing: unknown, recipe: string): ClaudeSettings {
+  const base: ClaudeSettings =
+    existing && typeof existing === 'object' ? { ...(existing as ClaudeSettings) } : {};
+  const hooks: Record<string, HookMatcherEntry[]> = { ...(base.hooks ?? {}) };
+  const priorPost = Array.isArray(hooks.PostToolUse) ? hooks.PostToolUse : [];
+
+  // Preserve every non-clud-bug hook — including any the user co-located INSIDE
+  // our own matcher entry: drop only the hook(s) carrying our marker, never the
+  // whole entry.
+  const ours = buildLocalReviewHook(recipe);
+  const otherEntries: HookMatcherEntry[] = [];
+  const coLocatedUserHooks: Array<Record<string, unknown>> = [];
+  for (const entry of priorPost) {
+    if (isCludBugReviewEntry(entry)) {
+      for (const h of entry.hooks) if (!isOurHook(h)) coLocatedUserHooks.push(h);
+    } else {
+      otherEntries.push(entry);
+    }
+  }
+  const ourEntry: HookMatcherEntry =
+    coLocatedUserHooks.length > 0 ? { ...ours, hooks: [...coLocatedUserHooks, ...ours.hooks] } : ours;
+  hooks.PostToolUse = [...otherEntries, ourEntry];
+  base.hooks = hooks;
+  return base;
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -67,6 +67,7 @@ function parseArgs(argv) {
     // .claude/commands/clud-bug-review.md so `/clud-bug-review` works in a
     // Claude Code session (reviews the current PR with the session's tokens).
     withLocalReview: false,
+    withHooks: false,
     // v0.7.0-rc.4: `clud-bug configure-github` flags.
     // --dry-run prints the diff but skips PATCH; --branch overrides "main".
     dryRun: false,
@@ -94,6 +95,7 @@ function parseArgs(argv) {
     else if (a === '--no-artifacts') args.artifacts = false;
     else if (a === '--with-skdd') args.withSkdd = true;
     else if (a === '--with-local-review') args.withLocalReview = true;
+    else if (a === '--with-hooks') args.withHooks = true;
     else if (a === '--dry-run') args.dryRun = true;
     else if (a === '--branch') args.branch = argv[++i];
     else if (a === '--trigger') args.trigger = argv[++i];
@@ -202,6 +204,11 @@ Options:
                         \`/clud-bug-review\` works in a Claude Code session —
                         reviews the current branch's PR using that session's
                         own tokens (no hosted App, no extra auth).
+  --with-hooks          (init) Also scaffold a native Claude Code \`type: agent\`
+                        commit-review hook into .claude/settings.json — on every
+                        \`git commit\` the agent makes, a backgrounded clud-bug
+                        review subagent runs on the session's subscription.
+                        Implies --with-local-review. Off by default.
   --quiet,-q            Token-frugal mode for agent invocations. Suppresses
                         progress chatter; emits exactly one final
                         \`ok <key-value>\` summary line per command. Errors
@@ -1261,12 +1268,50 @@ async function runInit(args) {
   // Claude Code session — the agent reviews the current branch's open PR using
   // THAT session's own tokens (Max or API), no hosted App or new auth required.
   // `.claude/` is already in the --commit add-list below, so it's staged too.
+  // `--with-hooks` implies `--with-local-review` — the auto hook and the manual
+  // `/clud-bug-review` command are complementary (the hook auto-runs the engine
+  // recipe on each commit; the command runs it on demand against the PR).
+  if (args.withHooks) args.withLocalReview = true;
   if (args.withLocalReview) {
     const commandPath = join(cwd, '.claude', 'commands', 'clud-bug-review.md');
     await mkdir(dirname(commandPath), { recursive: true });
     const commandContent = await renderFile(join(TEMPLATES, 'clud-bug-review.md.tmpl'), {});
     await writeFile(commandPath, commandContent);
     log(`    wrote ${rel(cwd, commandPath)}`);
+  }
+
+  // v0.7.0 (Wave 6b): optional native commit-review hook. Merges a Claude Code
+  // `type: agent` PostToolUse hook into `.claude/settings.json` (preserving any
+  // existing settings + hooks) that, on every `git commit` the agent makes,
+  // spawns a clud-bug review subagent on the session's subscription, in the
+  // background — the hook's prompt runs `clud-bug review-prompt` and follows it.
+  if (args.withHooks) {
+    const { mergeLocalReviewHook, COMMIT_REVIEW_PROMPT } = await import('./hooks.js');
+    const settingsPath = join(cwd, '.claude', 'settings.json');
+    await mkdir(dirname(settingsPath), { recursive: true });
+    // Read-then-parse so we can tell "no file yet" (fresh merge) from "file
+    // exists but is invalid JSON" (leave it ALONE — never clobber user content).
+    let raw: string | undefined;
+    try {
+      raw = await readFile(settingsPath, 'utf8');
+    } catch {
+      raw = undefined; // no settings.json yet → fresh
+    }
+    let existing: unknown;
+    let proceed = true;
+    if (raw !== undefined) {
+      try {
+        existing = JSON.parse(raw);
+      } catch {
+        proceed = false;
+        log(`    skipped ${rel(cwd, settingsPath)} (existing file is not valid JSON; left untouched)`);
+      }
+    }
+    if (proceed) {
+      const merged = mergeLocalReviewHook(existing, COMMIT_REVIEW_PROMPT);
+      await writeFile(settingsPath, JSON.stringify(merged, null, 2) + '\n');
+      log(`    wrote ${rel(cwd, settingsPath)} (commit-review hook)`);
+    }
   }
 
   // Stamp the manifest. Sets strictMode: true ONLY on fresh installs —

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -5,6 +5,7 @@ import { reviewPrompt } from '../core/prompts.js';
 import { detect, buildDescriptionLine } from '../core/detect.js';
 import { loadBaseline, readManifest, writeManifest, type LoadBaselineOptions } from './skills.js';
 import { applyToRepo as applyAgentDocs } from './agents-md.js';
+import { mergeLocalReviewHook, COMMIT_REVIEW_PROMPT, CLUD_BUG_HOOK_MARKER } from './hooks.js';
 
 // Re-render the user's workflow + refresh baseline skills using the
 // templates / baseline shipped with the currently-installed clud-bug.
@@ -159,6 +160,27 @@ export async function runUpdate(opts: RunUpdateOptions): Promise<RunUpdateResult
         label: 'local-review slash command',
         reason: 'markerless (user-customized); delete + `clud-bug init --with-local-review` to refresh',
       });
+    }
+  }
+
+  // 5c. Refresh the native commit-review hook (Wave 6b) in place when it was
+  //     scaffolded via `clud-bug init --with-hooks` and our entry is intact (the
+  //     `clud-bug-local-review` marker). settings.json is user-managed — we only
+  //     re-merge OUR marked hook, never touching the user's other hooks/settings.
+  const settingsPath = join(cwd, '.claude', 'settings.json');
+  if (await pathExists(settingsPath)) {
+    const prior = await readSafe(settingsPath);
+    if (prior && prior.includes(CLUD_BUG_HOOK_MARKER)) {
+      try {
+        const merged = mergeLocalReviewHook(JSON.parse(prior), COMMIT_REVIEW_PROMPT);
+        await maybeWrite(settingsPath, JSON.stringify(merged, null, 2) + '\n', changed, unchanged, 'commit-review hook');
+      } catch {
+        skipped.push({
+          path: settingsPath,
+          label: 'commit-review hook',
+          reason: 'settings.json is not valid JSON; left untouched',
+        });
+      }
     }
   }
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1,0 +1,92 @@
+// Wave 6b — `clud-bug init --with-hooks` scaffolds a native Claude Code
+// `type: agent` commit-review hook into .claude/settings.json. These cover the
+// pure hook-builder + the merge-into-existing-settings logic (idempotent,
+// non-clobbering).
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildLocalReviewHook,
+  mergeLocalReviewHook,
+  COMMIT_REVIEW_PROMPT,
+} from '../src/cli/hooks.js';
+
+describe('buildLocalReviewHook', () => {
+  it('is a backgrounded type:agent PostToolUse entry targeting git commit', () => {
+    const entry = buildLocalReviewHook(COMMIT_REVIEW_PROMPT);
+    expect(entry.matcher).toBe('Bash');
+    const h = entry.hooks[0];
+    expect(h.type).toBe('agent');
+    expect(h.if).toBe('Bash(git commit *)');
+    expect(h.async).toBe(true); // commit never blocks
+    expect(h.asyncRewake).toBe(true); // findings surface back to the agent
+    expect(h.prompt).toBe(COMMIT_REVIEW_PROMPT);
+  });
+});
+
+describe('mergeLocalReviewHook', () => {
+  it('adds the hook to empty / undefined settings', () => {
+    const s = mergeLocalReviewHook(undefined, COMMIT_REVIEW_PROMPT);
+    expect(s.hooks.PostToolUse).toHaveLength(1);
+    expect(s.hooks.PostToolUse[0].hooks[0].type).toBe('agent');
+  });
+
+  it('preserves unrelated settings and other hooks', () => {
+    const existing = {
+      model: 'opus',
+      hooks: {
+        PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: './x.sh' }] }],
+        PostToolUse: [{ matcher: 'Edit', hooks: [{ type: 'command', command: './fmt.sh' }] }],
+      },
+    };
+    const s = mergeLocalReviewHook(existing, COMMIT_REVIEW_PROMPT);
+    expect(s.model).toBe('opus'); // unrelated top-level key preserved
+    expect(s.hooks.PreToolUse).toHaveLength(1); // other event preserved
+    expect(s.hooks.PostToolUse).toHaveLength(2); // the user's Edit hook + ours
+    expect(s.hooks.PostToolUse.some((e) => e.matcher === 'Edit')).toBe(true);
+  });
+
+  it('is idempotent — re-running replaces ours, never duplicates', () => {
+    const once = mergeLocalReviewHook(undefined, COMMIT_REVIEW_PROMPT);
+    const twice = mergeLocalReviewHook(once, COMMIT_REVIEW_PROMPT);
+    expect(twice.hooks.PostToolUse).toHaveLength(1);
+  });
+
+  it('preserves a user hook co-located INSIDE our entry across a re-merge', () => {
+    const v1 = mergeLocalReviewHook(undefined, COMMIT_REVIEW_PROMPT);
+    // user hand-appends their own hook into OUR Bash matcher entry
+    v1.hooks.PostToolUse[0].hooks.push({ type: 'command', command: './notify.sh' });
+    const v2 = mergeLocalReviewHook(v1, COMMIT_REVIEW_PROMPT);
+    const entry = v2.hooks.PostToolUse.find((e) =>
+      e.hooks.some((h) => typeof h.prompt === 'string' && h.prompt.includes('clud-bug-local-review')),
+    );
+    // the user's co-located hook survives, and ours is not duplicated
+    expect(entry.hooks.some((h) => h.command === './notify.sh')).toBe(true);
+    expect(
+      entry.hooks.filter(
+        (h) => typeof h.prompt === 'string' && h.prompt.includes('clud-bug-local-review'),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('refreshes our hook in place when the recipe changes', () => {
+    const v1 = mergeLocalReviewHook(undefined, COMMIT_REVIEW_PROMPT);
+    const v2recipe = COMMIT_REVIEW_PROMPT + '\n<!-- bumped -->';
+    const v2 = mergeLocalReviewHook(v1, v2recipe);
+    expect(v2.hooks.PostToolUse).toHaveLength(1);
+    expect(v2.hooks.PostToolUse[0].hooks[0].prompt).toBe(v2recipe);
+  });
+
+  it('tolerates a non-object existing value', () => {
+    const s = mergeLocalReviewHook('garbage', COMMIT_REVIEW_PROMPT);
+    expect(s.hooks.PostToolUse).toHaveLength(1);
+  });
+});
+
+describe('COMMIT_REVIEW_PROMPT', () => {
+  it('carries the marker and delegates to the review-prompt engine on the subscription', () => {
+    expect(COMMIT_REVIEW_PROMPT).toMatch(/clud-bug-local-review/);
+    expect(COMMIT_REVIEW_PROMPT).toMatch(/review-prompt --trigger commit/);
+    expect(COMMIT_REVIEW_PROMPT).toMatch(/subscription/i);
+  });
+});

--- a/test/init-local-review.test.js
+++ b/test/init-local-review.test.js
@@ -4,7 +4,7 @@
 import { test } from 'vitest';
 import { strict as assert } from 'node:assert';
 import { spawnSync } from 'node:child_process';
-import { mkdtemp, mkdir, readFile, access } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, writeFile, access } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -57,4 +57,36 @@ test('init without --with-local-review does NOT scaffold the slash command', asy
     exists = false;
   }
   assert.equal(exists, false, 'slash command should not exist without the flag');
+});
+
+test('init --with-hooks scaffolds the native commit-review hook + the slash command', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-hooks-'));
+  await mkdir(join(dir, '.git'), { recursive: true });
+  const r = runInit(dir, ['--with-hooks']);
+  assert.equal(r.status, 0, r.stderr);
+  // --with-hooks implies --with-local-review, so the slash command is there too
+  await access(join(dir, '.claude', 'commands', 'clud-bug-review.md'));
+  // the native `type: agent` commit-review hook, merged into .claude/settings.json
+  const settings = JSON.parse(await readFile(join(dir, '.claude', 'settings.json'), 'utf8'));
+  const entry = settings.hooks.PostToolUse[0];
+  assert.equal(entry.matcher, 'Bash');
+  assert.equal(entry.hooks[0].type, 'agent');
+  assert.equal(entry.hooks[0].if, 'Bash(git commit *)');
+  assert.equal(entry.hooks[0].async, true);
+  assert.match(entry.hooks[0].prompt, /clud-bug-local-review/);
+  assert.match(entry.hooks[0].prompt, /review-prompt --trigger commit/);
+});
+
+test('init --with-hooks does NOT clobber a pre-existing malformed settings.json', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-hooks-bad-'));
+  await mkdir(join(dir, '.git'), { recursive: true });
+  await mkdir(join(dir, '.claude'), { recursive: true });
+  const settingsPath = join(dir, '.claude', 'settings.json');
+  const malformed = '{ "model": "opus", oops not json';
+  await writeFile(settingsPath, malformed);
+  const r = runInit(dir, ['--with-hooks']);
+  assert.equal(r.status, 0, r.stderr);
+  // the user's (malformed) file must be left untouched, never overwritten with just our hook
+  const after = await readFile(settingsPath, 'utf8');
+  assert.equal(after, malformed, 'malformed settings.json must not be clobbered');
 });


### PR DESCRIPTION
## `clud-bug init --with-hooks` (off by default)

The final local-mode piece — makes review **automatic**. Scaffolds a native Claude Code `type: agent` PostToolUse hook into `.claude/settings.json` (merged non-clobbering). On every `git commit` the agent makes:
- a **backgrounded** (`async`) review subagent spawns **in the same session** → runs on the **session's own subscription**, no API key, and the commit never blocks;
- its prompt simply runs **`clud-bug review-prompt --trigger commit`** and follows the engine recipe — so it's always current (no baked/stale recipe);
- findings surface back via `asyncRewake`.

Both non-negotiables hold *by construction*: native Claude Code primitives + subscription-only (an in-session subagent). Implies `--with-local-review`; `clud-bug update` refreshes our marked hook in place. `type: agent` is experimental — a `type: command` + `additionalContext` fallback reaches the same outcome on stable primitives.

### Adversarial + self review — 2 issues fixed
- **Data loss (self-caught)**: a pre-existing *malformed* `settings.json` was clobbered (parse error → fresh write). Now **read-then-parse**: ENOENT → fresh; invalid JSON → skip + warn, never overwrite. Regression-tested.
- **Non-clobbering gap (reviewer)**: the merge replaced the whole matcher *entry*, dropping any user hook co-located inside ours on the next `update`. Now preserves co-located user hooks. Regression-tested.

### Verification
- `npm run build` (tsc strict): clean
- `npm test`: **841 passed** (37 files)
- `npm run test:fixtures`: 5/5
- Functional smoke: `init --with-hooks` writes the exact `type: agent` commit hook (matcher Bash, `if Bash(git commit *)`, async/asyncRewake, timeout 180, the dynamic prompt).

Rides the unpublished rc.12. Next: dogfood — install it in clud-bug itself (the dogfood loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)