### PR TITLE
Dogfood: populate clud-bug's own skill manifest (4 baseline)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -1,6 +1,35 @@
 {
   "version": 1,
-  "installed": [],
+  "installed": [
+    {
+      "slug": "clud-bug-collaboration",
+      "name": "clud-bug-collaboration",
+      "source": "clud-bug-baseline",
+      "kind": "baseline",
+      "description": "(baseline)"
+    },
+    {
+      "slug": "critical-issues-only",
+      "name": "critical-issues-only",
+      "source": "clud-bug-baseline",
+      "kind": "baseline",
+      "description": "(baseline)"
+    },
+    {
+      "slug": "evidence-based-review",
+      "name": "evidence-based-review",
+      "source": "clud-bug-baseline",
+      "kind": "baseline",
+      "description": "(baseline)"
+    },
+    {
+      "slug": "respect-existing-conventions",
+      "name": "respect-existing-conventions",
+      "source": "clud-bug-baseline",
+      "kind": "baseline",
+      "description": "(baseline)"
+    }
+  ],
   "lastUpdate": "2026-06-01T14:17:41.585Z",
   "lastUpdateVersion": "0.6.32",
   "strictMode": true,

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ site/next-env.d.ts
 
 # Local Claude Code session state
 .claude/scheduled_tasks.lock
+.claude/settings.local.json
 .playwright-mcp/
 
 # >>> logmind >>>

--- a/docs/decisions-branches/dogfood-skill-manifest.md
+++ b/docs/decisions-branches/dogfood-skill-manifest.md
@@ -1,0 +1,14 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-28 23:21 - dogfood: populate clud-bug's own .clud-bug.json with the 4 baseline skills
+
+**Reasoning:** The self-review manifest had installed:[] while skill dirs sat on disk, so the commit-review hook loaded 0 skill files. Populate installed[] to match 'clud-bug init' (the 4 baseline) so the dogfood reviews against real discipline.
+
+**Alternatives considered:** Include clud-bug-brand-voice (the 5th on-disk skill) — rejected: it is not baseline and the recipe lists every installed slug, so it would apply naturalist-voice critique to code diffs, Teach the local recipe to honor applies_to and auto-load brand-voice for docs/site only — deferred (separate change)
+
+**Implications:**
+- review-prompt --trigger commit now resolves 4 skills (verified)
+- Also gitignore .claude/settings.local.json so the local dogfood hook settings never get committed
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (57 decisions)
+## 2026-06 (58 decisions)
 
-- **2026-06-28** — rc.13 — render SPEC §6.8.1/§6.10.1 markers + pin the hook's clud-bug version *(wave-6b-spec-render-rc13)* — [decisions-branches/wave-6b-spec-render-rc13.md](decisions-branches/wave-6b-spec-render-rc13.md)
-- *... 55 more decisions ...*
+- **2026-06-28** — dogfood: populate clud-bug's own .clud-bug.json with the 4 baseline skills *(dogfood-skill-manifest)* — [decisions-branches/dogfood-skill-manifest.md](decisions-branches/dogfood-skill-manifest.md)
+- *... 56 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)


### PR DESCRIPTION
## What

clud-bug's own `.claude/skills/.clud-bug.json` had `installed: []` while the baseline skill dirs sat on disk, so the dogfood commit-review hook (`review-prompt --trigger commit`) resolved **0 skill files**. This populates `installed[]` with the 4 baseline skills, matching what `clud-bug init` writes.

- `clud-bug-collaboration`, `critical-issues-only`, `evidence-based-review`, `respect-existing-conventions` — each `{source: clud-bug-baseline, kind: baseline, description: "(baseline)"}`, alphabetical order matching `readBundled` + clud-bug-test's manifest.
- Also gitignores `.claude/settings.local.json` so the local dogfood hook settings are never committed.

## Why not brand-voice?

`clud-bug-brand-voice` is on disk but is **not** baseline. The local recipe lists every installed slug, so adding it to `installed[]` would point naturalist-voice critique at code diffs. It stays a `custom` on-disk skill. (Honoring `applies_to` in the local recipe is a separate change.)

## Verify

```
$ node bin/clud-bug.js review-prompt --trigger commit
**1-pass review across 4 skill(s) [commit], tiered down (commit); est $0.08**
## 2. Load the review skills
  - `.claude/skills/clud-bug-collaboration/SKILL.md`
  - `.claude/skills/critical-issues-only/SKILL.md`
  - `.claude/skills/evidence-based-review/SKILL.md`
  - `.claude/skills/respect-existing-conventions/SKILL.md`
```

`npm run build && npm test && npm run test:fixtures` — all green. Repo-local change only (`.claude/` is not in `package.json#files`); no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)