### PR TITLE
max mode: init --local-only (slash command + commit hook, no Action)

### DIFF
--- a/.claude/commands/clud-bug-review.md
+++ b/.claude/commands/clud-bug-review.md
@@ -1,0 +1,115 @@
+---
+description: Review the current branch's open PR locally, in this Claude Code session
+argument-hint: "[pr-number]"
+---
+
+<!-- clud-bug-local-version: v1 -->
+
+You are running **clud-bug** as a local code review — inside this Claude Code
+session, using this session's own model tokens (Max or API, whatever you have).
+No hosted App, no extra auth: you already have `gh`, `git`, and file access.
+
+## 1. Find the PR
+
+PR number: `$ARGUMENTS`
+
+If `$ARGUMENTS` is empty, detect the current branch's open PR:
+
+```bash
+gh pr list --head "$(git branch --show-current)" --state open --json number --jq '.[0].number'
+```
+
+If there is no open PR, stop and tell the user to open one (or pass a PR number).
+
+## 2. Load the review skills
+
+Read the manifest and every referenced skill body from the checkout:
+
+- `.claude/skills/.clud-bug.json` — which skills are installed, plus `strictMode`.
+- For each installed skill, `.claude/skills/<name>/SKILL.md` — the discipline to apply.
+
+Load skills **before** the diff. At minimum the baseline set applies:
+**critical-issues-only** (flag only correctness / security / performance — skip
+nits), **evidence-based-review** (quote the exact line you criticize — no
+hand-waving), **respect-existing-conventions** (don't fight the codebase's
+established patterns).
+
+## 3. Fetch the diff
+
+```bash
+gh pr diff <PR_NUMBER>
+```
+
+## 4. Review
+
+Review the diff against every loaded skill. For each finding record: `file`,
+`line`, `severity` (`critical` | `minor` | `preexisting`), the `skill` that
+motivated it, and a one-line `summary`. Apply the skills strictly — especially
+critical-issues-only (no nits) and evidence-based-review (quote the code).
+
+## 5. Render the review comment
+
+Build the body in clud-bug's standard shape (omit any empty findings section):
+
+```
+## 🐛 Clud Bug review — <clean | critical findings>
+
+**This round:** N critical · N minor · N resolved from prior · N still open
+
+Found: N 🔴 / N 🟡 / N 🟣
+
+### Per-skill scan
+- [<skill>]: <one line on what it scanned + found>
+
+### Critical findings
+🔴 [<skill>]: <summary> (<file>:<line>).
+
+### Minor findings
+🟡 [<skill>]: <summary> (<file>:<line>).
+
+### Pre-existing findings
+🟣 [<skill>]: <summary> (<file>:<line>).
+
+Skills referenced: [<skill>, <skill>]
+
+<!-- written-by: @<your-gh-login> (clud-bug local-mode) -->
+<!-- review-sha: <HEAD_SHA> -->
+```
+
+Get your gh login with `gh api user --jq .login` and the head sha with
+`git rev-parse HEAD`. The `written-by` marker **MUST** end with
+`(clud-bug local-mode)` so the bot's auto-resolve never mistakes this for a
+`clud-bug[bot]` comment.
+
+## 6. Post (or update) the comment
+
+Look for an existing local-mode comment and edit it in place (one rolling review
+comment), otherwise post a fresh one. Use the **REST** issues-comments endpoint
+for the lookup — its `.id` is the **integer** comment id the PATCH endpoint needs.
+(Do NOT use `gh pr view --json comments`; that returns GraphQL node IDs, which
+404 on the REST PATCH and cause duplicate comments.) `gh` fills `{owner}/{repo}`.
+
+```bash
+# existing local-mode comment id (integer), if any:
+EXISTING_ID=$(gh api --paginate "repos/{owner}/{repo}/issues/<PR_NUMBER>/comments" \
+  --jq '[.[] | select(.body | test("written-by: @.* \\(clud-bug local-mode\\)"))] | first | .id // empty')
+```
+
+- `$EXISTING_ID` empty → `gh pr comment <PR_NUMBER> --body-file <body.md>`
+- `$EXISTING_ID` set → `gh api "repos/{owner}/{repo}/issues/comments/$EXISTING_ID" -X PATCH -F body=@<body.md>`
+
+## 7. Summarize
+
+Print one line:
+`clud-bug local-review: N critical · N minor · N preexisting — <PASS | FAIL (strictMode) | advisory>`
+
+If `.clud-bug.json` has `strictMode: true` and there are critical findings, say
+**FAIL** and tell the user to fix them before merging.
+
+---
+
+_Optional: if the `clud-bug-mcp` MCP server is connected, you may use its
+structured tools (`load_skills_from_pr_base`, `fetch_pr_diff`,
+`partition_findings_by_severity`, `emit_review_comment`) in place of the raw
+`gh`/`git` calls above — same flow, with the base-ref skill read and the exact
+review rendering done for you._

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "async": true,
+            "asyncRewake": true,
+            "timeout": 180,
+            "command": "# clud-bug-local-review v2 — clud-bug commit review on the session subscription\nev=$(cat 2>/dev/null)\nif [ -n \"$ev\" ]; then case \"$ev\" in *'git commit'*|*'logmind log'*) ;; *) exit 0 ;; esac; fi\nsha=$(git rev-parse HEAD 2>/dev/null) || exit 0\ngitdir=$(git rev-parse --git-dir 2>/dev/null) || exit 0\nmarker=\"$gitdir/clud-bug-last-commit-review\"\n[ \"$(cat \"$marker\" 2>/dev/null)\" = \"$sha\" ] && exit 0\nrecipe=$(npx clud-bug@0.7.0-rc.18 review-prompt --trigger commit 2>/dev/null) || exit 0\n[ -n \"$recipe\" ] || exit 0\nprintf '%s' \"$sha\" > \"$marker\" 2>/dev/null || true\nprintf '%s\\n\\n%s\\n' \"clud-bug commit review (max mode — on this session's subscription): a commit was just made. Follow this recipe now — review that commit against the skills it names and surface any findings.\" \"$recipe\"\nexit 2",
+            "if": "Bash(git commit *)"
+          },
+          {
+            "type": "command",
+            "async": true,
+            "asyncRewake": true,
+            "timeout": 180,
+            "command": "# clud-bug-local-review v2 — clud-bug commit review on the session subscription\nev=$(cat 2>/dev/null)\nif [ -n \"$ev\" ]; then case \"$ev\" in *'git commit'*|*'logmind log'*) ;; *) exit 0 ;; esac; fi\nsha=$(git rev-parse HEAD 2>/dev/null) || exit 0\ngitdir=$(git rev-parse --git-dir 2>/dev/null) || exit 0\nmarker=\"$gitdir/clud-bug-last-commit-review\"\n[ \"$(cat \"$marker\" 2>/dev/null)\" = \"$sha\" ] && exit 0\nrecipe=$(npx clud-bug@0.7.0-rc.18 review-prompt --trigger commit 2>/dev/null) || exit 0\n[ -n \"$recipe\" ] || exit 0\nprintf '%s' \"$sha\" > \"$marker\" 2>/dev/null || true\nprintf '%s\\n\\n%s\\n' \"clud-bug commit review (max mode — on this session's subscription): a commit was just made. Follow this recipe now — review that commit against the skills it names and surface any findings.\" \"$recipe\"\nexit 2",
+            "if": "Bash(logmind log *)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -30,8 +30,8 @@
       "description": "(baseline)"
     }
   ],
