### PR TITLE
rc.13: render SPEC §6.8.1/§6.10.1 markers + pin the hook's clud-bug version

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.12
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.13
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.7.0-rc.13] — 2026-06-28
+
+Wave 6b — SPEC render conformance + the hook version-pin.
+
+### Fixed
+
+- **SPEC §6.8.1 / §6.10.1 markers (NORMATIVE) now rendered.** `renderMultiPassMarkdown`
+  emits a `<!-- pass: <id> -->` attribution comment (the originating pass, lowercased) and,
+  for gated findings, a `<!-- consensus: 1-of-N | 2-of-2 | arbitrated -->` comment immediately
+  before each finding's bullet. The auto-fix gate (§6.10.2) was already safe (reads
+  `finding.consensus` directly); this closes the auditable/dashboard-parseable output gap.
+- **`init --with-hooks` pins the clud-bug version** in the commit-review hook prompt
+  (`npx clud-bug@<version> review-prompt`). A bare `npx clud-bug` resolves to the `latest`
+  dist-tag, which can predate the `review-prompt` verb while v0.7 is prerelease on `next` —
+  pinning guarantees the verb resolves. `clud-bug update` refreshes the pin in place.
+
 ## [0.7.0-rc.12] — 2026-06-28
 
 Wave 6b (PR 0) — shared review engine extracted into `core` (single source of truth).

--- a/docs/decisions-branches/wave-6b-spec-render-rc13.md
+++ b/docs/decisions-branches/wave-6b-spec-render-rc13.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-28 18:52 - rc.13 — render SPEC §6.8.1/§6.10.1 markers + pin the hook's clud-bug version
+
+**Reasoning:** SPEC conformance (drift the pre-launch audit caught): renderMultiPassMarkdown now emits the NORMATIVE per-finding '<!-- pass: <id> -->' (§6.8.1, originating pass lowercased) and '<!-- consensus: 1-of-N|2-of-2|arbitrated -->' (§6.10.1, when gated) markers immediately before each bullet — the auditable/dashboard-parseable contract. The auto-fix gate (§6.10.2) already read finding.consensus directly; only the rendered marker was missing. AND: init --with-hooks now pins 'npx clud-bug@<version> review-prompt' so the commit hook never resolves to a 'latest' dist-tag (0.6.34) that predates the review-prompt verb; clud-bug update refreshes the pin in place (marker-gated).
+
+**Alternatives considered:** Amend §6.8.1 to bless the inline [Pass N] bracket format instead of adding HTML markers — rejected: the markers are the machine contract; keep both (human brackets + machine markers). Pin via @next (moving target) — rejected for the deterministic scaffolding-version pin.
+
+**Implications:**
+- rc.13 publish is a USER ACTION (npm publish --tag next). Adversarial review clean. Closes the §6.10.1 render gap flagged in PR 0b + the npx->latest gap. The clud-bug dogfood install uses the LOCAL bin (not npx), so it's independent of this publish. 843 tests green.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (56 decisions)
+## 2026-06 (57 decisions)
 
