### PR TITLE
H4: harden the commit hook (retry + diagnostic skip marker)

### DIFF
--- a/docs/decisions-branches/h4-hook-robustness.md
+++ b/docs/decisions-branches/h4-hook-robustness.md
@@ -9,3 +9,12 @@
 
 ---
 
+## 2026-06-29 15:50 - H4 review fix: clear $recipe on non-zero npx exit so partial/error stdout is never surfaced
+
+**Reasoning:** The adversarial review caught a semantic regression: dropping the original '|| exit 0' meant a non-zero npx that wrote PARTIAL stdout (a mid-run review-prompt crash, or an old npm warning routed to stdout) would leave $recipe non-empty — bypassing both [ -z ] guards, stamping the idempotency marker, and surfacing the partial/error text as a valid recipe (and never retrying). Added '|| recipe=' to BOTH npx attempts so a non-zero exit clears it → treated as empty → retry then skip-marker. Only a clean exit-0 run surfaces. Test asserts both guards present.
+
+**Implications:**
+- Part of H4 (no version bump)
+
+---
+

--- a/docs/decisions-branches/h4-hook-robustness.md
+++ b/docs/decisions-branches/h4-hook-robustness.md
@@ -1,0 +1,11 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 15:45 - H4: harden the commit hook — retry on transient npx failure + a diagnostic skip marker
+
+**Reasoning:** The hardening audit flagged two hook-robustness gaps: (1) a transient npx/network blip made the recipe fetch silently exit 0 — no review, indistinguishable from a clean commit; (2) no way to tell a FAILED review from a CLEAN one. Added one retry (sleep 1 + re-fetch) before giving up, and a .git/clud-bug-review-skipped diagnostic marker written when the fetch ultimately fails, so a silent no-op is detectable. Still never blocks the commit (exit 0). Added a 'sh -n' syntax-validation test — the earlier marker-fragility bug showed shell validity needs a test.
+
+**Implications:**
+- Part of H4 (no version bump; batches into rc.19). The retry adds up to ~1s + a second npx on hard failure, but the hook is async/backgrounded so the commit never waits
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (74 decisions)
+## 2026-06 (75 decisions)
 
-- **2026-06-29** — H4: harden the commit hook — retry on transient npx failure + a diagnostic skip marker *(h4-hook-robustness)* — [decisions-branches/h4-hook-robustness.md](decisions-branches/h4-hook-robustness.md)
-- *... 72 more decisions ...*
+- **2026-06-29** — H4 review fix: clear $recipe on non-zero npx exit so partial/error stdout is never surfaced *(h4-hook-robustness)* — [decisions-branches/h4-hook-robustness.md](decisions-branches/h4-hook-robustness.md)
+- *... 73 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (73 decisions)
+## 2026-06 (74 decisions)
 
