### PR TITLE
rc.18: init --local-only (max mode, no API-key Action)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.17
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.18
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/decisions-branches/rc18-local-only.md
+++ b/docs/decisions-branches/rc18-local-only.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 14:02 - rc.18: clud-bug init --local-only — max mode without the GitHub Action (no API key)
+
+**Reasoning:** Prepping the F4 max-mode rollout caught that a plain 'clud-bug init' always writes the self-hosted GitHub Action workflows (clud-bug-review/audit.yml), which run claude-code-action with ANTHROPIC_API_KEY — per-token cost + double-review with the hosted App. For 'max mode everywhere' across our repos we want ONLY the local subscription path. New --local-only flag installs the slash command + the commit hook (implies --with-local-review + --with-hooks) but SKIPS all 3 Action workflows; the closing instructions + the --commit add-list drop the API-key + workflow references. Also a clean product command: 'clud-bug init --local-only' = clud-bug on your Claude Max subscription, no key, no bill.
+
+**Alternatives considered:** Run plain init then rm the workflows — rejected: fragile, could delete legit workflows. A flag is the correct reusable primitive
+
+**Implications:**
+- New rc.18 (lockstep bump). [CEO] publish v0.7.0-rc.18 → then the F4 rollout runs 'npx clud-bug@rc.18 init --local-only' across the 8 Action-free repos
+
+---
+

--- a/docs/decisions-branches/rc18-local-only.md
+++ b/docs/decisions-branches/rc18-local-only.md
@@ -11,3 +11,9 @@
 
 ---
 
+## 2026-06-29 14:08 - rc.18 review fix: gate the post-init Action/branch-protection log lines under --local-only
+
+**Reasoning:** The rc.18 review found three post-init log lines (Actions tab → Audit, Self-update cron, 'add clud-bug-review to branch protection') firing unconditionally — contradicting --local-only's 'no GitHub Action' message and sending users to look for workflows that aren't there. Gated them behind !args.localOnly; under --local-only print a max-mode-accurate note instead (strict-mode/branch-protection apply to the Action path; max mode is advisory, findings surface in-session). Verified the 3 phrases are gone and the local-only lines present. Review otherwise confirmed clean (ordering, add-list, --with-design composition, tests, version lockstep).
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (67 decisions)
+## 2026-06 (68 decisions)
 
-- **2026-06-29** — rc.18: clud-bug init --local-only — max mode without the GitHub Action (no API key) *(rc18-local-only)* — [decisions-branches/rc18-local-only.md](decisions-branches/rc18-local-only.md)
-- *... 65 more decisions ...*
+- **2026-06-29** — rc.18 review fix: gate the post-init Action/branch-protection log lines under --local-only *(rc18-local-only)* — [decisions-branches/rc18-local-only.md](decisions-branches/rc18-local-only.md)
+- *... 66 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (66 decisions)
+## 2026-06 (67 decisions)
 
-- **2026-06-29** — rc.17 review fixes: correct --with-hooks help text + assert asyncRewake in the integration test *(f1-max-mode-hook)* — [decisions-branches/f1-max-mode-hook.md](decisions-branches/f1-max-mode-hook.md)
-- *... 64 more decisions ...*
+- **2026-06-29** — rc.18: clud-bug init --local-only — max mode without the GitHub Action (no API key) *(rc18-local-only)* — [decisions-branches/rc18-local-only.md](decisions-branches/rc18-local-only.md)
+- *... 65 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.17",
+  "version": "0.7.0-rc.18",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1455,11 +1455,19 @@ async function runInit(args) {
   }
   log('');
   log('Drop your own .claude/skills/<name>/SKILL.md files anytime — they get pinned automatically.');
-  log('For a whole-repo walk: Actions tab → Clud Bug 🐛 Audit → Run workflow.');
-  log('Self-update is on (weekly Mondays 12:00 UTC). Pin via "pinVersion" in .claude/skills/.clud-bug.json.');
+  // These reference the GitHub Action workflows, which --local-only does not write.
+  if (!args.localOnly) {
+    log('For a whole-repo walk: Actions tab → Clud Bug 🐛 Audit → Run workflow.');
+    log('Self-update is on (weekly Mondays 12:00 UTC). Pin via "pinVersion" in .claude/skills/.clud-bug.json.');
+  }
   log('');