-- **2026-06-28** — Add clud-bug init --with-hooks — native type:agent commit-review hook (Wave 6b PR C) *(wave-6b-hooks)* — [decisions-branches/wave-6b-hooks.md](decisions-branches/wave-6b-hooks.md)
-- *... 54 more decisions ...*
+- **2026-06-28** — rc.13 — render SPEC §6.8.1/§6.10.1 markers + pin the hook's clud-bug version *(wave-6b-spec-render-rc13)* — [decisions-branches/wave-6b-spec-render-rc13.md](decisions-branches/wave-6b-spec-render-rc13.md)
+- *... 55 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.12",
+  "version": "0.7.0-rc.13",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/cli/hooks.ts
+++ b/src/cli/hooks.ts
@@ -16,29 +16,36 @@
 export const CLUD_BUG_HOOK_MARKER = 'clud-bug-local-review';
 
 /**
- * The `prompt` of the Claude Code `type: agent` commit-review hook. Rather than
- * baking a static recipe (which would drift from the repo's skills/config), it
- * tells the subagent to run `clud-bug review-prompt` — the engine-driven verb
- * that emits a recipe tailored to THIS repo's resolved plan — and follow it.
- * The recipe is therefore generated fresh at commit time, always current.
+ * Build the `prompt` of the Claude Code `type: agent` commit-review hook,
+ * pinned to the clud-bug VERSION that scaffolded it. Pinning matters: a bare
+ * `npx clud-bug` resolves to the `latest` dist-tag, which can predate the
+ * `review-prompt` verb (e.g. while v0.7 is prerelease on `next`); `@${version}`
+ * guarantees the verb exists. `clud-bug update` refreshes the pin in place.
+ *
+ * Rather than baking a static recipe (which would drift from the repo's
+ * skills/config), it tells the subagent to run `clud-bug review-prompt` — the
+ * engine-driven verb that emits a recipe tailored to THIS repo's resolved plan
+ * — and follow it. The recipe is generated fresh at commit time, always current.
  */
-export const COMMIT_REVIEW_PROMPT = `<!-- ${CLUD_BUG_HOOK_MARKER} v1 -->
+export function buildCommitReviewPrompt(version: string): string {
+  return `<!-- ${CLUD_BUG_HOOK_MARKER} v1 -->
 You are clud-bug's local commit review, running as a background subagent on this
 session's own subscription (no extra auth — you have git, gh, and file access).
 
 Step 1 — get your review recipe from clud-bug's engine:
 
-    npx clud-bug review-prompt --trigger commit
+    npx clud-bug@${version} review-prompt --trigger commit
 
 That prints a structured review recipe tailored to THIS repo's skills + config (a
-fast single pass for a commit). If \`npx clud-bug\` isn't available, run the repo's
-installed clud-bug CLI instead.
+fast single pass for a commit). If that command isn't available, run the repo's
+installed clud-bug CLI's \`review-prompt --trigger commit\` instead.
 
 Step 2 — follow that recipe exactly: review the commit that was just made against
 the skills it names, and surface any findings back into the session so they can be
 fixed. A clean commit needs only a one-line note.
 
 Keep it tight — this is the commit-time safety net; the deeper review runs at PR time.`;
