### PR TITLE
design-critic B1b (rc.15): the design pass — config + gated recipe step

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.14
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.15
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.7.0-rc.15] — 2026-06-29
+
+Design-critic lens (B1) — the skill-driven review thesis pointed at pixels. OPTIONAL and
+off by default.
+
+### Added
+
+- **`kind: design` skills** (`core/skills.ts`) — a third skill lens alongside `rule` /
+  `voice`. Design skills review the *rendered* surface (screenshots) rather than the diff
+  text; they need no `voice_scope`. Ships a 3-skill design baseline kit under
+  `templates/skills/design/` (`design-system-consistency`, `visual-polish`, `frontend-a11y`)
+  encoding an elite bar (token/color discipline, optical centering & spacing, glyph/pattern
+  quality, light/dark parity, contrast/focus/tap-target a11y) and told to flag
+  "fine but not elite," not only broken.
+- **`core/design.ts`** — `readDesignConfig` (the `.clud-bug.json` `design` block; default
+  `{ enabled: false, gate: 'advisory', themes: ['light','dark'], viewports: ['desktop'] }`)
+  and `shouldRunDesign` (pure gate: opted-in + design skills present + `pr` trigger). A typo
+  can never silently *enable* the cost-bearing pass.
+- **`review-prompt` design-critic step** — when the gate passes, the local recipe emits an
+  optional "## 3b. Design-critic" step: find the deploy-preview URL, render the changed
+  routes (light + dark) via a browser MCP, and critique the screenshots against the design
+  skills (`<!-- pass: design -->`). Defers to runtime — no preview URL or no browser MCP →
+  skipped silently. Code (`kind != design`) and design skills are partitioned: code skills
+  drive the multi-pass plan, design skills drive this step.
+- `refresh` now preserves installed `kind: design` skills (like baseline), so a re-sync
+  can't drop a repo's design kit.
+
+### Notes
+
+- v1 is **local + advisory**. A repo opts in via the `design` block + installed design
+  skills. The `clud-bug init --with-design` installer and the hosted Vercel-Sandbox render
+  path (which feeds screenshots to AI-Gateway vision) are follow-ups. rc.15 → `next`.
+
 ## [0.7.0-rc.14] — 2026-06-28
 
 6c — the conditional Mantis arbiter (the decision lives in `core`; consumers wire the pass).

--- a/docs/decisions-branches/b1b-design-pass.md
+++ b/docs/decisions-branches/b1b-design-pass.md
@@ -1,0 +1,14 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 08:34 - design-critic B1b: the design pass — config, gated recipe step, rc.15
+
+**Reasoning:** Second half of the local design-critic (rc.15). core/design.ts holds the off-by-default config (readDesignConfig) + a pure run-gate (shouldRunDesign: opted-in + kind:design skills + pr trigger). review-prompt partitions code vs design skills and emits an optional '## 3b. Design-critic' step that finds the deploy-preview, renders light/dark via a browser MCP, and critiques screenshots against the design skills — advisory by default, never auto-fix. refresh now preserves installed design skills.
+
+**Alternatives considered:** Make design a builtin default — rejected: it is off by default + cost-gated (config + pr-only + preview-required), Bundle the --with-design installer + Action MCP opt-in here — deferred to a fast-follow to keep rc.15 tight (manual .clud-bug.json opt-in works meanwhile)
+
+**Implications:**
+- Bumps version to rc.15 across the 5 lockstep pins + CHANGELOG
+- Adversarial review caught + fixed a fail-silent bug: the preview-URL lookup used unset $OWNER/$REPO shell vars (would neuter the pass in local mode); now uses gh's {owner}/{repo} placeholders, with a regression test
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (61 decisions)
+## 2026-06 (62 decisions)
 
-- **2026-06-29** — design-critic B1a: add kind:design skill lens + ship the design baseline kit *(b1a-design-kit)* — [decisions-branches/b1a-design-kit.md](decisions-branches/b1a-design-kit.md)
-- *... 59 more decisions ...*
+- **2026-06-29** — design-critic B1b: the design pass — config, gated recipe step, rc.15 *(b1b-design-pass)* — [decisions-branches/b1b-design-pass.md](decisions-branches/b1b-design-pass.md)
+- *... 60 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.14",
+  "version": "0.7.0-rc.15",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/cli/review-prompt.ts
+++ b/src/cli/review-prompt.ts
@@ -13,11 +13,14 @@ import {
   planReview,
   roleForPass,
   readReviewPassesConfig,
+  readDesignConfig,
+  shouldRunDesign,
   parseFrontmatter,
   type ReviewPlan,
   type ReviewPlanSkill,
   type ReviewTrigger,
   type ReviewPassMode,
+  type DesignConfig,
 } from '../core/index.js';
 import { readManifest } from './skills.js';
 