-  log('Strict mode is ON by default (clud-bug-review fails the check on critical findings).');
-  log('  • Add `clud-bug-review` to your branch protection required checks for full enforcement.');
+  if (args.localOnly) {
+    log('Strict mode + branch-protection enforcement apply to the GitHub Action path; max mode is');
+    log('advisory by design — findings surface in your session for you to act on.');
+  } else {
+    log('Strict mode is ON by default (clud-bug-review fails the check on critical findings).');
+    log('  • Add `clud-bug-review` to your branch protection required checks for full enforcement.');
+  }
   log('  • Opt out by setting "strictMode": false in .claude/skills/.clud-bug.json.');
 
   // v0.6.33 — opt-in unified install (mirror of logmind v0.6.8). When

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -73,6 +73,12 @@ function parseArgs(argv) {
     // (3 `kind: design` skills) and flips the off-by-default `design` block to
     // enabled so the visual review lens runs (local recipe + hosted bot).
     withDesign: false,
+    // rc.18: `clud-bug init --local-only` installs MAX MODE (skills + slash
+    // command + commit hook), but SKIPS the GitHub Action workflows (which run
+    // claude-code-action with ANTHROPIC_API_KEY). For repos that review on a
+    // Claude subscription via the in-session hook, not a billed CI Action.
+    // Implies --with-local-review + --with-hooks.
+    localOnly: false,
     // v0.7.0-rc.4: `clud-bug configure-github` flags.
     // --dry-run prints the diff but skips PATCH; --branch overrides "main".
     dryRun: false,
@@ -102,6 +108,7 @@ function parseArgs(argv) {
     else if (a === '--with-local-review') args.withLocalReview = true;
     else if (a === '--with-hooks') args.withHooks = true;
     else if (a === '--with-design') args.withDesign = true;
+    else if (a === '--local-only') args.localOnly = true;
     else if (a === '--dry-run') args.dryRun = true;
     else if (a === '--branch') args.branch = argv[++i];
     else if (a === '--trigger') args.trigger = argv[++i];
@@ -218,6 +225,10 @@ Options:
   --with-design         (init) Install the design-critic kit (3 \`kind: design\`
                         skills) and enable the off-by-default visual review
                         lens — renders changed UI and critiques it. Off by default.
+  --local-only          (init) MAX MODE: install the slash command + commit hook
+                        (implies --with-local-review + --with-hooks) but SKIP the
+                        GitHub Action workflows. Reviews run in your Claude Code
+                        session on your subscription — no API key, no per-review bill.
   --quiet,-q            Token-frugal mode for agent invocations. Suppresses
                         progress chatter; emits exactly one final
                         \`ok <key-value>\` summary line per command. Errors
@@ -1248,29 +1259,38 @@ async function runInit(args) {
       language: templateLanguage(tmplName),
     }),
   });
-  const workflowPath = join(cwd, '.github', 'workflows', 'clud-bug-review.yml');
-  await mkdir(dirname(workflowPath), { recursive: true });
-  await writeFile(workflowPath, workflow);
-  log(`    wrote ${rel(cwd, workflowPath)}`);
+  // --local-only (max mode): SKIP the GitHub Action workflows entirely. The
+  // review + audit workflows run `claude-code-action` with ANTHROPIC_API_KEY
+  // (per-token cost); max mode reviews on the session's own subscription, so a
+  // local-only install must never add a token-billing Action. (self-update is
+  // benign but skipped too — local-only means no clud-bug CI workflows at all.)
+  if (args.localOnly) {
+    log('    skipped GitHub Action workflows (--local-only: max mode runs on the session subscription, no API key)');
+  } else {
+    const workflowPath = join(cwd, '.github', 'workflows', 'clud-bug-review.yml');
+    await mkdir(dirname(workflowPath), { recursive: true });
+    await writeFile(workflowPath, workflow);
+    log(`    wrote ${rel(cwd, workflowPath)}`);
 
-  // Install the audit workflow alongside the per-PR review one.
-  // Manual-trigger by default; users opt into the cron by uncommenting.
-  // Routed through renderFile so {{CCA_VERSION}} substitution pins
-  // claude-code-action consistently with the review workflow.
-  const auditTmpl = await renderFile(join(TEMPLATES, 'audit.yml.tmpl'), {});
-  const auditPath = join(cwd, '.github', 'workflows', 'clud-bug-audit.yml');
-  await writeFile(auditPath, auditTmpl);
-  log(`    wrote ${rel(cwd, auditPath)}`);
+    // Install the audit workflow alongside the per-PR review one.
+    // Manual-trigger by default; users opt into the cron by uncommenting.
+    // Routed through renderFile so {{CCA_VERSION}} substitution pins
+    // claude-code-action consistently with the review workflow.
+    const auditTmpl = await renderFile(join(TEMPLATES, 'audit.yml.tmpl'), {});
+    const auditPath = join(cwd, '.github', 'workflows', 'clud-bug-audit.yml');
+    await writeFile(auditPath, auditTmpl);
+    log(`    wrote ${rel(cwd, auditPath)}`);
 
-  // Install the self-update workflow. Cron weekly Mondays 12:00 UTC; opens
-  // a PR if a newer clud-bug version is published. Disable by deleting the
-  // file or pinning via .claude/skills/.clud-bug.json.
-  // Routed through renderFile for parity (no CCA ref today but future
-  // tokens should propagate uniformly).
-  const selfUpdateTmpl = await renderFile(join(TEMPLATES, 'self-update.yml.tmpl'), {});
-  const selfUpdatePath = join(cwd, '.github', 'workflows', 'clud-bug-self-update.yml');
-  await writeFile(selfUpdatePath, selfUpdateTmpl);
-  log(`    wrote ${rel(cwd, selfUpdatePath)}`);
+    // Install the self-update workflow. Cron weekly Mondays 12:00 UTC; opens
+    // a PR if a newer clud-bug version is published. Disable by deleting the
+    // file or pinning via .claude/skills/.clud-bug.json.
+    // Routed through renderFile for parity (no CCA ref today but future
+    // tokens should propagate uniformly).
+    const selfUpdateTmpl = await renderFile(join(TEMPLATES, 'self-update.yml.tmpl'), {});
+    const selfUpdatePath = join(cwd, '.github', 'workflows', 'clud-bug-self-update.yml');
+    await writeFile(selfUpdatePath, selfUpdateTmpl);
+    log(`    wrote ${rel(cwd, selfUpdatePath)}`);
+  }
 
   // v0.7.0 (Wave 6b): optional local-review slash command. Scaffolds
   // `.claude/commands/clud-bug-review.md` so `/clud-bug-review` works inside a
@@ -1280,6 +1300,12 @@ async function runInit(args) {
   // `--with-hooks` implies `--with-local-review` — the auto hook and the manual
   // `/clud-bug-review` command are complementary (the hook auto-runs the engine
   // recipe on each commit; the command runs it on demand against the PR).
+  // --local-only IS the max-mode install: the slash command + the commit hook,
+  // minus the GitHub Action workflows (gated above).
+  if (args.localOnly) {
+    args.withLocalReview = true;
+    args.withHooks = true;
+  }
   if (args.withHooks) args.withLocalReview = true;
   if (args.withLocalReview) {
     const commandPath = join(cwd, '.claude', 'commands', 'clud-bug-review.md');
@@ -1384,9 +1410,14 @@ async function runInit(args) {
     log('  committing...');
     const toAdd = [
       '.claude',
-      '.github/workflows/clud-bug-review.yml',
-      '.github/workflows/clud-bug-audit.yml',
-      '.github/workflows/clud-bug-self-update.yml',
+      // No GitHub Action workflows under --local-only (none were written).
+      ...(args.localOnly
+        ? []
+        : [
+            '.github/workflows/clud-bug-review.yml',
+            '.github/workflows/clud-bug-audit.yml',
+            '.github/workflows/clud-bug-self-update.yml',
+          ]),
       ...agentDocs.created,
       ...agentDocs.touched,
     ];
@@ -1403,13 +1434,24 @@ async function runInit(args) {
 
   log('');
   log('Field kit assembled. Next:');
-  log('  1. Set ANTHROPIC_API_KEY in your repo secrets:');
-  log('     Settings → Secrets and variables → Actions → New repository secret');
-  if (!args.commit) {
-    log('  2. git add .claude .github/workflows/clud-bug-*.yml && git commit && git push');
-    log('  3. Open a PR — the naturalist arrives within ~2 minutes.');
+  if (args.localOnly) {
+    log('  Max mode — reviews run inside your Claude Code session on your own');
+    log('  subscription. No API key, no GitHub Action, no per-review bill. On every');
+    log('  commit the hook surfaces a review recipe; or run /clud-bug-review on demand.');
+    if (!args.commit) {
+      log('  → git add .claude && git commit && git push');
+    } else {
+      log('  → git push.');
+    }
   } else {
-    log('  2. git push, then open a PR — the naturalist arrives within ~2 minutes.');
+    log('  1. Set ANTHROPIC_API_KEY in your repo secrets:');
+    log('     Settings → Secrets and variables → Actions → New repository secret');
+    if (!args.commit) {
+      log('  2. git add .claude .github/workflows/clud-bug-*.yml && git commit && git push');
+      log('  3. Open a PR — the naturalist arrives within ~2 minutes.');
+    } else {
+      log('  2. git push, then open a PR — the naturalist arrives within ~2 minutes.');
+    }
   }
   log('');
   log('Drop your own .claude/skills/<name>/SKILL.md files anytime — they get pinned automatically.');

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.17
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.18
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.17
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.18
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -717,7 +717,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.17
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.18
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/init-local-review.test.js
+++ b/test/init-local-review.test.js
@@ -98,3 +98,24 @@ test('init --with-hooks does NOT clobber a pre-existing malformed settings.json'
   const after = await readFile(settingsPath, 'utf8');
   assert.equal(after, malformed, 'malformed settings.json must not be clobbered');
 });
+
+test('init --local-only installs max mode (slash command + hook) but NO Action workflows', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-localonly-'));
+  await mkdir(join(dir, '.git'), { recursive: true });
+  const r = runInit(dir, ['--local-only']);
+  assert.equal(r.status, 0, r.stderr);
+  // max mode present: slash command + the type:command hook
+  await access(join(dir, '.claude', 'commands', 'clud-bug-review.md'));
+  const settings = JSON.parse(await readFile(join(dir, '.claude', 'settings.json'), 'utf8'));
+  assert.equal(settings.hooks.PostToolUse[0].hooks[0].type, 'command');
+  // NO GitHub Action workflows (those run claude-code-action with ANTHROPIC_API_KEY)
+  for (const wf of ['clud-bug-review.yml', 'clud-bug-audit.yml', 'clud-bug-self-update.yml']) {
+    let exists = true;
+    try {
+      await access(join(dir, '.github', 'workflows', wf));
+    } catch {
+      exists = false;
+    }
+    assert.equal(exists, false, `${wf} must NOT be written under --local-only`);
+  }
+});


### PR DESCRIPTION
Adds `clud-bug init --local-only`: installs **max mode** (slash command + the rc.17 commit hook) but **skips the GitHub Action workflows** that run `claude-code-action` with `ANTHROPIC_API_KEY`. The F4 rollout primitive — and a clean product command (clud-bug on your Claude subscription, no key, no bill). Implies `--with-local-review` + `--with-hooks`; the `--commit` add-list + closing instructions drop the API-key/workflow references. e2e-verified (slash + hook present, 0 workflows); new test; lockstep bump rc.17→rc.18. **[CEO]** publish `v0.7.0-rc.18` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)