### PR TITLE
H1: harden the max-mode review recipe to adversarial quality

### DIFF
--- a/docs/decisions-branches/h1-recipe-depth.md
+++ b/docs/decisions-branches/h1-recipe-depth.md
@@ -1,0 +1,11 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 15:11 - H1: harden the max-mode review recipe to adversarial quality (refute + 3 lenses + ground + tiebreak)
+
+**Reasoning:** The hardening audit found the multi-pass ENGINE is already wired into the local recipe, but the recipe's INSTRUCTIONS weren't adversarial — so clud-bug's own review missed things the ad-hoc adversarial reviewers caught (the goal is to RETIRE those). Rewrote review-prompt.ts recipe text: (1) the cross-check pass is now ADVERSARIAL — Wasp tries to REFUTE pass-1 findings, not just confirm; (2) the baseline skills are framed as three disciplined lenses (correctness/security/regression); (3) verify-and-ground discipline — every finding must quote the exact line + match the line number, else DROP it (default to silence over false positives); (4) the arbiter gets an explicit severity tiebreak. Engine untouched (planReview/multi-pass). New test locks the rigor for single + multi pass.
+
+**Implications:**
+- No version bump — batches into rc.19 with the rest of Phase H. The hardened recipe reaches the repos when rc.19 publishes + hooks re-pin (clud-bug update)
+
+---
+

--- a/docs/decisions-branches/h1-recipe-depth.md
+++ b/docs/decisions-branches/h1-recipe-depth.md
@@ -9,3 +9,12 @@
 
 ---
 
