### PR TITLE
rc.14 (6c): conditional Mantis arbiter — pure shouldEscalate + recipe prose

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.13
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.14
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -126,7 +126,17 @@ jobs:
         # generation. --access public is required for unscoped packages.
         # prepublishOnly runs npm test first, so a broken tag fails the
         # publish loudly instead of silently shipping.
-        run: npm publish --provenance --access public
+        #
+        # Prerelease-aware dist-tag: npm does NOT auto-route a `-rc.N`
+        # prerelease away from `latest` — a bare `npm publish` would point
+        # `latest` (the `npm i clud-bug` stable channel) at the prerelease.
+        # Derive the tag from the version: anything with a `-` (e.g.
+        # 0.7.0-rc.14) → `next`; a clean semver → `latest`.
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          if [[ "${VERSION}" == *-* ]]; then DIST_TAG=next; else DIST_TAG=latest; fi
+          echo "Publishing clud-bug@${VERSION} to dist-tag '${DIST_TAG}'"
+          npm publish --provenance --access public --tag "${DIST_TAG}"
 
   promote-tag:
     if: github.event_name == 'workflow_dispatch' && inputs.mode == 'promote-tag'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.7.0-rc.14] — 2026-06-28
+
+6c — the conditional Mantis arbiter (the decision lives in `core`; consumers wire the pass).
+
+### Added
+
+- **`shouldEscalate(...)` in `core/multi-pass-aggregate.ts`** — a pure gate that returns true
+  only when a 2-pass `cross-check` disagreed on a `critical` or `minor` Pass-1 finding (the
+  SPEC §6.10.1 `arbitrated` case). It reads the verdicts Pass 2 already produced — no I/O, no
+  AI call. Scope: cross-check only, exactly `passCount === 2` (a statically-configured 3-pass
+  plan already runs Mantis as pass 3 via the loop), severity `critical | minor` (a
+  `preexisting` dispute can't flip the merge gate, so it doesn't earn an Opus arbiter).
+  Authority is marker-only — the arbiter sets the disputed finding's consensus marker +
+  rationale; it does not change which findings gate the merge (that stays `resolveVerdict`).
+  Exported from `core` so the hosted bot and the local recipe share one decision (SPEC §11.5).
+- **`review-prompt` recipe describes the arbiter.** A 2-pass cross-check plan now appends a
+  conditional "dispatch a 3rd Mantis arbiter on disagreement" paragraph, gated to
+  `cross-check` + exactly 2 passes so 3-pass / consensus plans don't get redundant prose.
+
+### Notes
+
+- The 2-pass cross-check default ships as a **Team-tier repo default in the hosted app**, not a
+  `BUILTIN_DEFAULT` flip — OSS / free / Solo keep the 1-pass floor (small commits/diffs still
+  tier down to 1). rc.14 publishes to the `next` dist-tag.
+
 ## [0.7.0-rc.13] — 2026-06-28
 
 Wave 6b — SPEC render conformance + the hook version-pin.

--- a/docs/decisions-branches/rc14-arbiter.md
+++ b/docs/decisions-branches/rc14-arbiter.md
@@ -1,0 +1,15 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-28 23:45 - rc.14 (6c): conditional Mantis arbiter — pure shouldEscalate in core + recipe prose
+
+**Reasoning:** 6c ships the quality default as a conditional 3rd Mantis arbiter that fires only when a 2-pass cross-check disagrees on a critical|minor finding. The decision lives in core as a pure shouldEscalate so the hosted bot and the local recipe share one rule (SPEC §11.5); the recipe describes it for local 2-pass cross-check plans.
+
+**Alternatives considered:** Flip BUILTIN_DEFAULT to {count:2} (universal 2-pass) — rejected: 2-pass is Team-tier-only (pricing positions multi-pass as a Team feature), applied app-side as a repo default, not a builtin floor change, Let the arbiter demote/drop the contested critical from the merge gate — deferred: marker+rationale only for rc.14 (resolveVerdict unchanged)
+
+**Implications:**
+- Bumps version to rc.14 across the 5 lockstep pins + CHANGELOG
+- Makes npm-publish.yml prerelease-aware (derives --tag next from the -rc.N version) so pushing the tag can't publish the prerelease onto the latest channel
+- Arbiter display name resolved by mantis tier (not positional index) so a custom <3-role config can't mislabel it
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (58 decisions)
+## 2026-06 (59 decisions)
 
