### PR TITLE
site: reconcile landing copy to shipped pricing + multi-pass reality

### DIFF
--- a/docs/decisions-branches/a5-landing-refresh.md
+++ b/docs/decisions-branches/a5-landing-refresh.md
@@ -1,0 +1,14 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-28 23:51 - site: reconcile landing copy to shipped pricing + multi-pass reality
+
+**Reasoning:** The landing page was stale: it sold a non-existent 'Pro tier', framed multi-pass as 'always three passes', and claimed 'free on public repos' for the hosted app. Align to reality — tiers are Trial/Solo/Team (multi-pass is a Team feature: a 2-pass cross-check plus a conditional Mantis arbiter on disagreement), and 'free' is the self-hosted OSS workflow.
+
+**Alternatives considered:** Full landing redesign — deferred; targeted accuracy fixes only for launch
+
+**Implications:**
+- Edits site/app/page.tsx (hero fineprint, step 2, the multi-pass marginalia + intro) and site/app/layout.tsx OG description
+- No price restatement — links to app.cludbug.dev/pricing per the brand-voice drift gate
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (59 decisions)
+## 2026-06 (60 decisions)
 
-- **2026-06-28** — rc.14 (6c): conditional Mantis arbiter — pure shouldEscalate in core + recipe prose *(rc14-arbiter)* — [decisions-branches/rc14-arbiter.md](decisions-branches/rc14-arbiter.md)
-- *... 57 more decisions ...*
+- **2026-06-28** — site: reconcile landing copy to shipped pricing + multi-pass reality *(a5-landing-refresh)* — [decisions-branches/a5-landing-refresh.md](decisions-branches/a5-landing-refresh.md)
+- *... 58 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'Clud Bug — AI PR review with project-aware skills',
     description:
-      'Install the GitHub App. Reviews land on every PR within two minutes, cited against the skills your team writes. Three-pass review on the Pro tier. Self-hosted workflow optional.',
+      'Install the GitHub App. Reviews land on every PR within two minutes, cited against the skills your team writes. Multi-pass review on the Team tier. Self-hosted workflow optional.',
     url: 'https://cludbug.dev',
     siteName: 'Clud Bug',
     type: 'website',

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -52,10 +52,11 @@ export default async function Home() {
               Install the GitHub App
             </a>
             <p className="cta-fineprint">
-              Free on public repos. See{' '}
+              Managed tiers — see{' '}
               <a href={APP_PRICING_URL} rel="noopener">pricing</a> and{' '}
-              <a href={APP_COMPARE_URL} rel="noopener">compare</a> tiers on{' '}
-              <a href={APP_ROOT_URL} rel="noopener">app.cludbug.dev</a>.
+              <a href={APP_COMPARE_URL} rel="noopener">compare</a> on{' '}
+              <a href={APP_ROOT_URL} rel="noopener">app.cludbug.dev</a>, or{' '}
+              <a href="#self-hosted">self-host the open-source workflow</a> for free.
             </p>
             <p className="cta-fineprint cta-secondary">
               <a href="#self-hosted">Self-hosted? Use the open-source workflow →</a>
@@ -99,9 +100,9 @@ export default async function Home() {
               <p className="howto-desc">
                 Pick a plan on the{' '}
                 <a href={APP_DASHBOARD_URL} rel="noopener">dashboard</a>{' '}
-                — free on public repos, or a Marketplace tier for private
-                ones. Skills are auto-curated from your repository on the
-                first PR.
+                — managed tiers for any repo, public or private. The bot
+                reviews against the skills in <code>.claude/skills/</code>,
+                starting with the baseline kit.
               </p>
             </li>
             <li className="howto-step">
@@ -198,15 +199,17 @@ export default async function Home() {
         </header>
         <div className="section-body">
           <aside className="marginalia">
-            Available on the Pro tier. Each pass writes to the same PR but
+            Available on the Team tier. Each pass writes to the same PR but
             signs its own comments. Disagreements get adjudicated, not
             averaged. <a href={APP_PRICING_URL} rel="noopener">Pricing →</a>
           </aside>
           <div className="section-prose">
             <p>
-              The default review is a single pass — fast, skill-aware, cited.
-              On the Pro tier, Clud Bug runs three passes that each see the
-              previous one&rsquo;s findings and react to them:
+              Most reviews are a single fast pass — skill-aware and cited. On
+              the Team tier, Clud Bug runs a two-pass cross-check: a second
+              naturalist re-reads the first one&rsquo;s findings against the
+              diff, and a third — the arbiter — is called in only when the two
+              disagree:
             </p>
             <div className="passes">
               <article className="pass">


### PR DESCRIPTION
## What

The marketing landing page had drifted from the shipped product. Targeted accuracy fixes (no redesign):

- **"Pro tier" → "Team tier"** (×2 in `page.tsx`, + the OpenGraph description in `layout.tsx`). There is no Pro tier — tiers are Trial / Solo / Team, and multi-pass is a **Team** feature.
- **Multi-pass framing → the shipped default.** §III no longer says "the default is a single pass; the Pro tier runs three passes." It now reads: most reviews are a single fast pass; the **Team tier runs a 2-pass cross-check**, with a **third (the arbiter) called in only when the two disagree** — matching the rc.14 `shouldEscalate` behavior. (The Beetle/Wasp/Mantis cards were already accurate.)
- **"Free on public repos" → self-hosted OSS.** That claim wasn't backed by the hosted billing policy; it refers to the **open-source self-hosted workflow** (bring-your-own-key). The hero fineprint + step 2 now say "managed tiers … or self-host the open-source workflow for free."
- Dropped the unverified "skills are auto-curated from your repository on the first PR" line; replaced with the accurate "reviews against the skills in `.claude/skills/`, starting with the baseline kit."

Brand-voice preserved (field-guide voice; App-first; **no price restatement** — links to `app.cludbug.dev/pricing`).

## Verify

`npx tsc --noEmit` clean; no residual stale phrases (`grep` for pro tier / three-pass / free-on-public / auto-curated → none). Vercel preview check will render it. (When the design-critic lands, I'll run it against this page's preview per the plan.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)