@@ -46,8 +49,17 @@ const TRIGGER_INTRO: Record<ReviewTrigger, string> = {
  * and the skills all come from the plan, so the recipe scales from a single
  * fast commit pass up to the full multi-pass PR review without branching here.
  */
-export function renderReviewRecipe(input: { plan: ReviewPlan; trigger: ReviewTrigger }): string {
-  const { plan, trigger } = input;
+export function renderReviewRecipe(input: {
+  plan: ReviewPlan;
+  trigger: ReviewTrigger;
+  /**
+   * Design-critic lens (rc.15). Present only when the caller's gate passed
+   * (`shouldRunDesign`): the repo opted in, `kind: design` skills are installed,
+   * and this is a `pr` trigger. Renders the optional visual-review step.
+   */
+  design?: { skills: string[]; config: DesignConfig };
+}): string {
+  const { plan, trigger, design } = input;
   const slugs = plan.perSkill.map((p) => p.slug);
   const maxPasses = plan.perSkill.length
     ? Math.max(...plan.perSkill.map((p) => p.count))
@@ -121,6 +133,30 @@ export function renderReviewRecipe(input: { plan: ReviewPlan; trigger: ReviewTri
       : 'Surface the findings into the session, and — if an open PR exists — post or edit (in ' +
         'place, by integer comment id) the clud-bug summary comment on it.';
 
+  // 3b (rc.15) — the OPTIONAL design-critic visual pass. Rendered only when the
+  // caller gated it on (design.enabled + kind:design skills + pr trigger). The
+  // step itself defers to runtime: no deploy-preview URL or no browser MCP in
+  // the session → skip silently. This is the local counterpart of the hosted
+  // Vercel-Sandbox render path.
+  const designStep = design
+    ? `\n\n## 3b. Design-critic (visual review)
+This repo opted into design review. If this PR has a live deploy-preview, also review the **rendered** UI — skip this whole step silently if there is no preview, or no browser MCP in this session.
+
+1. **Find the preview URL** (GitHub deployments first, then a Vercel/Netlify status or bot comment):
+\`\`\`bash
+gh api "repos/{owner}/{repo}/deployments?per_page=10" --jq '.[].id' \\
+  | while read -r id; do gh api "repos/{owner}/{repo}/deployments/$id/statuses" --jq '.[0].environment_url // empty'; done | head -1
+\`\`\`
+2. **Render** each changed rendered surface (infer the route from the changed file path) on the preview, in ${design.config.themes.join(' + ')}, at the ${design.config.viewports.join(', ')} viewport(s). Hard-refresh to bypass cached assets, then take a full-page screenshot.
+3. **Critique** each screenshot against the design skills — cite the element you see + the skill, and flag what is *fine but not elite*, not only what is broken:
+${design.skills.map((s) => `  - \`.claude/skills/${s}/SKILL.md\``).join('\n')}
+   Record each finding with \`file\`, \`severity\` (\`critical\` | \`minor\` | \`preexisting\`), the design \`skill\`, and a one-line \`summary\`; tag design findings \`<!-- pass: design -->\`. ${
+     design.config.gate === 'strict'
+       ? 'Gated: a design `critical` blocks the merge (`design.gate: strict`).'
+       : 'Advisory: design findings inform, they do not block the merge.'
+   }`
+    : '';
+
   return `<!-- ${CLUD_BUG_RECIPE_MARKER} v1 -->
 You are **clud-bug**, running ${TRIGGER_INTRO[trigger]} inside this Claude Code session, on
 this session's own model tokens — no hosted App, no extra auth (you already have \`git\`,
@@ -142,7 +178,7 @@ or performance bugs — skip nits), **evidence-based-review** (quote the exact l
 and **respect-existing-conventions** (don't fight the codebase's patterns).
 
 ## 3. Review
-${reviewStep}
+${reviewStep}${designStep}
 
 ## 4. Report
 Render the body in clud-bug's standard shape (§1.8.1) — omit any empty section:
@@ -203,16 +239,32 @@ export async function runReviewPrompt(args: ReviewPromptArgs): Promise<void> {
     }
   }
 
+  // Partition by lens: `kind: design` skills drive the visual design-critic
+  // pass, not the code-correctness multi-pass plan. Code skills go to
+  // planReview; design skills go to the (gated) design step.
+  const designSkills = skills.filter((s) => s.frontmatter.kind === 'design');
+  const codeSkills = skills.filter((s) => s.frontmatter.kind !== 'design');
+
   const config = readReviewPassesConfig(manifest);
   const plan = planReview({
-    skills,
+    skills: codeSkills,
     config,
     trigger,
     rawSkillMd,
     ...(args.diffSizeBytes !== undefined ? { diffSizeBytes: args.diffSizeBytes } : {}),
   });
 
-  process.stdout.write(renderReviewRecipe({ plan, trigger }) + '\n');
+  // The design-critic is gated: opted-in (`design.enabled`) + at least one
+  // installed design skill + a `pr` trigger. The deploy-preview + browser-MCP
+  // preconditions are deferred to the agent at runtime (see the rendered step).
+  const designConfig = readDesignConfig(manifest);
+  const design = shouldRunDesign(designConfig, designSkills.length, trigger)
+    ? { skills: designSkills.map((s) => s.slug), config: designConfig }
+    : undefined;
+
+  process.stdout.write(
+    renderReviewRecipe({ plan, trigger, ...(design ? { design } : {}) }) + '\n',
+  );
 }
 
 function normalizeTrigger(raw: string | undefined): ReviewTrigger {

--- a/src/cli/skills.ts
+++ b/src/cli/skills.ts
@@ -374,7 +374,10 @@ export function diffManifest(manifest: Manifest, recommended: RankableSkill[]): 
     }
   }
   for (const [key, entry] of installedByKey) {
-    if (entry.kind === 'baseline') continue; // baseline always stays
+    // Baseline + design-kit skills are first-party opt-ins, not skills.sh
+    // recommendations — `refresh` must never drop them just because they're
+    // absent from the recommended set.
+    if (entry.kind === 'baseline' || entry.kind === 'design') continue;
     if (!recByKey.has(key)) remove.push(entry);
   }
   return { add, remove, unchanged };

--- a/src/core/design.ts
+++ b/src/core/design.ts
@@ -1,0 +1,73 @@
+// Design-critic lens config + gate (Track B, rc.15).
+//
+// The design-critic is an OPTIONAL, off-by-default visual review pass that
+// renders the changed UI (light + dark) and critiques it against `kind: design`
+// skills. It is gated tightly so it only ever runs — and only ever costs — when
+// a repo has explicitly opted in. This module is the shared, pure brain: the
+// local recipe (`review-prompt`) and the hosted bot both resolve the config and
+// the run-gate here so the policy can't fork (SPEC §11.5 / §12).
+
+import type { ReviewTrigger } from './plan-review.js';
+
+/** How design findings interact with the merge gate. */
+export type DesignGate = 'advisory' | 'strict';
+
+/** Resolved `.clud-bug.json` `design` block (defaults applied). */
+export interface DesignConfig {
+  /** Master switch. Default OFF — the design pass never runs unless this is true. */
+  enabled: boolean;
+  /**
+   * `advisory` (default) — design findings post as comments, never block merge.
+   * `strict` — a design `critical` turns the check RED (opt-in).
+   */
+  gate: DesignGate;
+  /** Themes to render + critique. Default both. */
+  themes: string[];
+  /** Viewports to render. Default a single desktop viewport. */
+  viewports: string[];
+}
+
+/** Off-by-default builtin — the cost-control floor. */
+export const BUILTIN_DESIGN_CONFIG: DesignConfig = {
+  enabled: false,
+  gate: 'advisory',
+  themes: ['light', 'dark'],
+  viewports: ['desktop'],
+};
+
+/**
+ * Read + normalize the `design` block from a parsed `.clud-bug.json` manifest.
+ * Tolerant: a missing/malformed block resolves to the off-by-default builtin,
+ * so a typo can never silently *enable* the (cost-bearing) pass.
+ */
+export function readDesignConfig(manifest: unknown): DesignConfig {
+  const raw = (manifest as { design?: unknown } | null | undefined)?.design;
+  if (!raw || typeof raw !== 'object') return { ...BUILTIN_DESIGN_CONFIG };
+  const d = raw as Record<string, unknown>;
+  const strArr = (v: unknown, fallback: string[]): string[] =>
+    Array.isArray(v) && v.length > 0 ? v.map(String) : [...fallback];
+  return {
+    enabled: d['enabled'] === true,
+    gate: d['gate'] === 'strict' ? 'strict' : 'advisory',
+    themes: strArr(d['themes'], BUILTIN_DESIGN_CONFIG.themes),
+    viewports: strArr(d['viewports'], BUILTIN_DESIGN_CONFIG.viewports),
+  };
+}
+
+/**
+ * Consumer-agnostic run-gate for the design-critic. Pure.
+ *
+ * True only when the repo opted in (`enabled`), at least one `kind: design`
+ * skill applies, and this is a PR-level review (the pass is too expensive for
+ * per-commit / per-push triggers). Consumers layer their own runtime
+ * preconditions on top: the local recipe defers the deploy-preview-URL check to
+ * the agent; the hosted bot additionally requires a paying tier + a resolved
+ * preview URL before it spends a render.
+ */
+export function shouldRunDesign(
+  config: DesignConfig,
+  designSkillCount: number,
+  trigger: ReviewTrigger,
+): boolean {
+  return config.enabled && designSkillCount > 0 && trigger === 'pr';
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -283,6 +283,13 @@ export {
   type EscalationInput,
 } from './multi-pass-aggregate.js';
 export {
+  readDesignConfig,
+  shouldRunDesign,
+  BUILTIN_DESIGN_CONFIG,
+  type DesignConfig,
+  type DesignGate,
+} from './design.js';
+export {
   API_BASE,
   MAX_SKILLS,
   SkillsClient,

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -400,7 +400,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.14
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.15
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -400,7 +400,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.14
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.15
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -704,7 +704,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.14
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.15
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/core/design.test.js
+++ b/test/core/design.test.js
@@ -1,0 +1,77 @@
+// Tests for src/core/design.ts — the design-critic config + run-gate.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  readDesignConfig,
+  shouldRunDesign,
+  BUILTIN_DESIGN_CONFIG,
+} from '../../src/core/design.js';
+
+describe('readDesignConfig', () => {
+  it('defaults to off when no design block is present', () => {
+    expect(readDesignConfig({})).toEqual(BUILTIN_DESIGN_CONFIG);
+    expect(readDesignConfig({}).enabled).toBe(false);
+    expect(readDesignConfig(null)).toEqual(BUILTIN_DESIGN_CONFIG);
+    expect(readDesignConfig(undefined)).toEqual(BUILTIN_DESIGN_CONFIG);
+  });
+
+  it('a malformed design block resolves to off (a typo can never enable it)', () => {
+    expect(readDesignConfig({ design: 'yes' }).enabled).toBe(false);
+    expect(readDesignConfig({ design: 42 }).enabled).toBe(false);
+    // enabled must be the literal boolean true — truthy strings do not count
+    expect(readDesignConfig({ design: { enabled: 'true' } }).enabled).toBe(false);
+    expect(readDesignConfig({ design: { enabled: 1 } }).enabled).toBe(false);
+  });
+
+  it('reads enabled + gate + themes + viewports', () => {
+    const cfg = readDesignConfig({
+      design: {
+        enabled: true,
+        gate: 'strict',
+        themes: ['dark'],
+        viewports: ['mobile', 'desktop'],
+      },
+    });
+    expect(cfg).toEqual({
+      enabled: true,
+      gate: 'strict',
+      themes: ['dark'],
+      viewports: ['mobile', 'desktop'],
+    });
+  });
+
+  it('defaults gate to advisory + themes/viewports to the builtin when omitted or empty', () => {
+    const cfg = readDesignConfig({ design: { enabled: true, themes: [] } });
+    expect(cfg.gate).toBe('advisory');
+    expect(cfg.themes).toEqual(['light', 'dark']);
+    expect(cfg.viewports).toEqual(['desktop']);
+  });
+
+  it('an unknown gate falls back to advisory', () => {
+    expect(readDesignConfig({ design: { enabled: true, gate: 'block' } }).gate).toBe(
+      'advisory',
+    );
+  });
+});
+
+describe('shouldRunDesign', () => {
+  const on = { ...BUILTIN_DESIGN_CONFIG, enabled: true };
+
+  it('runs only when enabled + has design skills + pr trigger', () => {
+    expect(shouldRunDesign(on, 1, 'pr')).toBe(true);
+  });
+
+  it('does NOT run when disabled', () => {
+    expect(shouldRunDesign(BUILTIN_DESIGN_CONFIG, 1, 'pr')).toBe(false);
+  });
+
+  it('does NOT run with zero design skills', () => {
+    expect(shouldRunDesign(on, 0, 'pr')).toBe(false);
+  });
+
+  it('does NOT run on commit or push triggers (too expensive)', () => {
+    expect(shouldRunDesign(on, 1, 'commit')).toBe(false);
+    expect(shouldRunDesign(on, 1, 'push')).toBe(false);
+  });
+});

--- a/test/review-prompt.test.js
+++ b/test/review-prompt.test.js
@@ -82,6 +82,38 @@ describe('renderReviewRecipe', () => {
     const consensusRecipe = renderReviewRecipe({ plan: consensusPlan, trigger: 'pr' });
     expect(consensusRecipe).not.toMatch(/arbiter sub-agent/i);
   });
+
+  it('renders the design-critic step only when the design lens is passed (gated on)', () => {
+    const plan = planReview({ skills: SKILLS, config: MULTIPASS_CONFIG, trigger: 'pr' });
+    const design = {
+      skills: ['visual-polish', 'frontend-a11y'],
+      config: { enabled: true, gate: 'advisory', themes: ['light', 'dark'], viewports: ['desktop'] },
+    };
+
+    const withDesign = renderReviewRecipe({ plan, trigger: 'pr', design });
+    expect(withDesign).toMatch(/## 3b\. Design-critic/);
+    expect(withDesign).toMatch(/visual-polish/);
+    expect(withDesign).toMatch(/frontend-a11y/);
+    expect(withDesign).toMatch(/light \+ dark/);
+    expect(withDesign).toMatch(/Advisory/);
+    // preview-URL lookup must use gh's {owner}/{repo} placeholders (self-resolved
+    // from the cwd repo), NOT unset $OWNER/$REPO shell vars that would neuter the
+    // whole pass in local mode.
+    expect(withDesign).toMatch(/repos\/\{owner\}\/\{repo\}\/deployments/);
+    expect(withDesign).not.toMatch(/\$OWNER|\$REPO/);
+
+    // strict gate flips the wording to merge-blocking
+    const strict = renderReviewRecipe({
+      plan,
+      trigger: 'pr',
+      design: { ...design, config: { ...design.config, gate: 'strict' } },
+    });
+    expect(strict).toMatch(/blocks the merge/);
+
+    // no design arg → no design step at all
+    const withoutDesign = renderReviewRecipe({ plan, trigger: 'pr' });
+    expect(withoutDesign).not.toMatch(/Design-critic/);
+  });
 });
 
 describe('review-prompt verb (integration)', () => {


### PR DESCRIPTION
## What (rc.15 — local design-critic, the CEO's priority feature)

Second half of the design-critic lens. Builds on B1a (`kind: design` + the design kit). **Off by default, cost-gated.**

- **`core/design.ts`** — `readDesignConfig` (the `.clud-bug.json` `design` block; default `{ enabled: false, gate: 'advisory', themes: ['light','dark'], viewports: ['desktop'] }`; a typo can never *enable* the cost-bearing pass) + `shouldRunDesign` (pure gate: opted-in **and** ≥1 `kind: design` skill **and** `pr` trigger — never commit/push). Exported from `core` so the hosted bot (B2) reuses the exact policy.
- **`review-prompt` partition + design step** — code (`kind != design`) skills drive the multi-pass plan; `kind: design` skills drive a new optional **"## 3b. Design-critic"** step: find the deploy-preview URL → render the changed routes (light + dark) via a browser MCP → critique the screenshots against the design skills (`<!-- pass: design -->`). Advisory by default (`design.gate: 'strict'` opt-in); **never auto-fixes**. Defers to runtime — no preview or no browser MCP → skipped silently.
- **`refresh` preserves installed `kind: design` skills** (like baseline).
- Version bump → **rc.15** (5 lockstep pins) + CHANGELOG.

## Deferred to a fast-follow (kept rc.15 tight)

`clud-bug init --with-design` installer + the Action-template MCP opt-in. Repos opt in today via the `design` block + installed design skills (I'll dogfood-enable it on this repo next).

## Adversarial review caught a real bug

A 3-lens review + verify pass flagged (confirmed) that the preview-URL lookup used **unset `$OWNER`/`$REPO`** shell vars — in local mode that expands to `repos//deployments`, fails, and the "skip silently" rule would have **neutered the whole pass** for anyone who opted in. Fixed to gh's native `{owner}/{repo}` placeholders (the codebase convention) + added a regression test.

## Verify

`npm run build && npm test && npm run test:fixtures` green — new `core/design.test.js` (config defaults / malformed→off / gate / `shouldRunDesign` matrix) + a recipe design-step test (renders only when gated on; uses `{owner}/{repo}`, not `$OWNER`). Dogfood (manual, since the auto-hook can't run in this permission mode): reviewed the diff against the baseline skills — clean (the one real issue was caught + fixed by the adversarial pass).

## [CEO] after merge

Publish rc.15: `git tag v0.7.0-rc.15 && git push origin v0.7.0-rc.15` (OIDC → `next`). Unblocks B2 (the hosted Vercel-Sandbox render path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)