### PR TITLE
H3: merge-gate parity — post-check-run + local self-attested clud-bug-review check

### DIFF
--- a/docs/decisions-branches/h3-merge-gate.md
+++ b/docs/decisions-branches/h3-merge-gate.md
@@ -11,3 +11,12 @@
 
 ---
 
+## 2026-06-29 16:09 - H3 review fixes: CLI-level false-green guard tests + document the check-run stacking tradeoff
+
+**Reasoning:** The adversarial review confirmed no false-green path + best-effort intact, with two notes: (1) the false-green guards (failed/garbage/critical+no-strict -> neutral) were only unit-tested, not through the full CLI wiring — added 3 post-check-run --dry-run tests so a regression that bypassed normalizeVerdict would be caught; (2) the verb POSTs a fresh check-run each call (no list+update) — gate integrity is zero-risk (GitHub uses the latest conclusion) but it stacks UI entries; documented the latest-wins + cosmetic-stacking tradeoff at the post site.
+
+**Implications:**
+- Part of H3. Idempotency upsert is a possible future refinement; not needed for gate correctness
+
+---
+

--- a/docs/decisions-branches/h3-merge-gate.md
+++ b/docs/decisions-branches/h3-merge-gate.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 16:01 - H3: merge-gate parity — clud-bug post-check-run + the local self-attested clud-bug-review check
+
+**Reasoning:** Branch protection can require a clud-bug-review check; the hosted bot posts it but local/Action didn't, so a max-mode review couldn't gate merge. Added shared core/check-verdict.ts (deriveCheck: clean->success, critical+strict->failure/blocks, critical+!strict->neutral/advisory, failed->neutral) + a 'clud-bug post-check-run' verb that posts the check via gh (best-effort, --dry-run, reads strictMode from .clud-bug.json). The local recipe's new §5 (PR trigger only) tells the in-session agent to post a SELF-ATTESTED check after reviewing, so an agent's self-merge is gated by its own clud-bug review. CTO call: the local/Action check conclusion REFLECTS findings (vs the hosted bot's success-on-run + separate strict-mode request_changes) because in local mode the check IS the gate — labeled self-attested so it's not mistaken for independent CI.
+
+**Alternatives considered:** Mirror the hosted success-always model + a separate request_changes (rejected — local mode posts no formal review, the check must carry the verdict); octokit (rejected — local/Action has gh, not the App token)
+
+**Implications:**
+- H3 local + verb done. Action-path posting (H3b) deferred — no production repo runs the self-hosted Action post-F4, so low-value. spec-v0.6.4 documents the check contract. No version bump (batches into rc.19)
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -60,6 +60,7 @@ clud-bug
 │   ├── agents-md.test.js
 │   ├── audit.test.js
 │   ├── branch-protection.test.js
+│   ├── check-verdict.test.js
 │   ├── cli.test.js
 │   ├── configure-github.test.js
 │   ├── detect.test.js

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (75 decisions)
+## 2026-06 (76 decisions)
 
-- **2026-06-29** — H4 review fix: clear $recipe on non-zero npx exit so partial/error stdout is never surfaced *(h4-hook-robustness)* — [decisions-branches/h4-hook-robustness.md](decisions-branches/h4-hook-robustness.md)
-- *... 73 more decisions ...*
+- **2026-06-29** — H3: merge-gate parity — clud-bug post-check-run + the local self-attested clud-bug-review check *(h3-merge-gate)* — [decisions-branches/h3-merge-gate.md](decisions-branches/h3-merge-gate.md)
+- *... 74 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (76 decisions)
+## 2026-06 (77 decisions)
 
-- **2026-06-29** — H3: merge-gate parity — clud-bug post-check-run + the local self-attested clud-bug-review check *(h3-merge-gate)* — [decisions-branches/h3-merge-gate.md](decisions-branches/h3-merge-gate.md)
-- *... 74 more decisions ...*
+- **2026-06-29** — H3 review fixes: CLI-level false-green guard tests + document the check-run stacking tradeoff *(h3-merge-gate)* — [decisions-branches/h3-merge-gate.md](decisions-branches/h3-merge-gate.md)
+- *... 75 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -32,6 +32,7 @@ import { computeAuditFileSet } from './audit.js';
 import { renderAuditHeader } from '../core/audit.js';
 import { runUpdate } from './update.js';
 import { runReviewPrompt } from './review-prompt.js';
+import { runPostCheckRun } from './post-check-run.js';
 import { getPendingWorkflowEdits, makeBranchName, git as gitCmd } from './edit-workflow.js';
 import { applyToRepo as applyAgentDocs } from './agents-md.js';
 import { detectRepo, detectDefaultBranch, getProtectionState, enableConversationResolution } from './branch-protection.js';
@@ -113,6 +114,15 @@ function parseArgs(argv) {
     else if (a === '--branch') args.branch = argv[++i];
     else if (a === '--trigger') args.trigger = argv[++i];
     else if (a === '--diff-size') args.diffSizeBytes = Number(argv[++i]);
+    // H3: `clud-bug post-check-run` flags.
+    else if (a === '--sha') args.sha = argv[++i];
+    else if (a === '--verdict') args.verdict = argv[++i];
+    else if (a === '--critical-count') args.criticalCount = Number(argv[++i]);
+    else if (a === '--source') args.source = argv[++i];
+    else if (a === '--strict') args.strict = true;
+    else if (a === '--no-strict') args.strict = false;
+    else if (a === '--owner') args.owner = argv[++i];
+    else if (a === '--details-url') args.detailsUrl = argv[++i];
     else args._.push(a);
   }
   return args;
@@ -208,6 +218,11 @@ Commands:
                         the session's own subscription. Plans via the shared
                         engine: --trigger commit (default) → a fast single pass;
                         push/pr → the full multi-pass plan. Prints to stdout.
+  post-check-run        Post the \`clud-bug-review\` GitHub check so branch
+                        protection can gate the merge (H3). --verdict
+                        clean|critical|failed --sha <sha> [--critical-count N]
+                        [--source local|ci] [--strict|--no-strict] [--dry-run].
+                        clean→success, critical+strict→failure, else neutral.
 
 Options:
   --offline             Skip skills.sh; pin only the bundled baseline specimens.
@@ -286,6 +301,7 @@ async function main() {
     case 'post-inline-threads': return runPostInlineThreads(args);
     case 'resolve-threads': return runResolveThreads(args);
     case 'review-prompt': return runReviewPrompt(args);
+    case 'post-check-run': return runPostCheckRun(args);
     default:
       process.stderr.write(`Unknown command: ${cmd || '(none)'}\n\n${HELP}`);
       process.exit(2);

--- a/src/cli/post-check-run.ts
+++ b/src/cli/post-check-run.ts
@@ -1,0 +1,110 @@
+// `clud-bug post-check-run` (H3) — post the `clud-bug-review` GitHub check-run
+// from the local recipe or the self-hosted Action, so a clean review can GATE
+// merge on those surfaces too (the hosted bot already posts it).
+//
+// Usage:
+//   clud-bug post-check-run --sha <sha> --verdict clean|critical|failed \
+//     [--critical-count N] [--source local|ci] [--strict|--no-strict] \
+//     [--owner O --repo R] [--details-url URL] [--dry-run]
+//
+// Verdict → conclusion is the shared `deriveCheck` brain. strictMode defaults to
+// the repo's `.clud-bug.json` (so `critical` blocks only where the repo opted in)
+// unless `--strict/--no-strict` overrides. Best-effort: any failure prints a
+// warning and exits 0 — posting a check must never break the review or a commit.
+
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { deriveCheck, normalizeVerdict, CLUD_BUG_CHECK_NAME } from '../core/index.js';
+import { readManifest } from './skills.js';
+
+interface PostCheckRunArgs {
+  sha?: string;
+  verdict?: string;
+  criticalCount?: number;
+  source?: string;
+  strict?: boolean;
+  owner?: string;
+  repo?: string;
+  detailsUrl?: string;
+  dryRun?: boolean;
+  cwd?: string;
+  _?: string[];
+}
+
+function sh(cmd: string, cmdArgs: string[], input?: string): { ok: boolean; out: string; err: string } {
+  const r = spawnSync(cmd, cmdArgs, { encoding: 'utf8', ...(input !== undefined ? { input } : {}) });
+  return { ok: r.status === 0, out: (r.stdout ?? '').trim(), err: (r.stderr ?? '').trim() };
+}
+
+export async function runPostCheckRun(args: PostCheckRunArgs): Promise<void> {
+  const cwd = args.cwd ?? process.cwd();
+  const warn = (m: string) => process.stderr.write(`clud-bug post-check-run: ${m}\n`);
+
+  // --- resolve the head SHA (default HEAD) -------------------------------
+  let sha = typeof args.sha === 'string' ? args.sha.trim() : '';
+  if (!sha) {
+    const r = sh('git', ['rev-parse', 'HEAD']);
+    if (!r.ok) return void warn('no --sha and `git rev-parse HEAD` failed; skipping.');
+    sha = r.out;
+  }
+
+  // --- strictMode: explicit flag wins, else the repo manifest -----------
+  let strictMode = false;
+  if (typeof args.strict === 'boolean') {
+    strictMode = args.strict;
+  } else {
+    try {
+      const manifest = await readManifest(join(cwd, '.claude', 'skills'));
+      strictMode = (manifest as { strictMode?: unknown }).strictMode === true;
+    } catch {
+      /* no manifest → advisory */
+    }
+  }
+
+  const verdict = normalizeVerdict(typeof args.verdict === 'string' ? args.verdict : undefined);
+  const criticalCount = Number(args.criticalCount ?? 0) || 0;
+  const source = args.source === 'local' ? 'local' : 'ci';
+  const { conclusion, title, summary } = deriveCheck({ verdict, strictMode, criticalCount, source });
+
+  // --- resolve owner/repo (flags, else gh) ------------------------------
+  let owner = typeof args.owner === 'string' ? args.owner : '';
+  let repo = typeof args.repo === 'string' ? args.repo : '';
+  if (!owner || !repo) {
+    const r = sh('gh', ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner']);
+    if (r.ok && r.out.includes('/')) {
+      const parts = r.out.split('/');
+      owner = parts[0] ?? '';
+      repo = parts[1] ?? '';
+    }
+  }
+
+  const body: Record<string, unknown> = {
+    name: CLUD_BUG_CHECK_NAME,
+    head_sha: sha,
+    status: 'completed',
+    conclusion,
+    output: { title, summary },
+  };
+  if (typeof args.detailsUrl === 'string') body['details_url'] = args.detailsUrl;
+
+  if (args.dryRun) {
+    process.stdout.write(
+      `clud-bug post-check-run (dry-run)\n` +
+        `  ${owner || '<owner>'}/${repo || '<repo>'} @ ${sha.slice(0, 12)}\n` +
+        `  verdict=${verdict} strict=${strictMode} source=${source} → conclusion=${conclusion}\n` +
+        `  title: ${title}\n`,
+    );
+    return;
+  }
+
+  if (!owner || !repo) return void warn('could not resolve owner/repo (pass --owner/--repo or run inside a gh-authed repo); skipping.');
+
+  const r = sh('gh', ['api', `repos/${owner}/${repo}/check-runs`, '-X', 'POST', '--input', '-'], JSON.stringify(body));
+  if (!r.ok) {
+    // Most common: the token lacks `checks: write`. Never fatal.
+    warn(`could not post the ${CLUD_BUG_CHECK_NAME} check (${r.err.split('\n')[0] || 'unknown error'}); the review still stands.`);
+    return;
+  }
+  process.stdout.write(`clud-bug: posted ${CLUD_BUG_CHECK_NAME} = ${conclusion} on ${sha.slice(0, 12)}\n`);
+}

--- a/src/cli/post-check-run.ts
+++ b/src/cli/post-check-run.ts
@@ -100,6 +100,11 @@ export async function runPostCheckRun(args: PostCheckRunArgs): Promise<void> {
 
   if (!owner || !repo) return void warn('could not resolve owner/repo (pass --owner/--repo or run inside a gh-authed repo); skipping.');
 
+  // NB: this POSTs a fresh check-run each call (no list+update like the hosted
+  // bot). Branch protection evaluates the MOST RECENT check-run for a name on a
+  // SHA, so the gate stays correct — a re-run after a fix overrides a prior
+  // failure. The only cost is cosmetic: repeated runs on one SHA stack entries
+  // in the PR's checks UI. (A list+update upsert is a possible future refinement.)
   const r = sh('gh', ['api', `repos/${owner}/${repo}/check-runs`, '-X', 'POST', '--input', '-'], JSON.stringify(body));
   if (!r.ok) {
     // Most common: the token lacks `checks: write`. Never fatal.

--- a/src/cli/review-prompt.ts
+++ b/src/cli/review-prompt.ts
@@ -177,6 +177,21 @@ export function renderReviewRecipe(input: {
       : 'Surface the findings into the session, and — if an open PR exists — post or edit (in ' +
         'place, by integer comment id) the clud-bug summary comment on it.';
 
+  // H3 — the merge-gate step (PR only). After reporting, the agent posts a
+  // SELF-ATTESTED `clud-bug-review` check so branch protection can gate the merge
+  // on a local review too. Commit/push triggers skip it (no PR head to anchor a
+  // check to). The conclusion is derived by `post-check-run` from the verdict +
+  // the repo's strictMode.
+  const gateStep =
+    trigger === 'pr'
+      ? `\n\n## 5. Post the merge-gate check
+After reporting, post the self-attested \`clud-bug-review\` check so branch protection can gate on it:
+\`\`\`bash
+clud-bug post-check-run --sha "$(git rev-parse HEAD)" --verdict <clean|critical> --critical-count <N> --source local
+\`\`\`
+\`clean\` → the check passes (merge unblocked); \`critical\` → it fails when the repo is in strict mode. This is a **self-attested** local review (this session), not independent CI — post it honestly from what you actually found. Skip silently if \`gh\` lacks \`checks: write\`.`
+      : '';
+
   // 3b (rc.15) — the OPTIONAL design-critic visual pass. Rendered only when the
   // caller gated it on (design.enabled + kind:design skills + pr trigger). The
   // step itself defers to runtime: no deploy-preview URL or no browser MCP in
@@ -252,7 +267,7 @@ Skills referenced: [<the skills you applied>]
 <!-- written-by: @<login> (clud-bug local-mode) -->
 \`\`\`
 
-${surface}
+${surface}${gateStep}
 
 Keep it tight — this is the local safety net; the deeper review still happens at PR time.
 `;

--- a/src/core/check-verdict.ts
+++ b/src/core/check-verdict.ts
@@ -1,0 +1,93 @@
+// Merge-gate verdict → GitHub check-run conclusion (H3). Shared, pure brain so
+// every surface that posts the `clud-bug-review` check derives the same
+// conclusion from a review outcome.
+//
+// The check name is HARD-CODED `clud-bug-review` everywhere — consumers attach
+// branch-protection rules by that exact string (see clud-bug-app/lib/check-runs.ts).
+//
+// CONCLUSION MODEL for the local + Action surfaces (this module):
+//   clean              → success  (review ran, no critical findings)
+//   critical + strict  → failure  (BLOCKS merge — fix the criticals)
+//   critical + !strict → neutral  (advisory; does not block)
+//   failed             → neutral  (couldn't run; never blocks — add signal, not outages)
+//
+// This intentionally differs from the HOSTED bot, whose check is success-on-run
+// and whose strict-mode block is a separate `request_changes` formal review. In
+// local/Action mode there is no formal review, so the check IS the gate — its
+// conclusion reflects the findings directly.
+
+/** The check name MUST match consumer branch-protection rules. Do not rename. */
+export const CLUD_BUG_CHECK_NAME = 'clud-bug-review';
+
+/** Outcome of a review, as the posting surface sees it. */
+export type ReviewVerdict = 'clean' | 'critical' | 'failed';
+
+/** The narrowed check-run conclusion set we emit. */
+export type CheckConclusion = 'success' | 'neutral' | 'failure';
+
+/** Which surface attested the review (drives the title + trust note). */
+export type CheckSource = 'local' | 'ci';
+
+export interface DerivedCheck {
+  conclusion: CheckConclusion;
+  title: string;
+  summary: string;
+}
+
+export interface DeriveCheckInput {
+  verdict: ReviewVerdict;
+  /** `.clud-bug.json` strictMode at the BASE ref. Default false (advisory). */
+  strictMode?: boolean;
+  /** Number of critical findings (for the title). */
+  criticalCount?: number;
+  /** 'local' (self-attested in-session) or 'ci' (Action). Default 'ci'. */
+  source?: CheckSource;
+}
+
+/**
+ * Derive the `clud-bug-review` check conclusion + title/summary from a review
+ * verdict. Pure. A `local` source appends a self-attested trust note so a
+ * reviewer can tell an in-session attestation from an independent CI check.
+ */
+export function deriveCheck(input: DeriveCheckInput): DerivedCheck {
+  const { verdict, strictMode = false, criticalCount = 0, source = 'ci' } = input;
+  const selfAttested =
+    source === 'local'
+      ? ' (self-attested by a local max-mode review in the author’s session — not an independent CI check)'
+      : '';
+
+  let conclusion: CheckConclusion;
+  let title: string;
+  let summary: string;
+
+  if (verdict === 'clean') {
+    conclusion = 'success';
+    title = 'clud-bug review — clean';
+    summary = `No critical findings.${selfAttested}`;
+  } else if (verdict === 'critical') {
+    const n = criticalCount > 0 ? `${criticalCount} ` : '';
+    if (strictMode) {
+      conclusion = 'failure';
+      title = `clud-bug review — ${n}critical (blocking)`;
+      summary = `${n}critical finding(s); strict mode blocks merge until they are resolved.${selfAttested}`;
+    } else {
+      conclusion = 'neutral';
+      title = `clud-bug review — ${n}critical (advisory)`;
+      summary = `${n}critical finding(s); advisory only (strict mode off) — does not block merge.${selfAttested}`;
+    }
+  } else {
+    // failed — never block on our own inability to run.
+    conclusion = 'neutral';
+    title = 'clud-bug review — could not run';
+    summary = `The review could not complete; the PR is not blocked. Re-run to retry.${selfAttested}`;
+  }
+
+  return { conclusion, title, summary };
+}
+
+/** Normalize a free-form verdict string (CLI input) to a `ReviewVerdict`. */
+export function normalizeVerdict(raw: string | undefined): ReviewVerdict {
+  if (raw === 'clean' || raw === 'critical' || raw === 'failed') return raw;
+  // Unknown/empty → 'failed' (safe: neutral check, never a false-green).
+  return 'failed';
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -298,6 +298,16 @@ export {
   type ReviewContextConfig,
 } from './review-context.js';
 export {
+  deriveCheck,
+  normalizeVerdict,
+  CLUD_BUG_CHECK_NAME,
+  type ReviewVerdict,
+  type CheckConclusion,
+  type CheckSource,
+  type DerivedCheck,
+  type DeriveCheckInput,
+} from './check-verdict.js';
+export {
   API_BASE,
   MAX_SKILLS,
   SkillsClient,

--- a/test/check-verdict.test.js
+++ b/test/check-verdict.test.js
@@ -64,4 +64,15 @@ describe('post-check-run --dry-run', () => {
   it('clean → success in dry-run', () => {
     expect(dryRun(['--verdict', 'clean']).stdout).toMatch(/conclusion=success/);
   });
+  // The false-green guards, exercised through the FULL CLI wiring (normalizeVerdict
+  // → deriveCheck), not just the pure functions — these inputs must never post success.
+  it('failed verdict → neutral (does not block)', () => {
+    expect(dryRun(['--verdict', 'failed']).stdout).toMatch(/conclusion=neutral/);
+  });
+  it('garbage verdict → neutral (no false-green)', () => {
+    expect(dryRun(['--verdict', 'garbage']).stdout).toMatch(/conclusion=neutral/);
+  });
+  it('critical + --no-strict → neutral (advisory)', () => {
+    expect(dryRun(['--verdict', 'critical', '--no-strict']).stdout).toMatch(/conclusion=neutral/);
+  });
 });

--- a/test/check-verdict.test.js
+++ b/test/check-verdict.test.js
@@ -1,0 +1,67 @@
+// H3 — merge-gate verdict → check conclusion + the `post-check-run` verb.
+
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { deriveCheck, normalizeVerdict, CLUD_BUG_CHECK_NAME } from '../src/core/index.js';
+
+const CLI = join(dirname(dirname(fileURLToPath(import.meta.url))), 'bin', 'clud-bug.js');
+
+describe('deriveCheck', () => {
+  it('clean → success regardless of strict mode', () => {
+    expect(deriveCheck({ verdict: 'clean', strictMode: true }).conclusion).toBe('success');
+    expect(deriveCheck({ verdict: 'clean', strictMode: false }).conclusion).toBe('success');
+  });
+  it('critical + strict → failure (blocks)', () => {
+    const d = deriveCheck({ verdict: 'critical', strictMode: true, criticalCount: 2 });
+    expect(d.conclusion).toBe('failure');
+    expect(d.title).toMatch(/2 critical \(blocking\)/);
+  });
+  it('critical + non-strict → neutral (advisory, does not block)', () => {
+    expect(deriveCheck({ verdict: 'critical', strictMode: false }).conclusion).toBe('neutral');
+  });
+  it('failed → neutral (never block on our own inability to run)', () => {
+    expect(deriveCheck({ verdict: 'failed', strictMode: true }).conclusion).toBe('neutral');
+  });
+  it('local source appends a self-attested trust note; ci does not', () => {
+    expect(deriveCheck({ verdict: 'clean', source: 'local' }).summary).toMatch(/self-attested/i);
+    expect(deriveCheck({ verdict: 'clean', source: 'ci' }).summary).not.toMatch(/self-attested/i);
+  });
+});
+
+describe('normalizeVerdict', () => {
+  it('passes known verdicts through and maps unknown → failed (never a false-green)', () => {
+    expect(normalizeVerdict('clean')).toBe('clean');
+    expect(normalizeVerdict('critical')).toBe('critical');
+    expect(normalizeVerdict('failed')).toBe('failed');
+    expect(normalizeVerdict('garbage')).toBe('failed');
+    expect(normalizeVerdict(undefined)).toBe('failed');
+  });
+});
+
+describe('check name', () => {
+  it('is the hard-coded clud-bug-review (consumer rulesets depend on it)', () => {
+    expect(CLUD_BUG_CHECK_NAME).toBe('clud-bug-review');
+  });
+});
+
+describe('post-check-run --dry-run', () => {
+  function dryRun(extra) {
+    return spawnSync(
+      process.execPath,
+      [CLI, 'post-check-run', '--sha', 'abc123', '--owner', 'o', '--repo', 'r', '--dry-run', ...extra],
+      { encoding: 'utf8' },
+    );
+  }
+  it('derives + prints the conclusion without posting', () => {
+    const r = dryRun(['--verdict', 'critical', '--critical-count', '3', '--strict', '--source', 'local']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/conclusion=failure/);
+    expect(r.stdout).toMatch(/dry-run/);
+  });
+  it('clean → success in dry-run', () => {
+    expect(dryRun(['--verdict', 'clean']).stdout).toMatch(/conclusion=success/);
+  });
+});

--- a/test/review-prompt.test.js
+++ b/test/review-prompt.test.js
@@ -57,6 +57,15 @@ describe('renderReviewRecipe', () => {
     expect(recipe).toMatch(/wasp/i);
     // pr reviews the branch against its base (not a single commit)
     expect(recipe).toMatch(/gh pr diff|origin\//);
+    // H3: a PR recipe posts the self-attested merge-gate check
+    expect(recipe).toMatch(/post-check-run --sha/);
+    expect(recipe).toMatch(/--source local/);
+  });
+
+  it('H3: the merge-gate step is PR-only — a commit recipe never posts a check', () => {
+    const plan = planReview({ skills: SKILLS, config: MULTIPASS_CONFIG, trigger: 'commit' });
+    const recipe = renderReviewRecipe({ plan, trigger: 'commit' });
+    expect(recipe).not.toMatch(/post-check-run/);
   });
 
   it('carries the plan summary so the operator sees what was resolved', () => {


### PR DESCRIPTION
Lets a max-mode review **gate merge**. New shared `core/check-verdict.ts` (`deriveCheck`: clean→success, critical+strict→failure/blocks, critical+non-strict→neutral, failed→neutral) + a `clud-bug post-check-run` verb (posts the `clud-bug-review` check via `gh`; best-effort, `--dry-run`, reads strictMode). The local recipe's **§5 (PR-only)** has the in-session agent post a **self-attested** check after reviewing — so an agent's self-merge is gated by its own review. The local check conclusion *reflects findings* (in local mode the check IS the gate; labeled self-attested, not independent CI). Tests for all combos + the dry-run + PR-only gating; full suite green. Action-path posting deferred (no production Action users post-F4). No version bump. 🤖