### PR TITLE
rc.16: clud-bug init --with-design + Action browser-MCP opt-in

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.15
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.16
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/decisions-branches/rc16-design-installer.md
+++ b/docs/decisions-branches/rc16-design-installer.md
@@ -1,0 +1,14 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 11:39 - rc.16: clud-bug init --with-design — install the design kit + enable the lens; Action browser-MCP opt-in
+
+**Reasoning:** The design lens shipped in rc.15 but there was no one-command way for a repo to install the 3 kind:design skills and flip the off-by-default design block on. --with-design mirrors --with-hooks: loadDesignKit (bundled-only, no network) writes the kit via writeSkills, then the manifest stamp flips design.enabled:true (preserving any existing gate/themes/viewports). The 3 workflow templates also gain a commented browser-MCP opt-in so the Action reviewer can render natively (Claude drives a real browser; no Browserless). Completes the design-critic everywhere-and-installable story.
+
+**Alternatives considered:** A separate 'clud-bug design enable' command — rejected: --with-design composes with the existing init flags and one bootstrap is simpler, Wiring the browser MCP into the templates live by default — rejected: a commented opt-in keeps the default workflow lean + free (no extra MCP cost)
+
+**Implications:**
+- New rc.16 (lockstep bump: package.json + 3 template strict-mode-gate pins + action.yml header). [CEO] push the v0.7.0-rc.16 tag after merge → OIDC publish to npm next
+- The Action opt-in is documentation-only (commented YAML); a future PR can wire the browser MCP live
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -66,6 +66,7 @@ clud-bug
 │   ├── formal-review.test.js
 │   ├── hooks.test.js
 │   ├── init-local-review.test.js
+│   ├── init-with-design.test.js
 │   ├── init-with-skdd.test.js
 │   ├── inline-threads.test.js
 │   ├── prompt-builder.test.js

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (62 decisions)
+## 2026-06 (63 decisions)
 
-- **2026-06-29** — design-critic B1b: the design pass — config, gated recipe step, rc.15 *(b1b-design-pass)* — [decisions-branches/b1b-design-pass.md](decisions-branches/b1b-design-pass.md)
-- *... 60 more decisions ...*
+- **2026-06-29** — rc.16: clud-bug init --with-design — install the design kit + enable the lens; Action browser-MCP opt-in *(rc16-design-installer)* — [decisions-branches/rc16-design-installer.md](decisions-branches/rc16-design-installer.md)
+- *... 61 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.15",
+  "version": "0.7.0-rc.16",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -25,7 +25,7 @@ import { renderFile, pickTemplate, templateLanguage } from '../core/render.js';
 import { reviewPrompt } from '../core/prompts.js';
 import { SkillsClient, rankAndCap } from '../core/skills.js';
 import {
-  writeSkills, writeSkill, loadBaseline,
+  writeSkills, writeSkill, loadBaseline, loadDesignKit,
   readManifest, writeManifest, removeSkill, listInstalled, diffManifest,
 } from './skills.js';
 import { computeAuditFileSet } from './audit.js';