-- **2026-06-29** — H2 security fixes: close the fence breakout + guard all passes + harden the base-ref contract *(h2-review-context)* — [decisions-branches/h2-review-context.md](decisions-branches/h2-review-context.md)
-- *... 71 more decisions ...*
+- **2026-06-29** — H4: harden the commit hook — retry on transient npx failure + a diagnostic skip marker *(h4-hook-robustness)* — [decisions-branches/h4-hook-robustness.md](decisions-branches/h4-hook-robustness.md)
+- *... 72 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/src/cli/hooks.ts
+++ b/src/cli/hooks.ts
@@ -58,8 +58,11 @@ export function buildCommitReviewCommand(version: string): string {
     `[ "$(cat "$marker" 2>/dev/null)" = "$sha" ] && exit 0`,
     // H4 — one retry on a transient npx/network blip (a stale lock, a slow
     // registry) before giving up, so a hiccup doesn't silently skip the review.
-    `recipe=$(npx clud-bug@${version} review-prompt --trigger commit 2>/dev/null)`,
-    `if [ -z "$recipe" ]; then sleep 1; recipe=$(npx clud-bug@${version} review-prompt --trigger commit 2>/dev/null); fi`,
+    // `|| recipe=` clears it on a NON-ZERO exit so partial/error stdout from a
+    // mid-run crash (or an old npm warning on stdout) is never mistaken for a
+    // valid recipe — only a clean, exit-0 run surfaces.
+    `recipe=$(npx clud-bug@${version} review-prompt --trigger commit 2>/dev/null) || recipe=`,
+    `if [ -z "$recipe" ]; then sleep 1; recipe=$(npx clud-bug@${version} review-prompt --trigger commit 2>/dev/null) || recipe=; fi`,
     // H4 — when the recipe still can't be fetched, leave a diagnostic marker so a
     // FAILED review is distinguishable from a CLEAN one (a clean review surfaces
     // the recipe + the agent reports clean). Never blocks the commit.

--- a/src/cli/hooks.ts
+++ b/src/cli/hooks.ts
@@ -56,8 +56,14 @@ export function buildCommitReviewCommand(version: string): string {
     `gitdir=$(git rev-parse --git-dir 2>/dev/null) || exit 0`,
     `marker="$gitdir/clud-bug-last-commit-review"`,
     `[ "$(cat "$marker" 2>/dev/null)" = "$sha" ] && exit 0`,
-    `recipe=$(npx clud-bug@${version} review-prompt --trigger commit 2>/dev/null) || exit 0`,
-    `[ -n "$recipe" ] || exit 0`,
+    // H4 — one retry on a transient npx/network blip (a stale lock, a slow
+    // registry) before giving up, so a hiccup doesn't silently skip the review.
+    `recipe=$(npx clud-bug@${version} review-prompt --trigger commit 2>/dev/null)`,
+    `if [ -z "$recipe" ]; then sleep 1; recipe=$(npx clud-bug@${version} review-prompt --trigger commit 2>/dev/null); fi`,
+    // H4 — when the recipe still can't be fetched, leave a diagnostic marker so a
+    // FAILED review is distinguishable from a CLEAN one (a clean review surfaces
+    // the recipe + the agent reports clean). Never blocks the commit.
+    `if [ -z "$recipe" ]; then printf '%s' "$sha" > "$gitdir/clud-bug-review-skipped" 2>/dev/null || true; exit 0; fi`,
     `printf '%s' "$sha" > "$marker" 2>/dev/null || true`,
     `printf '%s\\n\\n%s\\n' "clud-bug commit review (max mode — on this session's subscription): a commit was just made. Follow this recipe now — review that commit against the skills it names and surface any findings." "$recipe"`,
     `exit 2`,

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -132,6 +132,9 @@ describe('buildCommitReviewCommand', () => {
     expect(COMMIT_REVIEW_COMMAND).toMatch(/sleep 1/);
     // exactly two npx attempts (initial + retry)
     expect(COMMIT_REVIEW_COMMAND.match(/npx clud-bug@[^ ]+ review-prompt --trigger commit/g)).toHaveLength(2);
+    // both attempts clear $recipe on a non-zero exit so partial/error stdout is
+    // never surfaced as a valid recipe (regression guard)
+    expect(COMMIT_REVIEW_COMMAND.match(/\|\| recipe=/g)).toHaveLength(2);
     // a failed fetch is recorded distinctly from a clean review
     expect(COMMIT_REVIEW_COMMAND).toMatch(/clud-bug-review-skipped/);
   });

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -5,6 +5,7 @@
 // merge-into-existing-settings logic (idempotent, non-clobbering).
 
 import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
 
 import {
   buildLocalReviewHook,
@@ -124,5 +125,20 @@ describe('buildCommitReviewCommand', () => {
     // belt-and-suspenders gate (in case CC ignores the `if` field)
     expect(COMMIT_REVIEW_COMMAND).toMatch(/cat 2>\/dev\/null/);
     expect(COMMIT_REVIEW_COMMAND).toMatch(/git commit.*logmind log/);
+  });
+
+  it('H4: retries once on a transient failure and leaves a diagnostic marker', () => {
+    // one `sleep 1` retry before giving up on the recipe fetch
+    expect(COMMIT_REVIEW_COMMAND).toMatch(/sleep 1/);
+    // exactly two npx attempts (initial + retry)
+    expect(COMMIT_REVIEW_COMMAND.match(/npx clud-bug@[^ ]+ review-prompt --trigger commit/g)).toHaveLength(2);
+    // a failed fetch is recorded distinctly from a clean review
+    expect(COMMIT_REVIEW_COMMAND).toMatch(/clud-bug-review-skipped/);
+  });
+
+  it('is valid POSIX sh (the retry + markers do not break the script)', () => {
+    const r = spawnSync('sh', ['-n'], { input: COMMIT_REVIEW_COMMAND, encoding: 'utf8' });
+    expect(r.status).toBe(0);
+    expect(r.stderr).toBe('');
   });
 });


### PR DESCRIPTION
Two hook-robustness fixes: **retry once** (sleep 1 + re-fetch) on a transient npx/network blip before giving up, and a **`.git/clud-bug-review-skipped` diagnostic marker** when the fetch ultimately fails — so a failed review is distinguishable from a clean one. Still exit-0 (never blocks the commit). New `sh -n` syntax-validation test. No version bump. 🤖