+## 2026-06-29 15:22 - H1 review fixes: skill-agnostic lenses + correct the local arbiter-gate consequence
+
+**Reasoning:** The adversarial review of H1 caught a real conceptual bug: the three lenses were 1:1-mapped to specific skills (Security=evidence-based-review — actually a cross-cutting evidence methodology, not a security-domain skill; Correctness=critical-issues-only — which also covers security+perf), and those names were hardcoded even though a repo may install different skills. Reframed the lenses as skill-AGNOSTIC domain categories, made 'quote the exact line' (evidence) + 'drop what fits no lens' cross-cutting, and said the installed skills (whatever they are) are the authority. Also fixed a contradiction: my tiebreak ('don't suppress') clashed with the pre-existing 'arbiter does not change which findings gate the merge' — that's the HOSTED engine's internal contract (resolveVerdict ignores the marker), but locally the agent IS the arbiter+renderer, so suppressing DOES change the gate. Replaced it with the real local consequence (upheld stays, false-positive dropped). Test asserts lenses reach multi-pass + the local wording.
+
+**Implications:**
+- Part of H1 (no version bump). The adversarial-review->fix loop is exactly the dogfood the plan wants
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (69 decisions)
+## 2026-06 (70 decisions)
 
-- **2026-06-29** — max mode: init --local-only — /clud-bug-review slash command + commit hook (F4 rollout) *(f4-maxmode-clud-bug)* — [decisions-branches/f4-maxmode-clud-bug.md](decisions-branches/f4-maxmode-clud-bug.md)
-- *... 67 more decisions ...*
+- **2026-06-29** — H1: harden the max-mode review recipe to adversarial quality (refute + 3 lenses + ground + tiebreak) *(h1-recipe-depth)* — [decisions-branches/h1-recipe-depth.md](decisions-branches/h1-recipe-depth.md)
+- *... 68 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (70 decisions)
+## 2026-06 (71 decisions)
 
-- **2026-06-29** — H1: harden the max-mode review recipe to adversarial quality (refute + 3 lenses + ground + tiebreak) *(h1-recipe-depth)* — [decisions-branches/h1-recipe-depth.md](decisions-branches/h1-recipe-depth.md)
-- *... 68 more decisions ...*
+- **2026-06-29** — H1 review fixes: skill-agnostic lenses + correct the local arbiter-gate consequence *(h1-recipe-depth)* — [decisions-branches/h1-recipe-depth.md](decisions-branches/h1-recipe-depth.md)
+- *... 69 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/src/cli/review-prompt.ts
+++ b/src/cli/review-prompt.ts
@@ -127,9 +127,10 @@ export function renderReviewRecipe(input: {
           `with a one-line rationale. Skip the arbiter if the passes agree, or disagree only on ` +
           `\`preexisting\` findings. **Tiebreak:** when a dispute is genuinely unresolvable from the ` +
           `diff + the cited skill, severity decides — surface at the higher severity ` +
-          `(\`critical\` > \`minor\` > \`preexisting\`) rather than suppress. The arbiter's verdict sets ` +
-          `each disputed finding's consensus marker (\`2-of-2\` if upheld, \`arbitrated\` if not) and its ` +
-          `rationale — it does not change which findings gate the merge.`
+          `(\`critical\` > \`minor\` > \`preexisting\`) rather than suppress. The arbiter records each ` +
+          `disputed finding's verdict + a one-line rationale and sets its consensus marker (\`2-of-2\` ` +
+          `if upheld, \`arbitrated\` if overturned): an upheld finding stays in the report; one the ` +
+          `arbiter judges a false positive is dropped.`
         : '';
     reviewStep =
       `Dispatch ${maxPasses} reviewer sub-agents — a ${maxPasses}-pass **${mode}** review on this ` +
@@ -187,16 +188,17 @@ ${diffStep}
 Read each skill's discipline from the checkout:
 ${skillsList}
 
-Apply them as three disciplined lenses — every finding must earn its place under one:
-  - **Correctness** (critical-issues-only): real bugs only — wrong logic, broken contracts,
-    unhandled cases, race conditions, performance cliffs. Skip nits and style.
-  - **Security** (evidence-based-review): injection, auth/authz gaps, secret or PII exposure,
-    SSRF, unsafe input — and quote the exact line that proves it.
-  - **Regression** (respect-existing-conventions): does the change break an existing pattern,
-    invariant, or caller? Flag where the diff fights the codebase — don't fight its conventions.
+Apply them through three disciplined lenses — every finding must earn its place under one:
+  - **Correctness**: real bugs — wrong logic, broken contracts, unhandled cases, race
+    conditions, performance cliffs. Skip nits and style.
+  - **Security**: injection, auth/authz gaps, secret or PII exposure, SSRF, unsafe input.
+  - **Regression**: does the change break an existing pattern, invariant, or caller? Flag
+    where the diff fights the codebase — don't fight its conventions.
 
-Run each lens deliberately; a generic "looks fine" is not a review. Findings that don't fit a
-lens are noise — drop them.
+The installed skills above are your authority — apply each skill's specific discipline within
+whichever lens it speaks to (a skill may sharpen more than one). Two rules cut across all three:
+**quote the exact line** every finding flags (evidence), and **drop anything that fits no lens**
+(noise). A generic "looks fine" is not a review.
 
 ## 3. Review
 ${reviewStep}${designStep}

--- a/src/cli/review-prompt.ts
+++ b/src/cli/review-prompt.ts
@@ -29,11 +29,18 @@ export const CLUD_BUG_RECIPE_MARKER = 'clud-bug-local-review';
 
 const MODE_AGGREGATION: Record<ReviewPassMode, string> = {
   'cross-check':
-    "Pass 1 reviews the diff against all the skills; each later pass re-reviews AND checks pass 1's findings (agree / disagree), adding any new ones it finds.",
+    "Pass 1 (broad scan) reviews the diff against all the skills — optimize for recall, surface every " +
+    "candidate. Each later pass is ADVERSARIAL: re-read the diff and try to REFUTE pass 1's findings — " +
+    "for each, ask 'can I prove this is a false positive, already handled elsewhere, or not actually in " +
+    "this diff?' Keep only findings that survive refutation, record an explicit agree/disagree verdict " +
+    "per finding, and add any real issues pass 1 missed. Skepticism is the job — do not just confirm.",
   consensus:
-    'Run all passes independently against all the skills, then keep only findings that two or more passes agree on.',
+    'Run all passes independently against all the skills, each attacking the diff from a different angle. ' +
+    'Then keep only findings two or more passes independently land on; a finding only one pass sees is ' +
+    'dropped (or downgraded to a note). This trades recall for precision.',
   independent:
-    'Run all passes independently against all the skills, then take the union of their findings, each attributed to its pass.',
+    'Run all passes independently against all the skills, each from a distinct lens, then take the union ' +
+    'of their findings (attributed to its pass) — but drop any that a quick adversarial re-read refutes.',
 };
 
 const TRIGGER_INTRO: Record<ReviewTrigger, string> = {
@@ -91,10 +98,12 @@ export function renderReviewRecipe(input: {
   let reviewStep: string;
   if (maxPasses <= 1) {
     reviewStep =
-      'Review the diff against every loaded skill in a single pass. For each REAL issue, ' +
-      'record `file`, `line`, `severity` (`critical` | `minor` | `preexisting`), the `skill` ' +
-      'that motivated it, and a one-line `summary` with the quoted offending line. Finding ' +
-      'nothing is the normal outcome — be precise, not exhaustive.';
+      'Review the diff against the three lenses above in a single pass. VERIFY before you record: ' +
+      'quote the exact offending line from the diff and confirm the `line` number matches that ' +
+      'quote — if you cannot ground a finding in a line you actually see in this diff, DROP it ' +
+      '(default to silence over a false positive). Record `file`, `line`, `severity` (`critical` | ' +
+      '`minor` | `preexisting`), the `skill`, and a one-line `summary`. Finding nothing is the ' +
+      'normal, common outcome — be precise, not exhaustive.';
   } else {
     const passLines = Array.from({ length: maxPasses }, (_, i) => {
       const role = roleForPass(plan.roles, i, 'Reviewer');
@@ -116,14 +125,19 @@ export function renderReviewRecipe(input: {
           `3rd **${arbiter}** arbiter sub-agent (opus-class, read-only tools) that re-examines ONLY ` +
           `the disputed findings against the diff + the cited skill and records the deciding verdict ` +
           `with a one-line rationale. Skip the arbiter if the passes agree, or disagree only on ` +
-          `\`preexisting\` findings. The arbiter's verdict sets each disputed finding's consensus ` +
-          `marker (\`2-of-2\` if upheld, \`arbitrated\` if not) and its rationale — it does not change ` +
-          `which findings gate the merge.`
+          `\`preexisting\` findings. **Tiebreak:** when a dispute is genuinely unresolvable from the ` +
+          `diff + the cited skill, severity decides — surface at the higher severity ` +
+          `(\`critical\` > \`minor\` > \`preexisting\`) rather than suppress. The arbiter's verdict sets ` +
+          `each disputed finding's consensus marker (\`2-of-2\` if upheld, \`arbitrated\` if not) and its ` +
+          `rationale — it does not change which findings gate the merge.`
         : '';
     reviewStep =
       `Dispatch ${maxPasses} reviewer sub-agents — a ${maxPasses}-pass **${mode}** review on this ` +
       `session's subscription (bind each tier to a Claude Code model: a fast model for \`beetle\`, ` +
-      `a strong model for \`wasp\`/\`mantis\`):\n\n${passLines}\n\n${MODE_AGGREGATION[mode]}${escalation}`;
+      `a strong model for \`wasp\`/\`mantis\`). Each pass applies the three lenses above:\n\n${passLines}\n\n` +
+      `${MODE_AGGREGATION[mode]}${escalation}\n\n` +
+      "**Grounding rule (every pass):** a finding only counts if it quotes the exact line from the diff " +
+      "and its `line` number matches that quote — drop anything you cannot ground.";
   }
 
   const surface =
@@ -173,9 +187,16 @@ ${diffStep}
 Read each skill's discipline from the checkout:
 ${skillsList}
 
-Apply them strictly — at minimum **critical-issues-only** (flag only correctness, security,
-or performance bugs — skip nits), **evidence-based-review** (quote the exact line you flag),
-and **respect-existing-conventions** (don't fight the codebase's patterns).
+Apply them as three disciplined lenses — every finding must earn its place under one:
+  - **Correctness** (critical-issues-only): real bugs only — wrong logic, broken contracts,
+    unhandled cases, race conditions, performance cliffs. Skip nits and style.
+  - **Security** (evidence-based-review): injection, auth/authz gaps, secret or PII exposure,
+    SSRF, unsafe input — and quote the exact line that proves it.
+  - **Regression** (respect-existing-conventions): does the change break an existing pattern,
+    invariant, or caller? Flag where the diff fights the codebase — don't fight its conventions.
+
+Run each lens deliberately; a generic "looks fine" is not a review. Findings that don't fit a
+lens are noise — drop them.
 
 ## 3. Review
 ${reviewStep}${designStep}

--- a/test/review-prompt.test.js
+++ b/test/review-prompt.test.js
@@ -83,6 +83,31 @@ describe('renderReviewRecipe', () => {
     expect(consensusRecipe).not.toMatch(/arbiter sub-agent/i);
   });
 
+  it('H1: carries adversarial rigor — three lenses, verify/ground, refute, tiebreak', () => {
+    // single-pass (commit): three explicit lenses + verify-and-ground discipline
+    const single = renderReviewRecipe({
+      plan: planReview({ skills: SKILLS, config: { count: 1, mode: 'cross-check' }, trigger: 'commit' }),
+      trigger: 'commit',
+    });
+    expect(single).toMatch(/three disciplined lenses/i);
+    expect(single).toMatch(/Correctness/);
+    expect(single).toMatch(/Security/);
+    expect(single).toMatch(/Regression/);
+    expect(single).toMatch(/VERIFY before you record/i);
+    expect(single).toMatch(/cannot ground/i);
+
+    // multi-pass cross-check (pr): adversarial refute framing + grounding rule + arbiter tiebreak
+    const multi = renderReviewRecipe({
+      plan: planReview({ skills: SKILLS, config: { count: 2, mode: 'cross-check' }, trigger: 'pr' }),
+      trigger: 'pr',
+    });
+    expect(multi).toMatch(/ADVERSARIAL/);
+    expect(multi).toMatch(/REFUTE/);
+    expect(multi).toMatch(/Grounding rule/i);
+    expect(multi).toMatch(/Tiebreak/);
+    expect(multi).toMatch(/severity decides/i);
+  });
+
   it('renders the design-critic step only when the design lens is passed (gated on)', () => {
     const plan = planReview({ skills: SKILLS, config: MULTIPASS_CONFIG, trigger: 'pr' });
     const design = {

--- a/test/review-prompt.test.js
+++ b/test/review-prompt.test.js
@@ -101,11 +101,19 @@ describe('renderReviewRecipe', () => {
       plan: planReview({ skills: SKILLS, config: { count: 2, mode: 'cross-check' }, trigger: 'pr' }),
       trigger: 'pr',
     });
+    // the three lenses live in the shared §2 segment — assert they reach multi-pass too
+    expect(multi).toMatch(/three disciplined lenses/i);
+    expect(multi).toMatch(/Correctness/);
+    expect(multi).toMatch(/Security/);
+    expect(multi).toMatch(/Regression/);
     expect(multi).toMatch(/ADVERSARIAL/);
     expect(multi).toMatch(/REFUTE/);
     expect(multi).toMatch(/Grounding rule/i);
     expect(multi).toMatch(/Tiebreak/);
     expect(multi).toMatch(/severity decides/i);
+    // the local arbiter consequence is stated, NOT the hosted "doesn't gate" invariant
+    expect(multi).toMatch(/stays in the report/i);
+    expect(multi).not.toMatch(/does not change which findings gate/i);
   });
 
   it('renders the design-critic step only when the design lens is passed (gated on)', () => {


### PR DESCRIPTION
Makes clud-bug's own review (max mode) match a rigorous adversarial review — the path to retiring ad-hoc adversarial passes. **Recipe text only** (engine untouched; multi-pass was already wired). `src/cli/review-prompt.ts`: (1) cross-check pass is now **adversarial** — Wasp tries to **refute** pass-1 findings; (2) baseline skills framed as **three lenses** (correctness/security/regression); (3) **verify-and-ground** — quote the exact line + match the line number or drop the finding; (4) arbiter **severity tiebreak**. New test locks it for single + multi pass; full suite green. No version bump (batches into rc.19). 🤖