@@ -44,6 +44,7 @@ import { computeReviewCost, costPerLOC, cacheHitRate, extractTokensFromLog, roll
 const PKG_ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const TEMPLATES = join(PKG_ROOT, 'templates');
 const BASELINE_DIR = join(TEMPLATES, 'skills', 'baseline');
+const DESIGN_DIR = join(TEMPLATES, 'skills', 'design');
 
 function parseArgs(argv) {
   const args = {
@@ -68,6 +69,10 @@ function parseArgs(argv) {
     // Claude Code session (reviews the current PR with the session's tokens).
     withLocalReview: false,
     withHooks: false,
+    // rc.16: `clud-bug init --with-design` installs the design-critic kit
+    // (3 `kind: design` skills) and flips the off-by-default `design` block to
+    // enabled so the visual review lens runs (local recipe + hosted bot).
+    withDesign: false,
     // v0.7.0-rc.4: `clud-bug configure-github` flags.
     // --dry-run prints the diff but skips PATCH; --branch overrides "main".
     dryRun: false,
@@ -96,6 +101,7 @@ function parseArgs(argv) {
     else if (a === '--with-skdd') args.withSkdd = true;
     else if (a === '--with-local-review') args.withLocalReview = true;
     else if (a === '--with-hooks') args.withHooks = true;
+    else if (a === '--with-design') args.withDesign = true;
     else if (a === '--dry-run') args.dryRun = true;
     else if (a === '--branch') args.branch = argv[++i];
     else if (a === '--trigger') args.trigger = argv[++i];
@@ -209,6 +215,9 @@ Options:
                         \`git commit\` the agent makes, a backgrounded clud-bug
                         review subagent runs on the session's subscription.
                         Implies --with-local-review. Off by default.
+  --with-design         (init) Install the design-critic kit (3 \`kind: design\`
+                        skills) and enable the off-by-default visual review
+                        lens — renders changed UI and critiques it. Off by default.
   --quiet,-q            Token-frugal mode for agent invocations. Suppresses
                         progress chatter; emits exactly one final
                         \`ok <key-value>\` summary line per command. Errors
@@ -1315,6 +1324,21 @@ async function runInit(args) {
     }
   }
 
+  // rc.16: --with-design installs the bundled design-critic kit (3 `kind:
+  // design` skills) and enables the off-by-default design lens. writeSkills
+  // writes the SKILL.md files + merges the manifest entries; the `design` block
+  // is flipped on the manifest read below so the local recipe + hosted bot both
+  // run the visual pass. Idempotent — re-runs replace the skills in place.
+  if (args.withDesign) {
+    const designKit = await loadDesignKit(DESIGN_DIR);
+    if (designKit.length > 0) {
+      await writeSkills(join(cwd, '.claude', 'skills'), designKit, client);
+      log(`    pinned ${designKit.length} design specimens (visual review lens enabled)`);
+    } else {
+      warn('No design-kit skills found to install (templates/skills/design/ empty?).');
+    }
+  }
+
   // Stamp the manifest. Sets strictMode: true ONLY on fresh installs —
   // a manifest that's never been touched by clud-bug init/update has no
   // lastUpdate field. Existing v0.3.x advisory installs (where strictMode
@@ -1323,6 +1347,12 @@ async function runInit(args) {
   // fresh inits. Users opt out by setting strictMode: false.
   const skillsDirPath = join(cwd, '.claude', 'skills');
   const manifest = await readManifest(skillsDirPath);
+  if (args.withDesign) {
+    // Flip the off-by-default design lens on; preserve any existing knobs
+    // (gate / themes / viewports) the user already set.
+    const prior = (manifest.design as Record<string, unknown> | undefined) ?? {};
+    manifest.design = { ...prior, enabled: true };
+  }
   const isFreshInstall = manifest.lastUpdate === undefined;
   manifest.lastUpdateVersion = await readPkgVersion();
   manifest.lastUpdate = new Date().toISOString();

--- a/src/cli/skills.ts
+++ b/src/cli/skills.ts
@@ -14,7 +14,12 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
 
-import { SkillsClient, type RankableSkill, type SkillDescriptor } from '../core/skills.js';
+import {
+  SkillsClient,
+  parseFrontmatter,
+  type RankableSkill,
+  type SkillDescriptor,
+} from '../core/skills.js';
 
 export const MANIFEST_FILE = '.clud-bug.json';
 export const MANIFEST_VERSION = 1;
@@ -118,6 +123,38 @@ async function readBundled(baselineDir: string): Promise<BaselineSkill[]> {
       kind: 'baseline',
       content,
     });
+  }
+  return skills;
+}
+
+/**
+ * Reads the bundled design-kit skills from the npm-package directory. Unlike
+ * `loadBaseline`, these are first-party and **bundled-only** — no skills.sh
+ * fetch (there's no upstream for them). Stamped `kind: 'design'` + `source:
+ * 'clud-bug-design'` so `diffManifest` / `refresh` never drop them.
+ */
+export async function loadDesignKit(designDir: string): Promise<WritableSkill[]> {
+  const skills: WritableSkill[] = [];
+  let entries;
+  try {
+    entries = await readdir(designDir, { withFileTypes: true });
+  } catch {
+    return skills;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+    const content = await readFile(join(designDir, entry.name), 'utf8');
+    const fallbackName = entry.name.replace(/\.md$/, '');
+    let name = fallbackName;
+    let description = '(design kit)';
+    try {
+      const fm = parseFrontmatter(content);
+      if (fm.name) name = fm.name;
+      if (fm.description) description = fm.description;
+    } catch {
+      // Malformed frontmatter on a first-party file — fall back to the filename.
+    }
+    skills.push({ source: 'clud-bug-design', name, description, installs: 0, kind: 'design', content });
   }
   return skills;
 }

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -213,6 +213,19 @@ jobs:
           echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
           exit 1
 
+      # ── Design-critic (optional, opt-in) ─────────────────────────────────
+      # clud-bug can also review the *rendered* UI of your PR's preview deploy.
+      # The hosted clud-bug[bot] does this for you on Team installs (Browserless).
+      # To run it here on the Action reviewer instead — Claude drives a real
+      # browser on this runner, no paid render service — enable it in 3 steps:
+      #   1. clud-bug init --with-design   (installs the design kit + flips the
+      #      `design` block in .claude/skills/.clud-bug.json to enabled: true)
+      #   2. add a browser MCP to claude_args below, e.g.:
+      #        --mcp-config '{"mcpServers":{"playwright":{"command":"npx","args":["-y","@playwright/mcp@latest"]}}}'
+      #   3. append the browser tools to --allowedTools, e.g.:
+      #        ,mcp__playwright__browser_navigate,mcp__playwright__browser_take_screenshot
+      # Off by default. See the §3b design step in `clud-bug review-prompt`.
+      # ──────────────────────────────────────────────────────────────────────
       - uses: anthropics/claude-code-action@{{CCA_VERSION}}
         if: steps.guard.outputs.skip != 'true'
         env:
@@ -400,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.15
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.16
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -213,6 +213,19 @@ jobs:
           echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
           exit 1
 
+      # ── Design-critic (optional, opt-in) ─────────────────────────────────
+      # clud-bug can also review the *rendered* UI of your PR's preview deploy.
+      # The hosted clud-bug[bot] does this for you on Team installs (Browserless).
+      # To run it here on the Action reviewer instead — Claude drives a real
+      # browser on this runner, no paid render service — enable it in 3 steps:
+      #   1. clud-bug init --with-design   (installs the design kit + flips the
+      #      `design` block in .claude/skills/.clud-bug.json to enabled: true)
+      #   2. add a browser MCP to claude_args below, e.g.:
+      #        --mcp-config '{"mcpServers":{"playwright":{"command":"npx","args":["-y","@playwright/mcp@latest"]}}}'
+      #   3. append the browser tools to --allowedTools, e.g.:
+      #        ,mcp__playwright__browser_navigate,mcp__playwright__browser_take_screenshot
+      # Off by default. See the §3b design step in `clud-bug review-prompt`.
+      # ──────────────────────────────────────────────────────────────────────
       - uses: anthropics/claude-code-action@{{CCA_VERSION}}
         if: steps.guard.outputs.skip != 'true'
         env:
@@ -400,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.15
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.16
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -383,6 +383,19 @@ jobs:
           echo "::error::Without it, Clud Bug review is a silent no-op."
           exit 1
 
+      # ── Design-critic (optional, opt-in) ─────────────────────────────────
+      # clud-bug can also review the *rendered* UI of your PR's preview deploy.
+      # The hosted clud-bug[bot] does this for you on Team installs (Browserless).
+      # To run it here on the Action reviewer instead — Claude drives a real
+      # browser on this runner, no paid render service — enable it in 3 steps:
+      #   1. clud-bug init --with-design   (installs the design kit + flips the
+      #      `design` block in .claude/skills/.clud-bug.json to enabled: true)
+      #   2. add a browser MCP to claude_args below, e.g.:
+      #        --mcp-config '{"mcpServers":{"playwright":{"command":"npx","args":["-y","@playwright/mcp@latest"]}}}'
+      #   3. append the browser tools to --allowedTools, e.g.:
+      #        ,mcp__playwright__browser_navigate,mcp__playwright__browser_take_screenshot
+      # Off by default. See the §3b design step in `clud-bug review-prompt`.
+      # ──────────────────────────────────────────────────────────────────────
       - uses: anthropics/claude-code-action@{{CCA_VERSION}}
         # Skip the action when guard already posted the bot/fork advisory.
         if: steps.guard.outputs.skip != 'true'
@@ -704,7 +717,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.15
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.16
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/init-with-design.test.js
+++ b/test/init-with-design.test.js
@@ -1,0 +1,89 @@
+// rc.16 — `clud-bug init --with-design` installs the design-critic kit (3
+// `kind: design` skills) and flips the off-by-default `design` block to
+// enabled, so the visual review lens runs (local recipe + hosted bot).
+
+import { test } from 'vitest';
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, access } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const CLI = join(dirname(dirname(fileURLToPath(import.meta.url))), 'bin', 'clud-bug.js');
+
+function runInit(dir, extraArgs) {
+  return spawnSync(
+    process.execPath,
+    [CLI, 'init', '--offline', '--accept-all', '--no-set-protection', ...extraArgs],
+    {
+      cwd: dir,
+      env: { ...process.env, HOME: dir, CLUD_BUG_QUIET: '1' },
+      encoding: 'utf8',
+      timeout: 30000,
+    },
+  );
+}
+
+async function readManifest(dir) {
+  return JSON.parse(await readFile(join(dir, '.claude', 'skills', '.clud-bug.json'), 'utf8'));
+}
+
+test('--with-design is advertised in --help', () => {
+  const r = spawnSync(process.execPath, [CLI, '--help'], { encoding: 'utf8' });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /--with-design/);
+});
+
+test('init --with-design installs the design kit + enables the design lens', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-design-'));
+  await mkdir(join(dir, '.git'), { recursive: true });
+  const r = runInit(dir, ['--with-design']);
+  assert.equal(r.status, 0, r.stderr);
+
+  const manifest = await readManifest(dir);
+  // The design block is flipped on.
+  assert.equal(manifest.design?.enabled, true, 'design.enabled should be true');
+
+  // The 3 design-kit skills are registered with kind: design.
+  const designEntries = (manifest.installed || []).filter((e) => e.kind === 'design');
+  assert.ok(designEntries.length >= 3, `expected >=3 design entries, got ${designEntries.length}`);
+  const slugs = designEntries.map((e) => e.slug).sort();
+  assert.deepEqual(
+    slugs,
+    ['design-system-consistency', 'frontend-a11y', 'visual-polish'],
+    'all three design-kit skills should be pinned',
+  );
+  for (const e of designEntries) {
+    assert.equal(e.source, 'clud-bug-design', `${e.slug} source should be clud-bug-design`);
+  }
+
+  // The SKILL.md files were written, carrying `kind: design` frontmatter.
+  const body = await readFile(
+    join(dir, '.claude', 'skills', 'visual-polish', 'SKILL.md'),
+    'utf8',
+  );
+  assert.match(body, /kind:\s*design/);
+});
+
+test('init WITHOUT --with-design leaves the design lens off', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-nodesign-'));
+  await mkdir(join(dir, '.git'), { recursive: true });
+  const r = runInit(dir, []);
+  assert.equal(r.status, 0, r.stderr);
+
+  const manifest = await readManifest(dir);
+  // No design block written, OR present but not enabled — either way, off.
+  assert.notEqual(manifest.design?.enabled, true);
+  const designEntries = (manifest.installed || []).filter((e) => e.kind === 'design');
+  assert.equal(designEntries.length, 0, 'no design skills should be installed');
+
+  // The design SKILL.md must not exist.
+  let exists = true;
+  try {
+    await access(join(dir, '.claude', 'skills', 'visual-polish', 'SKILL.md'));
+  } catch {
+    exists = false;
+  }
+  assert.equal(exists, false);
+});