+}
 
 /** One Claude Code hook entry: a tool matcher plus its hook list. */
 export interface HookMatcherEntry {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1286,7 +1286,8 @@ async function runInit(args) {
   // spawns a clud-bug review subagent on the session's subscription, in the
   // background — the hook's prompt runs `clud-bug review-prompt` and follows it.
   if (args.withHooks) {
-    const { mergeLocalReviewHook, COMMIT_REVIEW_PROMPT } = await import('./hooks.js');
+    const { mergeLocalReviewHook, buildCommitReviewPrompt } = await import('./hooks.js');
+    const hookPrompt = buildCommitReviewPrompt(await readPkgVersion());
     const settingsPath = join(cwd, '.claude', 'settings.json');
     await mkdir(dirname(settingsPath), { recursive: true });
     // Read-then-parse so we can tell "no file yet" (fresh merge) from "file
@@ -1308,7 +1309,7 @@ async function runInit(args) {
       }
     }
     if (proceed) {
-      const merged = mergeLocalReviewHook(existing, COMMIT_REVIEW_PROMPT);
+      const merged = mergeLocalReviewHook(existing, hookPrompt);
       await writeFile(settingsPath, JSON.stringify(merged, null, 2) + '\n');
       log(`    wrote ${rel(cwd, settingsPath)} (commit-review hook)`);
     }

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -5,7 +5,7 @@ import { reviewPrompt } from '../core/prompts.js';
 import { detect, buildDescriptionLine } from '../core/detect.js';
 import { loadBaseline, readManifest, writeManifest, type LoadBaselineOptions } from './skills.js';
 import { applyToRepo as applyAgentDocs } from './agents-md.js';
-import { mergeLocalReviewHook, COMMIT_REVIEW_PROMPT, CLUD_BUG_HOOK_MARKER } from './hooks.js';
+import { mergeLocalReviewHook, buildCommitReviewPrompt, CLUD_BUG_HOOK_MARKER } from './hooks.js';
 
 // Re-render the user's workflow + refresh baseline skills using the
 // templates / baseline shipped with the currently-installed clud-bug.
@@ -172,7 +172,7 @@ export async function runUpdate(opts: RunUpdateOptions): Promise<RunUpdateResult
     const prior = await readSafe(settingsPath);
     if (prior && prior.includes(CLUD_BUG_HOOK_MARKER)) {
       try {
-        const merged = mergeLocalReviewHook(JSON.parse(prior), COMMIT_REVIEW_PROMPT);
+        const merged = mergeLocalReviewHook(JSON.parse(prior), buildCommitReviewPrompt(ourVersion));
         await maybeWrite(settingsPath, JSON.stringify(merged, null, 2) + '\n', changed, unchanged, 'commit-review hook');
       } catch {
         skipped.push({

--- a/src/core/review-writeback.ts
+++ b/src/core/review-writeback.ts
@@ -521,6 +521,15 @@ function renderUnifiedFinding(
   }
   const headLabel = formatAttributionLabel(head);
   const lines: string[] = [];
+  // SPEC §6.8.1 (NORMATIVE for multi-pass): a per-finding pass-attribution HTML
+  // comment immediately preceding the bullet, naming the originating pass as a
+  // stable lowercase identifier so consumers can aggregate per-pass metrics.
+  lines.push(`<!-- pass: ${passIdentifier(head.roleName)} -->`);
+  // SPEC §6.10.1 (NORMATIVE for gated reviewers): the consensus marker alongside
+  // the pass attribution, when the finding carries a consensus verdict.
+  if (f.consensus) {
+    lines.push(`<!-- consensus: ${f.consensus} -->`);
+  }
   lines.push(`- ${headLabel} **${location}** — ${f.skill}: ${f.summary}`);
   if (includeReasoning && f.reasoning) {
     lines.push(`  Reasoning: ${f.reasoning}`);
@@ -543,6 +552,14 @@ function renderUnifiedFinding(
  * `source: 'first'` — i.e. when a later pass surfaced this finding without
  * Pass 1 raising it.
  */
+/** SPEC §6.8.1 pass identifier: a stable lowercase slug of the role name. */
+function passIdentifier(roleName: string): string {
+  return roleName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
 function formatAttributionLabel(a: PassAttribution): string {
   const independent =
     a.source === 'independent' && a.passNumber > 1

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -400,7 +400,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.12
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.13
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -400,7 +400,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.12
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.13
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -704,7 +704,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.12
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.13
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -8,8 +8,12 @@ import { describe, expect, it } from 'vitest';
 import {
   buildLocalReviewHook,
   mergeLocalReviewHook,
-  COMMIT_REVIEW_PROMPT,
+  buildCommitReviewPrompt,
 } from '../src/cli/hooks.js';
+
+// The hook prompt is now version-pinned; build one at a fixed test version so
+// the merge/builder tests below read as before.
+const COMMIT_REVIEW_PROMPT = buildCommitReviewPrompt('0.7.0-rc.13');
 
 describe('buildLocalReviewHook', () => {
   it('is a backgrounded type:agent PostToolUse entry targeting git commit', () => {
@@ -83,10 +87,11 @@ describe('mergeLocalReviewHook', () => {
   });
 });
 
-describe('COMMIT_REVIEW_PROMPT', () => {
-  it('carries the marker and delegates to the review-prompt engine on the subscription', () => {
+describe('buildCommitReviewPrompt', () => {
+  it('carries the marker, pins the clud-bug version, and delegates to review-prompt on the subscription', () => {
     expect(COMMIT_REVIEW_PROMPT).toMatch(/clud-bug-local-review/);
-    expect(COMMIT_REVIEW_PROMPT).toMatch(/review-prompt --trigger commit/);
+    // version-pinned so the hook never resolves to a `latest` that predates the verb
+    expect(COMMIT_REVIEW_PROMPT).toMatch(/npx clud-bug@0\.7\.0-rc\.13 review-prompt --trigger commit/);
     expect(COMMIT_REVIEW_PROMPT).toMatch(/subscription/i);
   });
 });

--- a/test/review-writeback.test.js
+++ b/test/review-writeback.test.js
@@ -305,6 +305,33 @@ test('renderMultiPassMarkdown: head line carries first pass attribution', () => 
   );
 });
 
+test('renderMultiPassMarkdown: §6.8.1 pass marker + §6.10.1 consensus marker precede each finding', () => {
+  const review = {
+    ...MULTI_PASS_REVIEW,
+    findings: [{ ...MULTI_PASS_REVIEW.findings[0], consensus: '2-of-2' }],
+  };
+  const md = renderMultiPassMarkdown({
+    review, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,
+  });
+  // §6.8.1 (NORMATIVE): the originating pass (Beetle) as a lowercase identifier.
+  assert.ok(md.includes('<!-- pass: beetle -->'), 'pass marker present');
+  // §6.10.1 (NORMATIVE for gated reviewers): the consensus marker alongside.
+  assert.ok(md.includes('<!-- consensus: 2-of-2 -->'), 'consensus marker present');
+  // Both markers immediately precede the finding's bullet, in spec order.
+  assert.ok(
+    /<!-- pass: beetle -->\n<!-- consensus: 2-of-2 -->\n- \[Pass 1/.test(md),
+    'markers precede the bullet in §6.8.1/§6.10.1 order',
+  );
+});
+
+test('renderMultiPassMarkdown: pass marker present without consensus (consensus marker omitted)', () => {
+  const md = renderMultiPassMarkdown({
+    review: MULTI_PASS_REVIEW, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,
+  });
+  assert.ok(md.includes('<!-- pass: beetle -->'), 'pass marker present');
+  assert.ok(!md.includes('<!-- consensus:'), 'no consensus marker when finding has no consensus');
+});
+
 test('renderMultiPassMarkdown: follow-up attribution renders ✅ AGREED', () => {
   const md = renderMultiPassMarkdown({
     review: MULTI_PASS_REVIEW, prNumber: 158, headSha: HEAD_SHA, prUrl: PR_URL,


### PR DESCRIPTION
## rc.13 — SPEC render conformance + hook version-pin

Two pre-launch fixes (the first from the SPEC drift audit):

### 1. SPEC §6.8.1 / §6.10.1 markers now rendered (NORMATIVE)
`renderMultiPassMarkdown` now emits, immediately before each multi-pass finding's bullet:
- `<!-- pass: <id> -->` — §6.8.1, the originating pass as a stable lowercase id (beetle/wasp/mantis)
- `<!-- consensus: 1-of-N | 2-of-2 | arbitrated -->` — §6.10.1, when the finding is gated

The auto-fix gate (§6.10.2) was already safe (reads `finding.consensus` directly); this closes the **auditable / dashboard-parseable output** gap (and the stale note PR 0b flagged). Single-pass reviews are unaffected (the markers are multi-pass-only, per §6.8.1).

### 2. `init --with-hooks` pins the clud-bug version
The hook prompt now runs `npx clud-bug@<version> review-prompt` instead of bare `npx clud-bug` (which resolves to `latest` = 0.6.34, predating the `review-prompt` verb). `clud-bug update` refreshes the pin in place (marker-gated).

### Verification
- `npm run build` (tsc strict): clean
- `npm test`: **843 passed** (37 files; +2 marker tests, version-pin assertion)
- `npm run test:fixtures`: 5/5 (fixtures are single-pass → unaffected)
- Adversarial review: **clean** (markers spec-correct; version sourced correctly in both callers; graceful unpublished-version fallback; idempotent refresh)

**rc.13 publish is a USER ACTION** (`npm publish --tag next`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)