### PR TITLE
rc.17: fix the broken max-mode commit hook (type:agent → type:command)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.16
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.17
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/decisions-branches/f1-max-mode-hook.md
+++ b/docs/decisions-branches/f1-max-mode-hook.md
@@ -12,3 +12,12 @@
 
 ---
 
+## 2026-06-29 13:16 - rc.17 hardening (dogfood-found): #-comment marker + stdin gate vs if-less Claude Code
+
+**Reasoning:** Dogfooding the rebuilt hook IN-SESSION caught two real issues. (1) The ': marker' line is sh-fragile — a paren/quote/dollar in the marker text breaks sh (a syntax error stalled the hook in my test). Switched to a '# comment' marker (sh -n validated; isOurHook still finds the marker). (2) The hook over-fired: Claude Code only honors the 'if' arg-gate on >=2.1.85; older CC ignores it and fires on EVERY Bash call — a review recipe after every command would make max mode unusable. Added a belt-and-suspenders stdin gate: command hooks receive the event JSON on stdin, so re-check it and exit 0 unless the command is git commit / logmind log; if stdin is empty (a CC that doesn't pipe it), fall through and trust 'if'. Verified a non-commit event (ls) now exits 0, gated out.
+
+**Implications:**
+- Both fixes ship in rc.17. The max-mode hook now fires only on commits regardless of CC version, and the marker can never break sh. This is exactly the value of dogfooding — running max mode on itself surfaced both.
+
+---
+

--- a/docs/decisions-branches/f1-max-mode-hook.md
+++ b/docs/decisions-branches/f1-max-mode-hook.md
@@ -1,0 +1,14 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 13:06 - rc.17: fix the broken max-mode commit hook — type:agent → type:command (+ logmind log trigger + idempotency)
+
+**Reasoning:** Dogfooding revealed clud-bug init --with-hooks NEVER worked for anyone: it scaffolded a Claude Code type:agent PostToolUse hook, but agent hooks get only Read/Grep/Glob (no Bash, not configurable, per the official docs), so the review subagent could never run the clud-bug CLI. Switch to type:command — the command runs review-prompt (which emits a recipe) and surfaces it via asyncRewake/exit-2 so the MAIN agent (Bash + the session subscription) performs the review. async + exit-0-on-failure so a commit is never blocked. Also fire on 'logmind log' (the thrillmade commit primitive — a git-commit pattern never matches its Bash call), and add a HEAD-SHA idempotency marker so a re-fire / amend-no-change doesn't re-review.
+
+**Alternatives considered:** Headless 'claude -p' inside the hook — rejected: nests Claude (recursion/cost/auth), Keep type:agent + pass the diff in the prompt — rejected: agent hooks can't get the diff (no Bash/git)
+
+**Implications:**
+- New rc.17 (lockstep bump: package.json + 3 template strict-mode-gate pins + action.yml). isOurHook matches 'command' OR 'prompt' so clud-bug update replaces the old broken agent hook in place
+- [CEO] publish the v0.7.0-rc.17 tag; then the auto-fire smoke in a real interactive Max session
+
+---
+

--- a/docs/decisions-branches/f1-max-mode-hook.md
+++ b/docs/decisions-branches/f1-max-mode-hook.md
@@ -21,3 +21,9 @@
 
 ---
 
+## 2026-06-29 13:27 - rc.17 review fixes: correct --with-hooks help text + assert asyncRewake in the integration test
+
+**Reasoning:** F1 adversarial review found two real gaps: (1) the --with-hooks --help text still described the old broken type:agent / 'subagent runs' behavior — corrected to type:command that fetches a recipe and surfaces it via asyncRewake (on git commit / logmind log); (2) the integration test asserted type/if/async/command but NOT asyncRewake — the field that actually surfaces the recipe (exit 2); without it the whole mechanism silently no-ops. Added asyncRewake assertions for both triggers. Review otherwise cleared shell-safety, idempotency, the stdin gate, the merge logic, and the version lockstep.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (63 decisions)
+## 2026-06 (64 decisions)
 
-- **2026-06-29** — rc.16: clud-bug init --with-design — install the design kit + enable the lens; Action browser-MCP opt-in *(rc16-design-installer)* — [decisions-branches/rc16-design-installer.md](decisions-branches/rc16-design-installer.md)
-- *... 61 more decisions ...*
+- **2026-06-29** — rc.17: fix the broken max-mode commit hook — type:agent → type:command (+ logmind log trigger + idempotency) *(f1-max-mode-hook)* — [decisions-branches/f1-max-mode-hook.md](decisions-branches/f1-max-mode-hook.md)
+- *... 62 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (65 decisions)
+## 2026-06 (66 decisions)
 
-- **2026-06-29** — rc.17 hardening (dogfood-found): #-comment marker + stdin gate vs if-less Claude Code *(f1-max-mode-hook)* — [decisions-branches/f1-max-mode-hook.md](decisions-branches/f1-max-mode-hook.md)
-- *... 63 more decisions ...*
+- **2026-06-29** — rc.17 review fixes: correct --with-hooks help text + assert asyncRewake in the integration test *(f1-max-mode-hook)* — [decisions-branches/f1-max-mode-hook.md](decisions-branches/f1-max-mode-hook.md)
+- *... 64 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (64 decisions)
+## 2026-06 (65 decisions)
 
-- **2026-06-29** — rc.17: fix the broken max-mode commit hook — type:agent → type:command (+ logmind log trigger + idempotency) *(f1-max-mode-hook)* — [decisions-branches/f1-max-mode-hook.md](decisions-branches/f1-max-mode-hook.md)
-- *... 62 more decisions ...*
+- **2026-06-29** — rc.17 hardening (dogfood-found): #-comment marker + stdin gate vs if-less Claude Code *(f1-max-mode-hook)* — [decisions-branches/f1-max-mode-hook.md](decisions-branches/f1-max-mode-hook.md)
+- *... 63 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.16",
+  "version": "0.7.0-rc.17",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/cli/hooks.ts
+++ b/src/cli/hooks.ts
@@ -41,7 +41,17 @@ export const CLUD_BUG_HOOK_MARKER = 'clud-bug-local-review';
  */
 export function buildCommitReviewCommand(version: string): string {
   return [
-    `: ${CLUD_BUG_HOOK_MARKER} v2 — clud-bug commit review on the session subscription`,
+    // Marker as a `#` comment (NOT a `:` no-op) so its free text can never break
+    // `sh` — a paren / quote / `$` in the marker line would be a syntax error
+    // under `: ...`. The dogfood caught this. `isOurHook` finds the marker here.
+    `# ${CLUD_BUG_HOOK_MARKER} v2 — clud-bug commit review on the session subscription`,
+    // Belt-and-suspenders gate. The `if: Bash(git commit *)` / `Bash(logmind log *)`
+    // field filters at the platform on Claude Code >= 2.1.85; OLDER CC ignores
+    // `if` and would fire this on EVERY Bash call (a review recipe after every
+    // command). Command hooks get the event JSON on stdin — re-check it here. If
+    // stdin is empty (a CC that doesn't pipe it), fall through and trust `if`.
+    `ev=$(cat 2>/dev/null)`,
+    `if [ -n "$ev" ]; then case "$ev" in *'git commit'*|*'logmind log'*) ;; *) exit 0 ;; esac; fi`,
     `sha=$(git rev-parse HEAD 2>/dev/null) || exit 0`,
     `gitdir=$(git rev-parse --git-dir 2>/dev/null) || exit 0`,
     `marker="$gitdir/clud-bug-last-commit-review"`,

--- a/src/cli/hooks.ts
+++ b/src/cli/hooks.ts
@@ -1,50 +1,57 @@
-// Wave 6b — Claude Code `type: agent` commit-review hook scaffolding.
+// Wave 6b (rc.17 fix) — Claude Code `type: command` commit-review hook scaffolding.
 //
 // `clud-bug init --with-hooks` writes a native Claude Code hook that, on every
-// `git commit` the agent makes, spawns a clud-bug review SUBAGENT in the same
-// session — so it runs on the session's subscription (no API key), in the
-// background (the commit never blocks), and surfaces findings back to the agent.
+// `git commit`, runs clud-bug's review recipe ON THIS SESSION'S SUBSCRIPTION
+// (no API key), in the background (the commit never blocks).
 //
-// The model (see the Wave 6b plan): clud-bug supplies the *recipe* (the
-// agent-hook `prompt`); Claude Code runs it as a subagent. This is the dynamic,
-// always-on counterpart to the `/clud-bug-review` slash command.
-//
-// `type: agent` hooks are documented as experimental; the same outcome is
-// reachable via a `type: command` hook + `additionalContext` if the API shifts.
+// WHY `type: command`, NOT `type: agent`: a Claude Code `type: agent` hook
+// spawns a subagent restricted to Read/Grep/Glob — it has NO Bash and the tool
+// set is not configurable (see code.claude.com/docs/en/hooks: "spawn a subagent
+// that can use tools like Read, Grep, and Glob"). The original Wave 6b hook used
+// `type: agent` and told the subagent to run `npx clud-bug review-prompt` — a
+// Bash CLI call an agent hook can never make — so the review NEVER ran for
+// anyone. A `type: command` hook CAN run the CLI: it fetches the engine's recipe
+// and surfaces it to the session via exit-2 (`asyncRewake`), so the MAIN agent —
+// which has Bash, git, gh, and the subscription — performs the review. The hook
+// exits 0 on any failure, so a review that can't run is a quiet no-op and the
+// commit is NEVER blocked.
 
-/** Stable marker embedded in our hook's prompt so re-runs replace it in place. */
+/** Stable marker embedded in our hook so re-runs — and upgrades from the old,
+ * broken `type: agent` hook — replace it in place. */
 export const CLUD_BUG_HOOK_MARKER = 'clud-bug-local-review';
 
 /**
- * Build the `prompt` of the Claude Code `type: agent` commit-review hook,
- * pinned to the clud-bug VERSION that scaffolded it. Pinning matters: a bare
- * `npx clud-bug` resolves to the `latest` dist-tag, which can predate the
- * `review-prompt` verb (e.g. while v0.7 is prerelease on `next`); `@${version}`
- * guarantees the verb exists. `clud-bug update` refreshes the pin in place.
+ * Build the shell `command` of the commit-review hook, pinned to the clud-bug
+ * VERSION that scaffolded it (a bare `npx clud-bug` resolves to the `latest`
+ * dist-tag, which can predate the `review-prompt` verb; `@${version}` guarantees
+ * it). `clud-bug update` refreshes the pin in place.
  *
- * Rather than baking a static recipe (which would drift from the repo's
- * skills/config), it tells the subagent to run `clud-bug review-prompt` — the
- * engine-driven verb that emits a recipe tailored to THIS repo's resolved plan
- * — and follow it. The recipe is generated fresh at commit time, always current.
+ * The command, in order:
+ *   1. Idempotency — skip if this exact HEAD was already surfaced (avoids a
+ *      re-review on an amend-with-no-change or a double-fire). The reviewed SHA
+ *      is recorded under `.git/` (untracked), reusing the "last-reviewed-sha"
+ *      idea the hosted bot uses on PR comments.
+ *   2. Fetch a fresh recipe tailored to THIS repo: `review-prompt --trigger
+ *      commit` (an instruction recipe — `git show HEAD` + the skills + the
+ *      report format — NOT raw data; it is meant to be FOLLOWED by an agent).
+ *   3. Surface it to the session by printing it and `exit 2`, so `asyncRewake`
+ *      shows it to the main agent as a system reminder. The agent then reviews
+ *      the commit on the session subscription.
+ *   4. Any failure or empty output → `exit 0` (quiet; the commit is never blocked).
  */
-export function buildCommitReviewPrompt(version: string): string {
-  return `<!-- ${CLUD_BUG_HOOK_MARKER} v1 -->
-You are clud-bug's local commit review, running as a background subagent on this
-session's own subscription (no extra auth — you have git, gh, and file access).
-
-Step 1 — get your review recipe from clud-bug's engine:
-
-    npx clud-bug@${version} review-prompt --trigger commit
-
-That prints a structured review recipe tailored to THIS repo's skills + config (a
-fast single pass for a commit). If that command isn't available, run the repo's
-installed clud-bug CLI's \`review-prompt --trigger commit\` instead.
-
-Step 2 — follow that recipe exactly: review the commit that was just made against
-the skills it names, and surface any findings back into the session so they can be
-fixed. A clean commit needs only a one-line note.
-
-Keep it tight — this is the commit-time safety net; the deeper review runs at PR time.`;
+export function buildCommitReviewCommand(version: string): string {
+  return [
+    `: ${CLUD_BUG_HOOK_MARKER} v2 — clud-bug commit review on the session subscription`,
+    `sha=$(git rev-parse HEAD 2>/dev/null) || exit 0`,
+    `gitdir=$(git rev-parse --git-dir 2>/dev/null) || exit 0`,
+    `marker="$gitdir/clud-bug-last-commit-review"`,
+    `[ "$(cat "$marker" 2>/dev/null)" = "$sha" ] && exit 0`,
+    `recipe=$(npx clud-bug@${version} review-prompt --trigger commit 2>/dev/null) || exit 0`,
+    `[ -n "$recipe" ] || exit 0`,
+    `printf '%s' "$sha" > "$marker" 2>/dev/null || true`,
+    `printf '%s\\n\\n%s\\n' "clud-bug commit review (max mode — on this session's subscription): a commit was just made. Follow this recipe now — review that commit against the skills it names and surface any findings." "$recipe"`,
+    `exit 2`,
+  ].join('\n');
 }
 
 /** One Claude Code hook entry: a tool matcher plus its hook list. */
@@ -60,28 +67,32 @@ export interface ClaudeSettings {
 }
 
 /**
- * Builds the PostToolUse entry that spawns the commit-review subagent: a native
- * `type: agent` hook that is backgrounded (`async`), surfaces findings
- * (`asyncRewake`), and fires only on `git commit` (`if`).
+ * Builds the PostToolUse entry that runs the commit-review command: a native
+ * `type: command` hook, backgrounded (`async`), surfacing the recipe back to the
+ * session (`asyncRewake` + exit 2), firing only on `git commit` (`if`).
  */
-export function buildLocalReviewHook(recipe: string): HookMatcherEntry {
+export function buildLocalReviewHook(command: string): HookMatcherEntry {
+  const base = { type: 'command', async: true, asyncRewake: true, timeout: 180, command } as const;
   return {
     matcher: 'Bash',
     hooks: [
-      {
-        type: 'agent',
-        if: 'Bash(git commit *)',
-        async: true,
-        asyncRewake: true,
-        timeout: 180,
-        prompt: recipe,
-      },
+      { ...base, if: 'Bash(git commit *)' },
+      // thrillmade repos (and any logmind user) commit via `logmind log`, which
+      // wraps `git commit` inside its own binary — so the Bash tool call is
+      // `logmind log ...`, which `Bash(git commit *)` never matches. Fire on it
+      // too, or max mode never triggers in a logmind repo. The idempotency
+      // SHA-marker means whichever path runs, a commit is reviewed exactly once.
+      { ...base, if: 'Bash(logmind log *)' },
     ],
   };
 }
 
 function isOurHook(h: Record<string, unknown> | undefined): boolean {
-  return typeof h?.['prompt'] === 'string' && (h['prompt'] as string).includes(CLUD_BUG_HOOK_MARKER);
+  // Match our marker in `command` (current `type: command` hook) OR `prompt`
+  // (the old, broken `type: agent` hook) so a re-install / `clud-bug update`
+  // replaces either in place.
+  const field = h?.['command'] ?? h?.['prompt'];
+  return typeof field === 'string' && field.includes(CLUD_BUG_HOOK_MARKER);
 }
 
 function isCludBugReviewEntry(entry: HookMatcherEntry | undefined): boolean {
@@ -90,12 +101,12 @@ function isCludBugReviewEntry(entry: HookMatcherEntry | undefined): boolean {
 
 /**
  * Merges the clud-bug commit-review hook into an existing `.claude/settings.json`
- * object. **Idempotent** (replaces any prior clud-bug entry rather than
- * duplicating) and **non-clobbering** (preserves every other top-level key,
- * every other event, and every other hook). Tolerates a missing/malformed
+ * object. **Idempotent** (replaces any prior clud-bug entry — including the old
+ * `type: agent` one — rather than duplicating) and **non-clobbering** (preserves
+ * every other top-level key, event, and hook). Tolerates a missing/malformed
  * `existing` value.
  */
-export function mergeLocalReviewHook(existing: unknown, recipe: string): ClaudeSettings {
+export function mergeLocalReviewHook(existing: unknown, command: string): ClaudeSettings {
   const base: ClaudeSettings =
     existing && typeof existing === 'object' ? { ...(existing as ClaudeSettings) } : {};
   const hooks: Record<string, HookMatcherEntry[]> = { ...(base.hooks ?? {}) };
@@ -104,7 +115,7 @@ export function mergeLocalReviewHook(existing: unknown, recipe: string): ClaudeS
   // Preserve every non-clud-bug hook — including any the user co-located INSIDE
   // our own matcher entry: drop only the hook(s) carrying our marker, never the
   // whole entry.
-  const ours = buildLocalReviewHook(recipe);
+  const ours = buildLocalReviewHook(command);
   const otherEntries: HookMatcherEntry[] = [];
   const coLocatedUserHooks: Array<Record<string, unknown>> = [];
   for (const entry of priorPost) {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -210,11 +210,11 @@ Options:
                         \`/clud-bug-review\` works in a Claude Code session —
                         reviews the current branch's PR using that session's
                         own tokens (no hosted App, no extra auth).
-  --with-hooks          (init) Also scaffold a native Claude Code \`type: agent\`
+  --with-hooks          (init) Scaffold a native Claude Code \`type: command\`
                         commit-review hook into .claude/settings.json — on every
-                        \`git commit\` the agent makes, a backgrounded clud-bug
-                        review subagent runs on the session's subscription.
-                        Implies --with-local-review. Off by default.
+                        \`git commit\` / \`logmind log\`, it fetches a review recipe and
+                        surfaces it to the agent (on this session's subscription)
+                        via asyncRewake. Implies --with-local-review. Off by default.
   --with-design         (init) Install the design-critic kit (3 \`kind: design\`
                         skills) and enable the off-by-default visual review
                         lens — renders changed UI and critiques it. Off by default.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1289,14 +1289,16 @@ async function runInit(args) {
     log(`    wrote ${rel(cwd, commandPath)}`);
   }
 
-  // v0.7.0 (Wave 6b): optional native commit-review hook. Merges a Claude Code
-  // `type: agent` PostToolUse hook into `.claude/settings.json` (preserving any
-  // existing settings + hooks) that, on every `git commit` the agent makes,
-  // spawns a clud-bug review subagent on the session's subscription, in the
-  // background — the hook's prompt runs `clud-bug review-prompt` and follows it.
+  // v0.7.0 (Wave 6b; rc.17 fix): optional native commit-review hook. Merges a
+  // Claude Code `type: command` PostToolUse hook into `.claude/settings.json`
+  // (preserving any existing settings + hooks) that, on every `git commit`, runs
+  // `clud-bug review-prompt` and surfaces the recipe back to the session so the
+  // agent reviews the commit on the session's subscription, in the background.
+  // (`type: command`, not `type: agent` — agent hooks get no Bash, so they could
+  // never run the CLI; see hooks.ts.)
   if (args.withHooks) {
-    const { mergeLocalReviewHook, buildCommitReviewPrompt } = await import('./hooks.js');
-    const hookPrompt = buildCommitReviewPrompt(await readPkgVersion());
+    const { mergeLocalReviewHook, buildCommitReviewCommand } = await import('./hooks.js');
+    const hookCommand = buildCommitReviewCommand(await readPkgVersion());
     const settingsPath = join(cwd, '.claude', 'settings.json');
     await mkdir(dirname(settingsPath), { recursive: true });
     // Read-then-parse so we can tell "no file yet" (fresh merge) from "file
@@ -1318,7 +1320,7 @@ async function runInit(args) {
       }
     }
     if (proceed) {
-      const merged = mergeLocalReviewHook(existing, hookPrompt);
+      const merged = mergeLocalReviewHook(existing, hookCommand);
       await writeFile(settingsPath, JSON.stringify(merged, null, 2) + '\n');
       log(`    wrote ${rel(cwd, settingsPath)} (commit-review hook)`);
     }

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -5,7 +5,7 @@ import { reviewPrompt } from '../core/prompts.js';
 import { detect, buildDescriptionLine } from '../core/detect.js';
 import { loadBaseline, readManifest, writeManifest, type LoadBaselineOptions } from './skills.js';
 import { applyToRepo as applyAgentDocs } from './agents-md.js';
-import { mergeLocalReviewHook, buildCommitReviewPrompt, CLUD_BUG_HOOK_MARKER } from './hooks.js';
+import { mergeLocalReviewHook, buildCommitReviewCommand, CLUD_BUG_HOOK_MARKER } from './hooks.js';
 
 // Re-render the user's workflow + refresh baseline skills using the
 // templates / baseline shipped with the currently-installed clud-bug.
@@ -172,7 +172,7 @@ export async function runUpdate(opts: RunUpdateOptions): Promise<RunUpdateResult
     const prior = await readSafe(settingsPath);
     if (prior && prior.includes(CLUD_BUG_HOOK_MARKER)) {
       try {
-        const merged = mergeLocalReviewHook(JSON.parse(prior), buildCommitReviewPrompt(ourVersion));
+        const merged = mergeLocalReviewHook(JSON.parse(prior), buildCommitReviewCommand(ourVersion));
         await maybeWrite(settingsPath, JSON.stringify(merged, null, 2) + '\n', changed, unchanged, 'commit-review hook');
       } catch {
         skipped.push({

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.16
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.17
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.16
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.17
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -717,7 +717,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.16
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.17
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1,38 +1,43 @@
-// Wave 6b — `clud-bug init --with-hooks` scaffolds a native Claude Code
-// `type: agent` commit-review hook into .claude/settings.json. These cover the
-// pure hook-builder + the merge-into-existing-settings logic (idempotent,
-// non-clobbering).
+// Wave 6b (rc.17 fix) — `clud-bug init --with-hooks` scaffolds a native Claude
+// Code `type: command` commit-review hook into .claude/settings.json. (It was a
+// broken `type: agent` hook before — agent hooks have no Bash, so they could
+// never run the clud-bug CLI.) These cover the pure hook-builder + the
+// merge-into-existing-settings logic (idempotent, non-clobbering).
 
 import { describe, expect, it } from 'vitest';
 
 import {
   buildLocalReviewHook,
   mergeLocalReviewHook,
-  buildCommitReviewPrompt,
+  buildCommitReviewCommand,
 } from '../src/cli/hooks.js';
 
-// The hook prompt is now version-pinned; build one at a fixed test version so
-// the merge/builder tests below read as before.
-const COMMIT_REVIEW_PROMPT = buildCommitReviewPrompt('0.7.0-rc.13');
+// The hook command is version-pinned; build one at a fixed test version.
+const COMMIT_REVIEW_COMMAND = buildCommitReviewCommand('0.7.0-rc.13');
 
 describe('buildLocalReviewHook', () => {
-  it('is a backgrounded type:agent PostToolUse entry targeting git commit', () => {
-    const entry = buildLocalReviewHook(COMMIT_REVIEW_PROMPT);
+  it('is a backgrounded type:command PostToolUse entry targeting git commit + logmind log', () => {
+    const entry = buildLocalReviewHook(COMMIT_REVIEW_COMMAND);
     expect(entry.matcher).toBe('Bash');
-    const h = entry.hooks[0];
-    expect(h.type).toBe('agent');
-    expect(h.if).toBe('Bash(git commit *)');
-    expect(h.async).toBe(true); // commit never blocks
-    expect(h.asyncRewake).toBe(true); // findings surface back to the agent
-    expect(h.prompt).toBe(COMMIT_REVIEW_PROMPT);
+    expect(entry.hooks).toHaveLength(2); // git commit + logmind log (the thrillmade commit primitive)
+    expect(entry.hooks.map((h) => h.if)).toEqual(
+      expect.arrayContaining(['Bash(git commit *)', 'Bash(logmind log *)']),
+    );
+    for (const h of entry.hooks) {
+      expect(h.type).toBe('command'); // NOT 'agent' — agent hooks can't run the CLI
+      expect(h.async).toBe(true); // commit never blocks
+      expect(h.asyncRewake).toBe(true); // recipe surfaces back to the main agent (exit 2)
+      expect(h.command).toBe(COMMIT_REVIEW_COMMAND);
+      expect(h.prompt).toBeUndefined(); // no agent prompt anymore
+    }
   });
 });
 
 describe('mergeLocalReviewHook', () => {
   it('adds the hook to empty / undefined settings', () => {
-    const s = mergeLocalReviewHook(undefined, COMMIT_REVIEW_PROMPT);
+    const s = mergeLocalReviewHook(undefined, COMMIT_REVIEW_COMMAND);
     expect(s.hooks.PostToolUse).toHaveLength(1);
-    expect(s.hooks.PostToolUse[0].hooks[0].type).toBe('agent');
+    expect(s.hooks.PostToolUse[0].hooks[0].type).toBe('command');
   });
 
   it('preserves unrelated settings and other hooks', () => {
@@ -43,7 +48,7 @@ describe('mergeLocalReviewHook', () => {
         PostToolUse: [{ matcher: 'Edit', hooks: [{ type: 'command', command: './fmt.sh' }] }],
       },
     };
-    const s = mergeLocalReviewHook(existing, COMMIT_REVIEW_PROMPT);
+    const s = mergeLocalReviewHook(existing, COMMIT_REVIEW_COMMAND);
     expect(s.model).toBe('opus'); // unrelated top-level key preserved
     expect(s.hooks.PreToolUse).toHaveLength(1); // other event preserved
     expect(s.hooks.PostToolUse).toHaveLength(2); // the user's Edit hook + ours
@@ -51,47 +56,70 @@ describe('mergeLocalReviewHook', () => {
   });
 
   it('is idempotent — re-running replaces ours, never duplicates', () => {
-    const once = mergeLocalReviewHook(undefined, COMMIT_REVIEW_PROMPT);
-    const twice = mergeLocalReviewHook(once, COMMIT_REVIEW_PROMPT);
+    const once = mergeLocalReviewHook(undefined, COMMIT_REVIEW_COMMAND);
+    const twice = mergeLocalReviewHook(once, COMMIT_REVIEW_COMMAND);
     expect(twice.hooks.PostToolUse).toHaveLength(1);
   });
 
+  it('replaces the OLD broken type:agent hook in place (upgrade path)', () => {
+    // Simulate a settings.json scaffolded by the pre-rc.17 broken version.
+    const old = {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'Bash',
+            hooks: [{ type: 'agent', if: 'Bash(git commit *)', prompt: '<!-- clud-bug-local-review v1 -->\nrun review-prompt' }],
+          },
+        ],
+      },
+    };
+    const s = mergeLocalReviewHook(old, COMMIT_REVIEW_COMMAND);
+    expect(s.hooks.PostToolUse).toHaveLength(1);
+    const h = s.hooks.PostToolUse[0].hooks[0];
+    expect(h.type).toBe('command'); // upgraded
+    expect(h.prompt).toBeUndefined();
+  });
+
   it('preserves a user hook co-located INSIDE our entry across a re-merge', () => {
-    const v1 = mergeLocalReviewHook(undefined, COMMIT_REVIEW_PROMPT);
+    const v1 = mergeLocalReviewHook(undefined, COMMIT_REVIEW_COMMAND);
     // user hand-appends their own hook into OUR Bash matcher entry
     v1.hooks.PostToolUse[0].hooks.push({ type: 'command', command: './notify.sh' });
-    const v2 = mergeLocalReviewHook(v1, COMMIT_REVIEW_PROMPT);
+    const v2 = mergeLocalReviewHook(v1, COMMIT_REVIEW_COMMAND);
     const entry = v2.hooks.PostToolUse.find((e) =>
-      e.hooks.some((h) => typeof h.prompt === 'string' && h.prompt.includes('clud-bug-local-review')),
+      e.hooks.some((h) => typeof h.command === 'string' && h.command.includes('clud-bug-local-review')),
     );
-    // the user's co-located hook survives, and ours is not duplicated
+    // the user's co-located hook survives, and ours (2 triggers) is not duplicated
     expect(entry.hooks.some((h) => h.command === './notify.sh')).toBe(true);
     expect(
       entry.hooks.filter(
-        (h) => typeof h.prompt === 'string' && h.prompt.includes('clud-bug-local-review'),
+        (h) => typeof h.command === 'string' && h.command.includes('clud-bug-local-review'),
       ),
-    ).toHaveLength(1);
+    ).toHaveLength(2);
   });
 
-  it('refreshes our hook in place when the recipe changes', () => {
-    const v1 = mergeLocalReviewHook(undefined, COMMIT_REVIEW_PROMPT);
-    const v2recipe = COMMIT_REVIEW_PROMPT + '\n<!-- bumped -->';
-    const v2 = mergeLocalReviewHook(v1, v2recipe);
+  it('refreshes our hook in place when the command changes', () => {
+    const v1 = mergeLocalReviewHook(undefined, COMMIT_REVIEW_COMMAND);
+    const v2command = COMMIT_REVIEW_COMMAND + '\n# bumped';
+    const v2 = mergeLocalReviewHook(v1, v2command);
     expect(v2.hooks.PostToolUse).toHaveLength(1);
-    expect(v2.hooks.PostToolUse[0].hooks[0].prompt).toBe(v2recipe);
+    expect(v2.hooks.PostToolUse[0].hooks[0].command).toBe(v2command);
   });
 
   it('tolerates a non-object existing value', () => {
-    const s = mergeLocalReviewHook('garbage', COMMIT_REVIEW_PROMPT);
+    const s = mergeLocalReviewHook('garbage', COMMIT_REVIEW_COMMAND);
     expect(s.hooks.PostToolUse).toHaveLength(1);
   });
 });
 
-describe('buildCommitReviewPrompt', () => {
-  it('carries the marker, pins the clud-bug version, and delegates to review-prompt on the subscription', () => {
-    expect(COMMIT_REVIEW_PROMPT).toMatch(/clud-bug-local-review/);
+describe('buildCommitReviewCommand', () => {
+  it('carries the marker, pins the clud-bug version, and runs review-prompt on the subscription', () => {
+    expect(COMMIT_REVIEW_COMMAND).toMatch(/clud-bug-local-review/);
     // version-pinned so the hook never resolves to a `latest` that predates the verb
-    expect(COMMIT_REVIEW_PROMPT).toMatch(/npx clud-bug@0\.7\.0-rc\.13 review-prompt --trigger commit/);
-    expect(COMMIT_REVIEW_PROMPT).toMatch(/subscription/i);
+    expect(COMMIT_REVIEW_COMMAND).toMatch(/npx clud-bug@0\.7\.0-rc\.13 review-prompt --trigger commit/);
+    expect(COMMIT_REVIEW_COMMAND).toMatch(/subscription/i);
+    // idempotency: skips re-surfacing the same HEAD; never blocks the commit
+    expect(COMMIT_REVIEW_COMMAND).toMatch(/git rev-parse HEAD/);
+    expect(COMMIT_REVIEW_COMMAND).toMatch(/exit 0/); // quiet degrade
+    expect(COMMIT_REVIEW_COMMAND).toMatch(/exit 2/); // surface via asyncRewake
   });
 });

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -121,5 +121,8 @@ describe('buildCommitReviewCommand', () => {
     expect(COMMIT_REVIEW_COMMAND).toMatch(/git rev-parse HEAD/);
     expect(COMMIT_REVIEW_COMMAND).toMatch(/exit 0/); // quiet degrade
     expect(COMMIT_REVIEW_COMMAND).toMatch(/exit 2/); // surface via asyncRewake
+    // belt-and-suspenders gate (in case CC ignores the `if` field)
+    expect(COMMIT_REVIEW_COMMAND).toMatch(/cat 2>\/dev\/null/);
+    expect(COMMIT_REVIEW_COMMAND).toMatch(/git commit.*logmind log/);
   });
 });

--- a/test/init-local-review.test.js
+++ b/test/init-local-review.test.js
@@ -73,11 +73,16 @@ test('init --with-hooks scaffolds the native commit-review hook + the slash comm
   assert.equal(entry.hooks[0].type, 'command');
   assert.equal(entry.hooks[0].if, 'Bash(git commit *)');
   assert.equal(entry.hooks[0].async, true);
+  // asyncRewake is what surfaces the recipe (exit 2) back to the agent — without
+  // it the whole mechanism silently no-ops, so assert it end-to-end.
+  assert.equal(entry.hooks[0].asyncRewake, true);
   assert.match(entry.hooks[0].command, /clud-bug-local-review/);
   assert.match(entry.hooks[0].command, /review-prompt --trigger commit/);
   // also fires on `logmind log` — the thrillmade commit primitive
   assert.equal(entry.hooks[1].if, 'Bash(logmind log *)');
   assert.equal(entry.hooks[1].type, 'command');
+  assert.equal(entry.hooks[1].async, true);
+  assert.equal(entry.hooks[1].asyncRewake, true);
 });
 
 test('init --with-hooks does NOT clobber a pre-existing malformed settings.json', async () => {

--- a/test/init-local-review.test.js
+++ b/test/init-local-review.test.js
@@ -66,15 +66,18 @@ test('init --with-hooks scaffolds the native commit-review hook + the slash comm
   assert.equal(r.status, 0, r.stderr);
   // --with-hooks implies --with-local-review, so the slash command is there too
   await access(join(dir, '.claude', 'commands', 'clud-bug-review.md'));
-  // the native `type: agent` commit-review hook, merged into .claude/settings.json
+  // the native `type: command` commit-review hook, merged into .claude/settings.json
   const settings = JSON.parse(await readFile(join(dir, '.claude', 'settings.json'), 'utf8'));
   const entry = settings.hooks.PostToolUse[0];
   assert.equal(entry.matcher, 'Bash');
-  assert.equal(entry.hooks[0].type, 'agent');
+  assert.equal(entry.hooks[0].type, 'command');
   assert.equal(entry.hooks[0].if, 'Bash(git commit *)');
   assert.equal(entry.hooks[0].async, true);
-  assert.match(entry.hooks[0].prompt, /clud-bug-local-review/);
-  assert.match(entry.hooks[0].prompt, /review-prompt --trigger commit/);
+  assert.match(entry.hooks[0].command, /clud-bug-local-review/);
+  assert.match(entry.hooks[0].command, /review-prompt --trigger commit/);
+  // also fires on `logmind log` — the thrillmade commit primitive
+  assert.equal(entry.hooks[1].if, 'Bash(logmind log *)');
+  assert.equal(entry.hooks[1].type, 'command');
 });
 
 test('init --with-hooks does NOT clobber a pre-existing malformed settings.json', async () => {


### PR DESCRIPTION
## The bug (dogfooding caught it)

`clud-bug init --with-hooks` has **never worked for anyone**. It scaffolds a Claude Code **`type: agent`** PostToolUse hook, but agent hooks get only Read/Grep/Glob — **no Bash, not configurable** (official docs). So the review subagent could never run the `clud-bug` CLI, get the diff, or review. The hook's prompt even claimed *"you have git, gh, and file access"* — false. The review never fired.

## The fix → `type: command`

`command` hooks **can** run the CLI. The new hook:
1. **Idempotency** — skips if this HEAD was already surfaced (a `.git/clud-bug-last-commit-review` SHA marker), so an amend-no-change / re-fire doesn't re-review.
2. Runs `clud-bug review-prompt --trigger commit` → a **recipe** (the `git show HEAD` + skills + report format), and **surfaces it** via `asyncRewake`/exit-2 so the **main agent** — which has Bash, git, gh, and the **session subscription** — performs the review.
3. **`async` + exit-0 on any failure** → the review never blocks the commit; a review that can't run is a quiet no-op (the other half of what bit me).

## Also: fires on `logmind log`

The hook now triggers on **`Bash(git commit *)` AND `Bash(logmind log *)`** — in thrillmade repos the commit primitive is `logmind log` (which wraps `git commit` in its own binary, so a `git commit` pattern never matches). Without this, max mode never fires in our own repos. The SHA marker keeps it exactly-once across both.

## Upgrade path
`isOurHook` matches the marker in `command` **or** `prompt`, so `clud-bug update` / a re-`init` cleanly **replaces the old broken `type: agent` hook** in place.

## Verify
`npm run build && npm test` green (rewritten hook tests + `release-discipline`). Proven standalone: the command surfaces a 49-line recipe on a new commit, idempotent-skips a re-fire, exits 0 on failure. Lockstep bump rc.16→rc.17.

## [CEO] after merge
Publish the **`v0.7.0-rc.17`** tag → npm `next`. Then the live auto-fire smoke in a real interactive Max session (`init --with-hooks`, commit, watch the recipe surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)