### PR DESCRIPTION
## What

Makes the design-critic **installable in one command** and available on the Action surface — completing "everywhere."

- **`clud-bug init --with-design`** — installs the 3 bundled `kind: design` skills (`templates/skills/design/*`) via a new bundled-only `loadDesignKit` (no network), and flips the off-by-default `design` block in `.claude/skills/.clud-bug.json` to `enabled: true` (preserving any existing `gate`/`themes`/`viewports`). Idempotent; composes cleanly with `--with-hooks`/`--with-local-review`.
- **Action reviewer opt-in** — a commented design-critic block in the 3 workflow templates showing how to wire a browser MCP (Playwright/chrome-devtools) so the Action reviewer renders the preview natively (**Claude drives a real browser on the runner — no Browserless, no cost to us**). Default off; pure YAML comment (verified: rendered workflow is still valid YAML).
- **Lockstep bump rc.15 → rc.16** — `package.json` + 3 template `strict-mode-gate@v…` pins + the `action.yml` header example (release-discipline test enforces this).

## Verify

`npm run build && npm test` green (incl. `release-discipline` + new `test/init-with-design.test.js`). End-to-end: a temp `init --with-design` writes the kit, flips `design.enabled`, and renders **valid** workflow YAML. A focused code-review pass found no bugs.

## Surfaces (design-critic everywhere)

- **Local** ✅ (rc.15) · **Hosted bot** ✅ (clud-bug-app #81, Browserless) · **Action reviewer** ✅ (this opt-in)

## [CEO] after merge

Push the **`v0.7.0-rc.16`** tag → the OIDC trusted-publisher workflow publishes to npm **`next`** (prerelease-aware; `latest` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)