### PR TITLE
rc.20: floating @next hook + update notifier + update local-only fix

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.19
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.20
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/decisions-branches/rc20-floating-pin.md
+++ b/docs/decisions-branches/rc20-floating-pin.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 17:39 - rc.20: floating @next hook + update notifier + fix update re-adding the Action in local-only repos
+
+**Reasoning:** Three 'effortless update' improvements per CEO direction. (1) The max-mode commit hook floats to the @next dist-tag (buildCommitReviewCommand defaults to 'next') instead of an exact version — every repo auto-fetches the latest recipe, so no per-release re-pin rollout (this is the LAST re-pin); the pin stays overridable for a frozen version. (2) An update notifier (brew/gh/vercel pattern): on an interactive run, a cached daily check prints an 'update available -> clud-bug update' nudge; the cache is refreshed by a detached background process so it never adds latency, and it's skipped for machine verbs + non-TTY (the hook's review-prompt stays silent). (3) Fixed a dogfood-caught bug: 'clud-bug update' created clud-bug-review.yml even in --local-only repos (maybeRefreshVersioned creates-when-absent) — now gated behind pathExists like audit/self-update, so update refreshes what's installed and never adds the API-key Action.
+
+**Alternatives considered:** Keep exact pins + re-pin every release (rejected — recurring friction, fights max-mode-everywhere); a full update-notifier npm dep (rejected — zero-dep lightweight version is enough)
+
+**Implications:**
+- [CEO] publish v0.7.0-rc.20. Then ONE final re-pin rollout (init --local-only rc.20) moves the 7 repos to the floating @next hook — after which they auto-update forever
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -87,6 +87,7 @@ clud-bug
 │   ├── skills-frontmatter.test.js
 │   ├── skills.test.js
 │   ├── strict-mode-gate-classifier.test.js
+│   ├── update-notifier.test.js
 │   ├── update-skill-usage.test.js
 │   ├── update.test.js
 │   └── usage.test.js

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (77 decisions)
+## 2026-06 (79 decisions)
 
-- **2026-06-29** — H3 review fixes: CLI-level false-green guard tests + document the check-run stacking tradeoff *(h3-merge-gate)* — [decisions-branches/h3-merge-gate.md](decisions-branches/h3-merge-gate.md)
-- *... 75 more decisions ...*
+- **2026-06-29** — rc.20: floating @next hook + update notifier + fix update re-adding the Action in local-only repos *(rc20-floating-pin)* — [decisions-branches/rc20-floating-pin.md](decisions-branches/rc20-floating-pin.md)
+- *... 77 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.19",
+  "version": "0.7.0-rc.20",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/cli/hooks.ts
+++ b/src/cli/hooks.ts
@@ -21,10 +21,13 @@
 export const CLUD_BUG_HOOK_MARKER = 'clud-bug-local-review';
 
 /**
- * Build the shell `command` of the commit-review hook, pinned to the clud-bug
- * VERSION that scaffolded it (a bare `npx clud-bug` resolves to the `latest`
- * dist-tag, which can predate the `review-prompt` verb; `@${version}` guarantees
- * it). `clud-bug update` refreshes the pin in place.
+ * Build the shell `command` of the commit-review hook. Pins to a FLOATING npm
+ * dist-tag (`next` by default) rather than an exact version, so every repo's hook
+ * auto-fetches the latest review recipe — no per-release re-pin rollout. (The
+ * original exact-pin guarded against a `latest` that predated the `review-prompt`
+ * verb; that verb now ships in every channel, so floating is safe + frictionless.)
+ * Max mode is advisory, so "always newest recipe" is the right default for a
+ * review tool. `pin` is overridable for a repo that wants a frozen, exact version.
  *
  * The command, in order:
  *   1. Idempotency — skip if this exact HEAD was already surfaced (avoids a
@@ -39,7 +42,7 @@ export const CLUD_BUG_HOOK_MARKER = 'clud-bug-local-review';
  *      the commit on the session subscription.
  *   4. Any failure or empty output → `exit 0` (quiet; the commit is never blocked).
  */
