### PR TITLE
design-critic B1a: kind:design skill lens + design baseline kit

### DIFF
--- a/docs/decisions-branches/b1a-design-kit.md
+++ b/docs/decisions-branches/b1a-design-kit.md
@@ -1,0 +1,14 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 08:12 - design-critic B1a: add kind:design skill lens + ship the design baseline kit
+
+**Reasoning:** First half of the design-critic lens (Track B). Adds 'design' as a third SkillKind alongside rule/voice so design skills route to a visual pass; ships a 3-skill design baseline kit (design-system-consistency, visual-polish, frontend-a11y) that reviews the RENDERED surface (screenshots) — each kind:design + review_mode:dedicated + applies_to frontend globs, encoding the elite bar and told to flag 'fine but not elite'.
+
+**Alternatives considered:** A 'lens:' frontmatter field instead of a new kind — rejected: kind is the existing category axis and flows through manifest/list/refresh; design needs no extra required field (unlike voice/voice_scope)
+
+**Implications:**
+- Additive — kind:design parses with no voice_scope required; the kit files are inert until installed (the installer + design config + recipe step land in B1b/rc.15)
+- diffManifest handling for kind:design rides with B1b's installer
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (60 decisions)
+## 2026-06 (61 decisions)
 
-- **2026-06-28** — site: reconcile landing copy to shipped pricing + multi-pass reality *(a5-landing-refresh)* — [decisions-branches/a5-landing-refresh.md](decisions-branches/a5-landing-refresh.md)
-- *... 58 more decisions ...*
+- **2026-06-29** — design-critic B1a: add kind:design skill lens + ship the design baseline kit *(b1a-design-kit)* — [decisions-branches/b1a-design-kit.md](decisions-branches/b1a-design-kit.md)
+- *... 59 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -655,7 +655,7 @@ export type SkillReviewMode = 'shared' | 'dedicated';
  * `PromptSkillFrontmatter` is a narrower subset (name + description +
  * applies_to) so we keep the full shape here.
  */