-- **2026-06-28** — dogfood: populate clud-bug's own .clud-bug.json with the 4 baseline skills *(dogfood-skill-manifest)* — [decisions-branches/dogfood-skill-manifest.md](decisions-branches/dogfood-skill-manifest.md)
-- *... 56 more decisions ...*
+- **2026-06-28** — rc.14 (6c): conditional Mantis arbiter — pure shouldEscalate in core + recipe prose *(rc14-arbiter)* — [decisions-branches/rc14-arbiter.md](decisions-branches/rc14-arbiter.md)
+- *... 57 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.13",
+  "version": "0.7.0-rc.14",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/cli/review-prompt.ts
+++ b/src/cli/review-prompt.ts
@@ -89,10 +89,29 @@ export function renderReviewRecipe(input: { plan: ReviewPlan; trigger: ReviewTri
       const tier = role.tier ? ` · ${role.tier} tier` : '';
       return `  ${i + 1}. **${role.name}**${tier}`;
     }).join('\n');
+    // 6c: a 2-pass cross-check escalates to a conditional 3rd Mantis arbiter
+    // only when the first two passes disagree on a gate-relevant finding. Gate
+    // the prose to the same shape as `shouldEscalate` (cross-check + exactly 2
+    // passes) so a 3-pass or consensus plan doesn't get redundant instructions.
+    // Resolve the arbiter by tier (not positional index) so a custom <3-role
+    // `roles` config can't make `roleForPass`'s modulo wrap name a fast tier as
+    // the opus-class arbiter. Falls back to the canonical name when no mantis
+    // tier is configured.
+    const arbiter = plan.roles.find((r) => r.tier === 'mantis')?.name ?? 'Mantis';
+    const escalation =
+      mode === 'cross-check' && maxPasses === 2
+        ? `\n\nIf passes 1 and 2 **disagree** on any \`critical\` or \`minor\` finding, dispatch a ` +
+          `3rd **${arbiter}** arbiter sub-agent (opus-class, read-only tools) that re-examines ONLY ` +
+          `the disputed findings against the diff + the cited skill and records the deciding verdict ` +
+          `with a one-line rationale. Skip the arbiter if the passes agree, or disagree only on ` +
+          `\`preexisting\` findings. The arbiter's verdict sets each disputed finding's consensus ` +
+          `marker (\`2-of-2\` if upheld, \`arbitrated\` if not) and its rationale — it does not change ` +
+          `which findings gate the merge.`
+        : '';
     reviewStep =
       `Dispatch ${maxPasses} reviewer sub-agents — a ${maxPasses}-pass **${mode}** review on this ` +
       `session's subscription (bind each tier to a Claude Code model: a fast model for \`beetle\`, ` +