-export function buildCommitReviewCommand(version: string): string {
+export function buildCommitReviewCommand(pin: string = 'next'): string {
   return [
     // Marker as a `#` comment (NOT a `:` no-op) so its free text can never break
     // `sh` — a paren / quote / `$` in the marker line would be a syntax error
@@ -61,8 +64,8 @@ export function buildCommitReviewCommand(version: string): string {
     // `|| recipe=` clears it on a NON-ZERO exit so partial/error stdout from a
     // mid-run crash (or an old npm warning on stdout) is never mistaken for a
     // valid recipe — only a clean, exit-0 run surfaces.
-    `recipe=$(npx clud-bug@${version} review-prompt --trigger commit 2>/dev/null) || recipe=`,
-    `if [ -z "$recipe" ]; then sleep 1; recipe=$(npx clud-bug@${version} review-prompt --trigger commit 2>/dev/null) || recipe=; fi`,
+    `recipe=$(npx clud-bug@${pin} review-prompt --trigger commit 2>/dev/null) || recipe=`,
+    `if [ -z "$recipe" ]; then sleep 1; recipe=$(npx clud-bug@${pin} review-prompt --trigger commit 2>/dev/null) || recipe=; fi`,
     // H4 — when the recipe still can't be fetched, leave a diagnostic marker so a
     // FAILED review is distinguishable from a CLEAN one (a clean review surfaces
     // the recipe + the agent reports clean). Never blocks the commit.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -283,6 +283,17 @@ async function main() {
   if (args.quiet) setQuiet(true);
 
   const cmd = args._[0];
+
+  // rc.20 — update notifier (brew/gh/vercel pattern). Only on an interactive
+  // terminal, and never for the machine-consumed verbs (the hook runs
+  // review-prompt in a non-TTY subprocess, so this is doubly skipped there).
+  // Best-effort + cache-backed, so it adds no latency to the command.
+  const MACHINE_VERBS = new Set(['review-prompt', 'post-check-run', 'render', 'update-skill-usage']);
+  if (process.stderr.isTTY && !MACHINE_VERBS.has(cmd)) {
+    const { maybeNotifyUpdate } = await import('./update-notifier.js');
+    await maybeNotifyUpdate(await readPkgVersion());
+  }
+
   switch (cmd) {
     case 'init':    return runInit(args);
     case 'list':    return runList(args);
@@ -1340,7 +1351,8 @@ async function runInit(args) {
   // never run the CLI; see hooks.ts.)
   if (args.withHooks) {
     const { mergeLocalReviewHook, buildCommitReviewCommand } = await import('./hooks.js');
-    const hookCommand = buildCommitReviewCommand(await readPkgVersion());
+    // Floating @next pin (default) — the hook auto-fetches the latest recipe.
+    const hookCommand = buildCommitReviewCommand();
     const settingsPath = join(cwd, '.claude', 'settings.json');
     await mkdir(dirname(settingsPath), { recursive: true });
     // Read-then-parse so we can tell "no file yet" (fresh merge) from "file

--- a/src/cli/update-notifier.ts
+++ b/src/cli/update-notifier.ts
@@ -1,0 +1,100 @@
+// Update notifier (rc.20) — the brew/npm/gh/vercel pattern: on an interactive
+// `clud-bug` run, if a newer version is published, print a one-line nudge to
+// upgrade. NEVER blocks the command: the notice is read from a local cache, and
+// the cache is refreshed by a DETACHED background process (at most once a day).
+// The notice therefore appears on the run AFTER a new release is detected — the
+// standard, zero-latency update-notifier UX.
+
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const CACHE_FILE = join(homedir(), '.cache', 'clud-bug', 'update-check.json');
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // once a day
+
+/**
+ * True if version `a` is newer than `b`, for clud-bug's `X.Y.Z` / `X.Y.Z-rc.N`
+ * scheme. A stable build (no prerelease) ranks ABOVE any prerelease of the same
+ * core (so `0.7.0` > `0.7.0-rc.20`). Pure.
+ */
+export function isNewerVersion(a: string, b: string): boolean {
+  const parse = (v: string): number[] => {
+    const [core = '', pre] = String(v).split('-');
+    const nums = core.split('.').map((n) => Number(n) || 0);
+    // No prerelease → Infinity so a stable sorts above any -rc.N of the same core.
+    const preNum = pre ? Number((pre.match(/\d+/) || ['0'])[0]) : Infinity;
+    return [...nums, preNum];
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i] ?? 0;
+    const y = pb[i] ?? 0;
+    if (x !== y) return x > y;
+  }
+  return false;
+}
+
+interface UpdateCache {
+  checkedAt?: number;
+  latest?: string;
+}
+
+/**
+ * Print an upgrade nudge if the cached latest version is newer than `current`,
+ * and (if the cache is stale) kick off a detached background refresh. Best-effort
+ * — any error is swallowed. Caller should gate on an interactive TTY.
+ */
+export async function maybeNotifyUpdate(
+  current: string,
+  opts: { channel?: string; now?: number; cacheFile?: string } = {},
+): Promise<void> {
+  const channel = opts.channel ?? 'next';
+  const now = opts.now ?? Date.now();
+  const cacheFile = opts.cacheFile ?? CACHE_FILE;
+  try {
+    let cache: UpdateCache = {};
+    try {
+      cache = JSON.parse(await readFile(cacheFile, 'utf8')) as UpdateCache;
+    } catch {
+      /* no/invalid cache — first run */
+    }
+
+    if (typeof cache.latest === 'string' && isNewerVersion(cache.latest, current)) {
+      process.stderr.write(
+        `\n  ⬆ clud-bug ${cache.latest} is available (you have ${current}).\n` +
+          `    Run \`clud-bug update\` to refresh your kit. (max-mode hooks already auto-update.)\n\n`,
+      );
+    }
+
+    if (!cache.checkedAt || now - cache.checkedAt > CHECK_INTERVAL_MS) {
+      refreshInBackground(channel, now, cacheFile);
+    }
+  } catch {
+    /* never throw — a version check must never break a command */
+  }
+}
+
+/**
+ * Spawn a detached, unref'd child that fetches the channel's current version
+ * from the npm registry and writes the cache, then the parent exits immediately.
+ * The registry's per-dist-tag endpoint returns just that manifest (small).
+ */
+function refreshInBackground(channel: string, now: number, cacheFile: string): void {
+  const script = `
+const https=require('https'),fs=require('fs'),path=require('path');
+const cf=${JSON.stringify(cacheFile)};
+https.get('https://registry.npmjs.org/clud-bug/'+${JSON.stringify(channel)},r=>{
+  let d='';r.on('data',c=>d+=c);r.on('end',()=>{try{
+    const v=JSON.parse(d).version;
+    if(v){fs.mkdirSync(path.dirname(cf),{recursive:true});fs.writeFileSync(cf,JSON.stringify({checkedAt:${now},latest:v}));}
+  }catch(e){}});
+}).on('error',()=>{});`;
+  try {
+    const child = spawn(process.execPath, ['-e', script], { detached: true, stdio: 'ignore' });
+    child.unref();
+  } catch {
+    /* spawn failed — skip; the notice just won't refresh this run */
+  }
+}

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -68,17 +68,25 @@ export async function runUpdate(opts: RunUpdateOptions): Promise<RunUpdateResult
   const unchanged: UpdateChangeRecord[] = [];
   const skipped: UpdateSkippedRecord[] = [];
 
-  // 1. Re-render review workflow with the latest template.
-  const signals = await detect(cwd);
-  const tmplName = pickTemplate(signals.languages);
-  // REVIEW_SCHEMA + CCA_VERSION + CLUD_BUG_VERSION come from render.js DEFAULTS.
-  const newReview = await renderFile(join(templatesDir, tmplName), {
-    REVIEW_PROMPT: reviewPrompt({
-      projectDescription: buildDescriptionLine(signals),
-      language: templateLanguage(tmplName),
-    }),
-  });
-  await maybeRefreshVersioned(join(cwd, '.github/workflows/clud-bug-review.yml'), newReview, changed, unchanged, skipped, 'review workflow');
+  // 1. Re-render the review workflow with the latest template — ONLY if it is
+  //    already installed. A `--local-only` (max-mode) repo has no review
+  //    workflow and must NOT have one created by `update`: that would
+  //    re-introduce the ANTHROPIC_API_KEY Action the local install deliberately
+  //    skips (dogfood caught `update` doing exactly this). Mirrors the
+  //    pathExists-gating the audit + self-update workflows already use below.
+  const reviewPath = join(cwd, '.github/workflows/clud-bug-review.yml');
+  if (await pathExists(reviewPath)) {
+    const signals = await detect(cwd);
+    const tmplName = pickTemplate(signals.languages);
+    // REVIEW_SCHEMA + CCA_VERSION + CLUD_BUG_VERSION come from render.js DEFAULTS.
+    const newReview = await renderFile(join(templatesDir, tmplName), {
+      REVIEW_PROMPT: reviewPrompt({
+        projectDescription: buildDescriptionLine(signals),
+        language: templateLanguage(tmplName),
+      }),
+    });
+    await maybeRefreshVersioned(reviewPath, newReview, changed, unchanged, skipped, 'review workflow');
+  }
 
   // 2. Re-render audit workflow if it's installed (init from v0.3+ ships it).
   // Routed through renderFile (was raw readFile pre-v0.5.11) so
@@ -172,7 +180,7 @@ export async function runUpdate(opts: RunUpdateOptions): Promise<RunUpdateResult
     const prior = await readSafe(settingsPath);
     if (prior && prior.includes(CLUD_BUG_HOOK_MARKER)) {
       try {
-        const merged = mergeLocalReviewHook(JSON.parse(prior), buildCommitReviewCommand(ourVersion));
+        const merged = mergeLocalReviewHook(JSON.parse(prior), buildCommitReviewCommand());
         await maybeWrite(settingsPath, JSON.stringify(merged, null, 2) + '\n', changed, unchanged, 'commit-review hook');
       } catch {
         skipped.push({

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.19
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.20
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.19
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.20
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -717,7 +717,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.19
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.20
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -13,8 +13,8 @@ import {
   buildCommitReviewCommand,
 } from '../src/cli/hooks.js';
 
-// The hook command is version-pinned; build one at a fixed test version.
-const COMMIT_REVIEW_COMMAND = buildCommitReviewCommand('0.7.0-rc.13');
+// The hook command floats to the `next` dist-tag by default (rc.20).
+const COMMIT_REVIEW_COMMAND = buildCommitReviewCommand();
 
 describe('buildLocalReviewHook', () => {
   it('is a backgrounded type:command PostToolUse entry targeting git commit + logmind log', () => {
@@ -113,10 +113,12 @@ describe('mergeLocalReviewHook', () => {
 });
 
 describe('buildCommitReviewCommand', () => {
-  it('carries the marker, pins the clud-bug version, and runs review-prompt on the subscription', () => {
+  it('carries the marker, floats to @next, and runs review-prompt on the subscription', () => {
     expect(COMMIT_REVIEW_COMMAND).toMatch(/clud-bug-local-review/);
-    // version-pinned so the hook never resolves to a `latest` that predates the verb
-    expect(COMMIT_REVIEW_COMMAND).toMatch(/npx clud-bug@0\.7\.0-rc\.13 review-prompt --trigger commit/);
+    // floating @next so the hook always fetches the latest recipe — no per-release re-pin
+    expect(COMMIT_REVIEW_COMMAND).toMatch(/npx clud-bug@next review-prompt --trigger commit/);
+    // the pin is overridable for a repo that wants a frozen exact version
+    expect(buildCommitReviewCommand('0.7.0-rc.99')).toMatch(/npx clud-bug@0\.7\.0-rc\.99 review-prompt/);
     expect(COMMIT_REVIEW_COMMAND).toMatch(/subscription/i);
     // idempotency: skips re-surfacing the same HEAD; never blocks the commit
     expect(COMMIT_REVIEW_COMMAND).toMatch(/git rev-parse HEAD/);

--- a/test/update-notifier.test.js
+++ b/test/update-notifier.test.js
@@ -1,0 +1,63 @@
+// rc.20 — the update notifier (brew/gh/vercel pattern).
+
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { isNewerVersion, maybeNotifyUpdate } from '../src/cli/update-notifier.js';
+
+describe('isNewerVersion', () => {
+  it('orders rc versions and ranks a stable build above a prerelease', () => {
+    expect(isNewerVersion('0.7.0-rc.20', '0.7.0-rc.19')).toBe(true);
+    expect(isNewerVersion('0.7.0-rc.19', '0.7.0-rc.20')).toBe(false);
+    expect(isNewerVersion('0.7.0', '0.7.0-rc.20')).toBe(true); // stable > prerelease
+    expect(isNewerVersion('0.8.0-rc.1', '0.7.0-rc.99')).toBe(true);
+    expect(isNewerVersion('0.7.0-rc.19', '0.7.0-rc.19')).toBe(false);
+    expect(isNewerVersion('0.7.1', '0.7.0')).toBe(true);
+  });
+});
+
+describe('maybeNotifyUpdate', () => {
+  // A cache stamped at `now` is fresh → no background refresh is spawned, so
+  // these tests exercise only the notice logic (no network, no child process).
+  async function freshCache(latest, now) {
+    const dir = await mkdtemp(join(tmpdir(), 'cb-notif-'));
+    const cacheFile = join(dir, 'update-check.json');
+    await writeFile(cacheFile, JSON.stringify({ checkedAt: now, latest }));
+    return cacheFile;
+  }
+  function captureStderr() {
+    return vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  }
+
+  it('prints a nudge when the cached latest is newer', async () => {
+    const now = 1_000_000;
+    const cacheFile = await freshCache('0.7.0-rc.20', now);
+    const spy = captureStderr();
+    await maybeNotifyUpdate('0.7.0-rc.19', { cacheFile, now });
+    const out = spy.mock.calls.map((c) => c[0]).join('');
+    spy.mockRestore();
+    expect(out).toMatch(/clud-bug 0\.7\.0-rc\.20 is available/);
+    expect(out).toMatch(/clud-bug update/);
+  });
+
+  it('is silent when the current version is already the latest', async () => {
+    const now = 1_000_000;
+    const cacheFile = await freshCache('0.7.0-rc.19', now);
+    const spy = captureStderr();
+    await maybeNotifyUpdate('0.7.0-rc.19', { cacheFile, now });
+    const out = spy.mock.calls.map((c) => c[0]).join('');
+    spy.mockRestore();
+    expect(out).not.toMatch(/is available/);
+  });
+
+  it('never throws on an unreadable cache (and returns undefined)', async () => {
+    // fresh-enough `now` is irrelevant; a missing file just means no notice.
+    const spy = captureStderr();
+    await expect(
+      maybeNotifyUpdate('0.7.0-rc.19', { cacheFile: join(tmpdir(), 'cb-does-not-exist', 'x.json'), now: 1 }),
+    ).resolves.toBeUndefined();
+    spy.mockRestore();
+  });
+});

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -231,3 +231,29 @@ test('runUpdate: re-renders audit + self-update workflows when installed (stale 
     assert.doesNotMatch(selfUpd, /\{\{[A-Z_]+\}\}/);
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
+
+test('runUpdate: a --local-only repo (manifest, no workflow) does NOT get a review workflow created', async () => {
+  // Max-mode install: installed skills + a hook, but NO clud-bug-review.yml.
+  // update must REFRESH what is installed, never ADD the API-key Action.
+  const dir = await makeRepo({
+    'package.json': JSON.stringify({ name: 'demo' }),
+    '.claude/skills/.clud-bug.json': JSON.stringify({
+      version: 1,
+      installed: [{ slug: 'critical-issues-only', kind: 'baseline' }],
+    }),
+    '.claude/skills/critical-issues-only/SKILL.md': '# baseline\n',
+  });
+  try {
+    await runUpdate({
+      cwd: dir, templatesDir: TEMPLATES, baselineDir: BASELINE, ourVersion: '0.3.0',
+      loadBaselineOpts: offlineLoadBaseline,
+    });
+    let created = true;
+    try {
+      await readFile(join(dir, '.github/workflows/clud-bug-review.yml'), 'utf8');
+    } catch {
+      created = false;
+    }
+    assert.equal(created, false, 'update must not create the review workflow in a workflow-less (local-only) repo');
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
The **effortless-update story**: (1) the max-mode hook floats to **`@next`** (auto-fetches the latest recipe — no per-release re-pin; overridable for a frozen pin); (2) an **update notifier** (brew/gh/vercel pattern — cached daily check, detached background refresh, never blocks, TTY + non-machine-verb only); (3) **fix** — `clud-bug update` no longer re-adds the API-key Action in `--local-only` repos (dogfood-caught; now `pathExists`-gated). Tests for the comparator, the notice, the never-throw, the floating pin + override, and the update regression. Lockstep rc.20; full suite green. **[CEO]** publish `v0.7.0-rc.20`, then I do the final re-pin. 🤖