-export type SkillKind = 'rule' | 'voice';
+export type SkillKind = 'rule' | 'voice' | 'design';
 export type VoiceScope = 'personal' | 'team' | 'org' | 'community';
 
 export interface SkillFrontmatter {
@@ -778,7 +778,13 @@ export function parseFrontmatter(raw: string): SkillFrontmatter {
   // "voice_scope REQUIRED when kind: voice") is the caller's job.
   const kindRaw = out['kind'];
   const kind: SkillKind | undefined =
-    kindRaw === 'voice' ? 'voice' : kindRaw === 'rule' ? 'rule' : undefined;
+    kindRaw === 'voice'
+      ? 'voice'
+      : kindRaw === 'design'
+        ? 'design'
+        : kindRaw === 'rule'
+          ? 'rule'
+          : undefined;
   const voiceScopeRaw = out['voice_scope'];
   const voiceScope: VoiceScope | undefined =
     voiceScopeRaw === 'personal' ||

--- a/templates/skills/design/design-system-consistency.md
+++ b/templates/skills/design/design-system-consistency.md
@@ -1,0 +1,41 @@
+---
+name: design-system-consistency
+description: Visual review — flag rendered UI that drifts from the design system's tokens, scale, and color discipline. Judges the screenshot, not just the code.
+kind: design
+review_mode: dedicated
+applies_to:
+  paths: ["site/**", "app/**", "**/components/**", "**/ui/**"]
+  extensions: [".tsx", ".jsx", ".css", ".scss", ".vue", ".svelte"]
+---
+
+# Design-system consistency
+
+You are reviewing the **rendered** change (screenshots, light and dark) against the
+project's design system. Cite the specific element you see in the screenshot — name it
+and where it is — not just the source line.
+
+## Flag
+
+1. **Off-token values.** A hardcoded color, spacing, radius, shadow, or font-size where a
+   design token / CSS variable already exists for that role. Quote the value and name the
+   token it should use.
+2. **Color discipline.** Fills should be cool/neutral; strokes and text are the warm/ink
+   layer; a saturated red (or the system's "danger" hue) is reserved for destructive or
+   critical states. Flag a red used for a non-critical accent, or a one-off accent hue that
+   isn't in the palette. Prefer perceptually-uniform color (OKLCH/LCH) over ad-hoc hex when
+   the system uses it.
+3. **Off-scale spacing.** Margins/padding/gaps that don't land on the spacing scale (e.g. a
+   `13px` gap in a 4-/8-pt system). Rhythm should be consistent between sibling elements.
+4. **Type ramp drift.** A font-size/weight/line-height combination outside the defined type
+   scale, or the same semantic level rendered at two different sizes across the view.
+5. **Re-implementation.** A button/card/input hand-rolled inline when a system component
+   exists — visible as subtly different padding, radius, or hover from its siblings.
+
+## How to judge
+
+- Compare the new surface against an existing, known-good surface in the same product.
+- "It renders" is not the bar — **token-correct** is the bar. Flag a value that looks fine
+  but bypasses the system; say which token restores consistency.
+- One concrete drift per finding, with the rendered element quoted and the fix named.
+
+If the rendered change is token-clean and on-scale in both themes, say so in one line.

--- a/templates/skills/design/frontend-a11y.md
+++ b/templates/skills/design/frontend-a11y.md
@@ -1,0 +1,41 @@
+---
+name: frontend-a11y
+description: Visual review — accessibility on the rendered surface: contrast, focus visibility, tap targets, semantics, motion. Cite the element and the failing ratio or state.
+kind: design
+review_mode: dedicated
+applies_to:
+  paths: ["site/**", "app/**", "**/components/**", "**/ui/**"]
+  extensions: [".tsx", ".jsx", ".css", ".scss", ".vue", ".svelte"]
+---
+
+# Frontend accessibility
+
+You are reviewing the **rendered** change (screenshots, light and dark) plus the markup for
+accessibility. Cite the element and the concrete failure (the measured ratio, the missing
+state, the tag).
+
+## Flag
+
+1. **Contrast.** Body text below WCAG AA 4.5:1, or large text / UI borders below 3:1 — in
+   **either** theme (check both screenshots; dark mode is where contrast quietly fails).
+   Name the foreground/background and the approximate ratio.
+2. **Focus visibility.** Any interactive element with no visible focus indicator, or a focus
+   ring removed (`outline: none`) without a replacement. Keyboard users must see focus.
+3. **Tap / click targets.** Controls smaller than ~24x24 CSS px (44px on touch surfaces),
+   or targets packed too tightly to hit reliably.
+4. **Semantics.** Icon-only buttons without an accessible name (`aria-label`/visually-hidden
+   text); headings that skip levels; a `<div>` with a click handler where a `<button>`/`<a>`
+   belongs; images conveying meaning without alt text.
+5. **Color-only signaling.** State or meaning carried by color alone (e.g. red/green status
+   with no icon or label).
+6. **Motion.** Auto-playing or large motion that doesn't honor `prefers-reduced-motion`.
+
+## How to judge
+
+- Prefer findings you can see or measure in the screenshot/markup; estimate the contrast
+  ratio rather than hand-waving "low contrast."
+- A genuine WCAG-AA failure on interactive/text content is high severity; a borderline ratio
+  or a nice-to-have is medium/low.
+- One issue per finding: element, the failure, the fix.
+
+If the surface is clean on these checks in both themes, say so in one line.

--- a/templates/skills/design/visual-polish.md
+++ b/templates/skills/design/visual-polish.md
@@ -1,0 +1,41 @@
+---
+name: visual-polish
+description: Visual review — hold the rendered UI to an elite bar: alignment, optical centering, spacing rhythm, glyph/pattern quality, state coverage, theme parity. Flag "fine but not elite," not only broken.
+kind: design
+review_mode: dedicated
+applies_to:
+  paths: ["site/**", "app/**", "**/components/**", "**/ui/**"]
+  extensions: [".tsx", ".jsx", ".css", ".scss", ".vue", ".svelte"]
+---
+
+# Visual polish
+
+You are judging the **rendered** change (screenshots, light and dark) against a
+Figma-grade bar. Most of what you flag will be "acceptable but not elite" — that is the
+point. Cite the element and where it sits in the screenshot.
+
+## Flag
+
+1. **Alignment & optical centering.** Elements off a shared grid/baseline; an icon
+   geometrically centered in a button but optically off (glyphs with side-bearing need a
+   nudge); label and control not on the same baseline; ragged edges between siblings.
+2. **Spacing rhythm.** Inconsistent gaps in a list/stack; cramped or floaty padding; a
+   section that breaks the vertical rhythm the rest of the page establishes.
+3. **Glyph & pattern quality.** Blurry/missized icons, mismatched stroke widths, a pattern
+   or texture that tiles visibly or clips, emoji where a real glyph is warranted.
+4. **State coverage.** Interactive elements missing a distinct hover / focus-visible /
+   active / disabled state, or states that are present but indistinguishable.
+5. **Theme parity.** Compare the light and dark screenshots: a color that loses contrast,
+   a shadow that vanishes, a border that disappears, or an asset baked for one theme only.
+6. **Clutter & duplication.** Redundant chrome, two affordances doing the same job,
+   competing focal points, or content that overflows / truncates awkwardly at the captured
+   viewport.
+
+## How to judge
+
+- Ask "would this ship in a top-tier product?" If it's *fine but not elite*, flag it with
+  the concrete upgrade (the nudge, the token, the missing state).
+- Severity: layout breakage or an unreadable state is high; polish gaps are medium/low.
+- One issue per finding; name the element, say what's off, say the fix.
+
+If the surface is genuinely polished in both themes, say so — don't manufacture nits.

--- a/test/skills-frontmatter.test.js
+++ b/test/skills-frontmatter.test.js
@@ -262,6 +262,22 @@ Body.
   assert.equal(fm.kind, 'rule');
 });
 
