### PR TITLE
rc.19: batch Phase H max-mode hardening (H1–H4)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.18
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.19
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/decisions-branches/rc19-release.md
+++ b/docs/decisions-branches/rc19-release.md
@@ -1,0 +1,11 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 16:12 - rc.19: batch Phase H max-mode hardening (H1-H4)
+
+**Reasoning:** Ships the hardened max mode to npm so the 7 repos' hooks can re-pin to it. rc.19 batches: H1 (adversarial recipe depth — refute/3-lenses/verify/tiebreak), H2 (contextual review instructions + the anti-injection fence), H3 (the post-check-run merge-gate verb + the local self-attested clud-bug-review check), H4 (hook retry + diagnostic skip marker). Lockstep bump: package.json + 3 workflow templates + the strict-mode-gate action.
+
+**Implications:**
+- [CEO] publish v0.7.0-rc.19 -> next; then re-pin the 7 max-mode repos (clud-bug update refreshes the hook's npx pin). The hardened recipe + merge-gate reach users after the re-pin
+
+---
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.18",
+  "version": "0.7.0-rc.19",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.18
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.19
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.18
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.19
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -717,7 +717,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.18
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.19
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow


### PR DESCRIPTION
Release bump shipping the hardened max mode: **H1** adversarial recipe depth, **H2** contextual review instructions + anti-injection fence, **H3** the `post-check-run` merge-gate + local self-attested check, **H4** hook retry + diagnostic marker. Lockstep version pins (package.json + 3 templates + strict-mode-gate action); release-discipline + full suite green. **[CEO]** publish `v0.7.0-rc.19` after merge, then re-pin the 7 repos. 🤖