-  "lastUpdate": "2026-06-01T14:17:41.585Z",
-  "lastUpdateVersion": "0.6.32",
+  "lastUpdate": "2026-06-29T18:19:31.973Z",
+  "lastUpdateVersion": "0.7.0-rc.18",
   "strictMode": true,
   "strictSkills": []
 }

--- a/.cursorrules
+++ b/.cursorrules
@@ -3,12 +3,21 @@ See [AGENTS.md](AGENTS.md) for project-specific AI agent instructions, including
 the decision-logging requirement (logmind) and required reading.
 
 <!-- clud-bug-start -->
-<!-- clud-bug-block-version: v3-app -->
+<!-- clud-bug-block-version: v2 -->
 ## clud-bug — Claude PR review
 
-**PR reviews:** automated via the `clud-bug[bot]` GitHub App (installed at the thrillmade org). No per-repo workflow needed. See <https://github.com/thrillmade/clud-bug-app> for the App source and the `.claude/skills/.clud-bug.json` manifest for skill selection.
+This repo uses [clud-bug](https://cludbug.dev) for automatic PR reviews.
+Full collaboration rules — fix-push flow, skill structure, comment format,
+strict-mode mechanics, workflow-edit constraint — live in the bundled
+[`clud-bug-collaboration` skill](.claude/skills/clud-bug-collaboration/SKILL.md).
+Read that skill before pushing fixes addressing prior review threads.
 
-Collaboration rules — fix-push flow, skill structure, comment format — live in the bundled [`clud-bug-collaboration` skill](.claude/skills/clud-bug-collaboration/SKILL.md). Read that skill before pushing fixes addressing prior review threads.
+Strict mode is **on** in this repo (workflow check fails on critical findings). Toggle via `.claude/skills/.clud-bug.json`
+(read from PR **base ref**, so PRs can't disable strict-mode on themselves).
 
-For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1` (or pass `--quiet`) — suppresses progress chatter and emits a single `ok <key-value>` summary line per command.
+For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
+(or pass `--quiet`) — suppresses progress chatter and emits a single
+`ok <key-value>` summary line per command.
+
+_Installed at clud-bug v0.7.0-rc.18._
 <!-- clud-bug-end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,12 +28,21 @@ This project uses [logmind](https://logmind.dev). What counts as a decision, bra
 <!-- Common commands a contributor needs (build, test, lint, run). -->
 
 <!-- clud-bug-start -->
-<!-- clud-bug-block-version: v3-app -->
+<!-- clud-bug-block-version: v2 -->
 ## clud-bug — Claude PR review
 
-**PR reviews:** automated via the `clud-bug[bot]` GitHub App (installed at the thrillmade org). No per-repo workflow needed. See <https://github.com/thrillmade/clud-bug-app> for the App source and the `.claude/skills/.clud-bug.json` manifest for skill selection.
+This repo uses [clud-bug](https://cludbug.dev) for automatic PR reviews.
+Full collaboration rules — fix-push flow, skill structure, comment format,
+strict-mode mechanics, workflow-edit constraint — live in the bundled
+[`clud-bug-collaboration` skill](.claude/skills/clud-bug-collaboration/SKILL.md).
+Read that skill before pushing fixes addressing prior review threads.
 
-Collaboration rules — fix-push flow, skill structure, comment format — live in the bundled [`clud-bug-collaboration` skill](.claude/skills/clud-bug-collaboration/SKILL.md). Read that skill before pushing fixes addressing prior review threads.
+Strict mode is **on** in this repo (workflow check fails on critical findings). Toggle via `.claude/skills/.clud-bug.json`
+(read from PR **base ref**, so PRs can't disable strict-mode on themselves).
 
-For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1` (or pass `--quiet`) — suppresses progress chatter and emits a single `ok <key-value>` summary line per command.
+For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
+(or pass `--quiet`) — suppresses progress chatter and emits a single
+`ok <key-value>` summary line per command.
+
+_Installed at clud-bug v0.7.0-rc.18._
 <!-- clud-bug-end -->

--- a/docs/decisions-branches/f4-maxmode-clud-bug.md
+++ b/docs/decisions-branches/f4-maxmode-clud-bug.md
@@ -1,0 +1,11 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 14:21 - max mode: init --local-only — /clud-bug-review slash command + commit hook (F4 rollout)
+
+**Reasoning:** rc.18 is published; rolling max mode (the local Claude-subscription review path) to the thrillmade repos via 'clud-bug init --local-only' — installs the /clud-bug-review slash command + the type:command commit hook, and writes NO GitHub Action (no ANTHROPIC_API_KEY). Verified: adds .claude/commands + .claude/settings.json, refreshes the manifest stamp + AGENTS.md, writes zero workflow files, drops no skills.
+
+**Implications:**
+- F4 rollout — each repo gets the same install as a reviewed PR. logmind excluded (active shape-up); clud-bug-test keeps its Action fixture
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -9,7 +9,9 @@ clud-bug
 │   ├── workflow-ts.yml
 │   └── workflow.yml
 ├── .claude
-│   └── skills
+│   ├── commands
+│   ├── skills
+│   └── settings.json
 ├── .github
 │   ├── actions
 │   ├── workflows

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (68 decisions)
+## 2026-06 (69 decisions)
 
-- **2026-06-29** — rc.18 review fix: gate the post-init Action/branch-protection log lines under --local-only *(rc18-local-only)* — [decisions-branches/rc18-local-only.md](decisions-branches/rc18-local-only.md)
-- *... 66 more decisions ...*
+- **2026-06-29** — max mode: init --local-only — /clud-bug-review slash command + commit hook (F4 rollout) *(f4-maxmode-clud-bug)* — [decisions-branches/f4-maxmode-clud-bug.md](decisions-branches/f4-maxmode-clud-bug.md)
+- *... 67 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)


### PR DESCRIPTION
F4 rollout (clud-bug). `clud-bug init --local-only` adds the `/clud-bug-review` slash command + the `type: command` commit hook (max mode on the session subscription) — **no GitHub Action, no API key**. Manifest unchanged except the version stamp; no skills dropped; zero workflow files. 🤖 max-mode rollout