+test('parseFrontmatter: kind: design surfaced (visual-review lens, no scope required)', () => {
+  const raw = `---
+name: visual-polish
+description: A design skill.
+kind: design
+review_mode: dedicated
+---
+Body.
+`;
+  const fm = parseFrontmatter(raw);
+  assert.equal(fm.kind, 'design');
+  // design needs no voice_scope (unlike kind: voice)
+  assert.equal(fm.voice_scope, undefined);
+  assert.equal(fm.review_mode, 'dedicated');
+});
+
 test('parseFrontmatter: unknown kind silently drops (defensive)', () => {
   const raw = `---
 name: weird


### PR DESCRIPTION
## What (foundation for the design-critic, Track B)

First half of the design-critic lens. **No version bump** — this is the skill-model + content foundation; the pass/config/recipe/installer land in B1b (rc.15).

- **`kind: design`** — adds `design` as a third `SkillKind` alongside `rule`/`voice` (`src/core/skills.ts`). Design skills route to a visual pass; unlike `voice`, `design` needs no extra required field (no `voice_scope`).
- **Design baseline kit** (`templates/skills/design/`):
  - `design-system-consistency` — off-token values, color discipline (cool fills / warm draws / red=critical, OKLCH), off-scale spacing, type-ramp drift, re-implementation.
  - `visual-polish` — alignment & optical centering, spacing rhythm, glyph/pattern quality, state coverage, **light/dark theme parity**, clutter/duplication. Holds an elite bar and **flags "fine but not elite," not only broken**.
  - `frontend-a11y` — contrast (both themes), focus visibility, tap targets, semantics, color-only signaling, reduced-motion.
  - Each is `kind: design` + `review_mode: dedicated` + `applies_to` frontend globs, and reviews the **rendered** surface (screenshots), citing the element.

## Why `kind` not a `lens:` field

`kind` is the existing category axis (it flows through manifest / list / refresh); `design` slots in cleanly with no new required frontmatter.

## Dogfood

Ran clud-bug's own `review-prompt --trigger commit` against this commit (4 baseline skills, 1-pass commit tier): **clean** — parser is a pure ternary, kit files are markdown matching house format, test added for `kind: design` parsing.

## Verify

`npm run build && npm test` green (incl. new `parseFrontmatter: kind: design` test); all 3 kit files parse as `kind=design, mode=dedicated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)