-      `a strong model for \`wasp\`/\`mantis\`):\n\n${passLines}\n\n${MODE_AGGREGATION[mode]}`;
+      `a strong model for \`wasp\`/\`mantis\`):\n\n${passLines}\n\n${MODE_AGGREGATION[mode]}${escalation}`;
   }
 
   const surface =

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -276,9 +276,11 @@ export {
   aggregatePasses,
   deriveConsensus,
   resolveVerdict,
+  shouldEscalate,
   type CrossCheckVerdict,
   type CrossCheckPassResult,
   type AggregateInput,
+  type EscalationInput,
 } from './multi-pass-aggregate.js';
 export {
   API_BASE,

--- a/src/core/multi-pass-aggregate.ts
+++ b/src/core/multi-pass-aggregate.ts
@@ -166,6 +166,52 @@ export function aggregatePasses(input: AggregateInput): MultiPassReview {
 }
 
 // ---------------------------------------------------------------------------
+// 6c — conditional Mantis-arbiter escalation
+// ---------------------------------------------------------------------------
+
+export interface EscalationInput {
+  /** Active aggregation mode — escalation only applies to cross-check. */
+  mode: ReviewPassMode;
+  /** Resolved pass count — escalation only when the plan ran exactly 2. */
+  passCount: number;
+  /** Pass 1's review; its findings are indexed by the cross-check verdicts. */
+  firstPass: Review;
+  /** Subsequent passes — the cross-check verdicts live here. */
+  subsequentPasses: AggregateInput['subsequentPasses'];
+}
+
+/**
+ * 6c arbiter gate (SPEC §6.10.1 `arbitrated`). Returns true when a 2-pass
+ * cross-check disagreed on a gate-relevant (`critical` | `minor`) Pass-1
+ * finding — the only case worth spending a 3rd Mantis arbiter pass on. Pure:
+ * it reads the verdicts Pass 2 already produced; no I/O, no AI call.
+ *
+ * Scope rationale:
+ *   - cross-check only — `consensus` already runs Mantis as its final pass and
+ *     `independent` has no arbiter; both return false.
+ *   - `passCount === 2` (not `>= 2`) — a statically-configured 3-pass
+ *     cross-check already runs Mantis as pass 3 via the loop, so escalating
+ *     there would stack a redundant 4th pass past MAX_PASSES.
+ *   - severity `critical | minor` — a `preexisting` dispute can never flip the
+ *     merge gate, so it doesn't earn an Opus-class arbiter.
+ *
+ * Authority is marker-only: the arbiter's verdict sets the disputed finding's
+ * consensus marker + rationale; it does not change which findings gate the
+ * merge (that stays `resolveVerdict`'s job).
+ */
+export function shouldEscalate(input: EscalationInput): boolean {
+  if (input.mode !== 'cross-check' || input.passCount !== 2) return false;
+  const pass1 = flattenFindings(input.firstPass);
+  return input.subsequentPasses.some((pass) =>
+    (pass.crossCheck?.verdicts ?? []).some((v) => {
+      if (v.verdict !== 'disagreed') return false;
+      const severity = pass1[v.pass1Index]?.severity;
+      return severity === 'critical' || severity === 'minor';
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Mode: cross-check
 // ---------------------------------------------------------------------------
 

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -400,7 +400,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.13
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.14
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -400,7 +400,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.13
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.14
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -704,7 +704,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.13
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.14
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/core/multi-pass-aggregate.test.js
+++ b/test/core/multi-pass-aggregate.test.js
@@ -10,6 +10,7 @@ import {
   aggregatePasses,
   deriveConsensus,
   resolveVerdict,
+  shouldEscalate,
 } from '../../src/core/multi-pass-aggregate.js';
 import { buildReviewFromFindings } from '../../src/core/review-schema-zod.js';
 
@@ -667,5 +668,110 @@ describe('aggregator populates UnifiedFinding.consensus', () => {
 
     expect(agg.findings).toHaveLength(1);
     expect(agg.findings[0]?.consensus).toBe('2-of-2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6c — shouldEscalate (conditional Mantis-arbiter gate)
+// ---------------------------------------------------------------------------
+
+describe('shouldEscalate', () => {
+  // Pass 1 (flattenFindings order: critical → minor → preexisting):
+  //   index 0 = critical, 1 = minor, 2 = preexisting.
+  const firstPass = reviewWith([
+    f('critical', 'race-conditions', 'auth.ts', 42, 'Race condition'),
+    f('minor', 'magic-numbers', 'utils.ts', 18, 'Magic number'),
+    f('preexisting', 'legacy', 'old.ts', 5, 'Legacy pattern'),
+  ]);
+  const pass2 = (verdicts) => ({
+    passNumber: 2,
+    role: ROLE_WASP,
+    crossCheck: { verdicts, independentFindings: [] },
+  });
+
+  it('escalates when a 2-pass cross-check disagrees on a critical finding', () => {
+    expect(
+      shouldEscalate({
+        mode: 'cross-check',
+        passCount: 2,
+        firstPass,
+        subsequentPasses: [pass2([{ pass1Index: 0, verdict: 'disagreed' }])],
+      }),
+    ).toBe(true);
+  });
+
+  it('escalates when a 2-pass cross-check disagrees on a minor finding', () => {
+    expect(
+      shouldEscalate({
+        mode: 'cross-check',
+        passCount: 2,
+        firstPass,
+        subsequentPasses: [pass2([{ pass1Index: 1, verdict: 'disagreed' }])],
+      }),
+    ).toBe(true);
+  });
+
+  it('does NOT escalate when the only disagreement is on a preexisting finding', () => {
+    expect(
+      shouldEscalate({
+        mode: 'cross-check',
+        passCount: 2,
+        firstPass,
+        subsequentPasses: [pass2([{ pass1Index: 2, verdict: 'disagreed' }])],
+      }),
+    ).toBe(false);
+  });
+
+  it('does NOT escalate when every verdict agrees', () => {
+    expect(
+      shouldEscalate({
+        mode: 'cross-check',
+        passCount: 2,
+        firstPass,
+        subsequentPasses: [
+          pass2([
+            { pass1Index: 0, verdict: 'agreed' },
+            { pass1Index: 1, verdict: 'agreed' },
+          ]),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('does NOT escalate for consensus or independent modes', () => {
+    for (const mode of ['consensus', 'independent']) {
+      expect(
+        shouldEscalate({
+          mode,
+          passCount: 2,
+          firstPass,
+          subsequentPasses: [pass2([{ pass1Index: 0, verdict: 'disagreed' }])],
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it('does NOT escalate at passCount 1 or 3 (a static 3-pass already runs Mantis)', () => {
+    for (const passCount of [1, 3]) {
+      expect(
+        shouldEscalate({
+          mode: 'cross-check',
+          passCount,
+          firstPass,
+          subsequentPasses: [pass2([{ pass1Index: 0, verdict: 'disagreed' }])],
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it('does NOT escalate when the disagreed pass1Index is out of range', () => {
+    expect(
+      shouldEscalate({
+        mode: 'cross-check',
+        passCount: 2,
+        firstPass,
+        subsequentPasses: [pass2([{ pass1Index: 99, verdict: 'disagreed' }])],
+      }),
+    ).toBe(false);
   });
 });

--- a/test/review-prompt.test.js
+++ b/test/review-prompt.test.js
@@ -64,6 +64,24 @@ describe('renderReviewRecipe', () => {
     const recipe = renderReviewRecipe({ plan, trigger: 'commit' });
     expect(recipe).toContain(plan.summary);
   });
+
+  it('describes the conditional 3rd Mantis arbiter for a 2-pass cross-check (6c), and omits it otherwise', () => {
+    // 2-pass cross-check on a pr → the arbiter escalation prose appears.
+    const ccPlan = planReview({
+      skills: SKILLS,
+      config: { count: 2, mode: 'cross-check' },
+      trigger: 'pr',
+    });
+    const ccRecipe = renderReviewRecipe({ plan: ccPlan, trigger: 'pr' });
+    expect(ccRecipe).toMatch(/dispatch 2 reviewer/i);
+    expect(ccRecipe).toMatch(/3rd \*\*Mantis\*\* arbiter/i);
+    expect(ccRecipe).toMatch(/disagree/i);
+
+    // A 3-pass consensus plan must NOT get the arbiter prose (gate correctness).
+    const consensusPlan = planReview({ skills: SKILLS, config: MULTIPASS_CONFIG, trigger: 'pr' });
+    const consensusRecipe = renderReviewRecipe({ plan: consensusPlan, trigger: 'pr' });
+    expect(consensusRecipe).not.toMatch(/arbiter sub-agent/i);
+  });
 });
 
 describe('review-prompt verb (integration)', () => {


### PR DESCRIPTION
## What (rc.14 — the "6c" cut)

Ships the conditional **Mantis arbiter** as a pure decision in `core`, so the hosted bot and the local recipe share one rule (SPEC §11.5).

- **`shouldEscalate(...)`** (`src/core/multi-pass-aggregate.ts`, exported from `core`) — pure gate, true only when a **2-pass `cross-check`** disagreed on a **`critical` or `minor`** Pass-1 finding. Scope: cross-check only, exactly `passCount === 2` (a static 3-pass already runs Mantis as pass 3), severity `critical|minor` (a `preexisting` dispute can't flip the gate). **Marker + rationale authority only** — `resolveVerdict` is unchanged; the arbiter sets the consensus marker, it doesn't change which findings gate the merge.
- **`review-prompt` recipe** describes the arbiter for a 2-pass cross-check plan (gated to `cross-check` + 2 passes; arbiter name resolved by `tier==='mantis'`, not positional index, so a custom <3-role config can't mislabel it).
- **Version bump rc.13 → rc.14** across all 5 release-discipline pins (package.json + 3 workflow templates + action.yml) + CHANGELOG.

## Not in this PR (by decision)

- `BUILTIN_DEFAULT` is **not** flipped — 2-pass is a **Team-tier** repo default applied app-side (multi-pass is positioned as a Team feature); OSS/free/Solo keep the 1-pass floor.
- Arbiter does not yet demote/drop a contested critical from the gate (marker-only for rc.14).

## Drive-by fix (caught by the adversarial review)

`npm-publish.yml` ran `npm publish` with **no `--tag`**, so pushing the `v0.7.0-rc.14` tag (which triggers the workflow) would have published the prerelease to **`latest`**, clobbering the `npm i clud-bug` stable channel. Made the publish **prerelease-aware**: it now derives `--tag next` from the `-rc.N` version (clean semver → `latest`). This makes the CHANGELOG's "publishes to `next`" claim actually true.

## Verify

`npm run build && npm test && npm run test:fixtures` + `actionlint` — all green. New tests: `shouldEscalate` suite (8 cases incl. mode/passCount/severity/out-of-range) + a recipe arbiter-prose test (present at 2-pass cross-check, absent at 3-pass consensus). Reviewed adversarially across correctness / spec-conformance / consumer-compat lenses.

## [CEO] after merge

Push the tag to publish rc.14 to **`next`** (OIDC trusted-publisher, no token): `git tag v0.7.0-rc.14 && git push origin v0.7.0-rc.14`. (Unblocks PR A3 — the app's Team 2-pass default + arbiter wiring, which bumps the dep to rc.14.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)