### PR TITLE
rc.21 (C1): parameterize verifier prompt/system by outputMode

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.20
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.21
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/decisions-branches/cl2-rc21.md
+++ b/docs/decisions-branches/cl2-rc21.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 20:12 - rc.21 (C1): parameterize buildVerifierPrompt + VERIFIER_SYSTEM by outputMode (json|structured)
+
+**Reasoning:** The last core-duplication gap: clud-bug-app's buildVerifierPrompt + VERIFIER_SYSTEM are byte-identical to core's except one output-instruction line (raw-JSON vs AI-SDK structured). Added outputMode: 'json' | 'structured' (default 'json', preserving the CLI raw path) to buildVerifierPrompt; refactored VERIFIER_SYSTEM into a shared body + a mode tail via buildVerifierSystem(mode), with VERIFIER_SYSTEM = buildVerifierSystem('json') for back-compat. Exported buildVerifierSystem + VerifierOutputMode. Verified: the CLI json prompt + system are byte-identical to before (VERIFIER_SYSTEM === buildVerifierSystem('json')); structured mode emits the app's wording.
+
+**Alternatives considered:** A second VERIFIER_SYSTEM_STRUCTURED const (rejected — a builder + shared body is cleaner + de-dups the body too); leave it duplicated (rejected — this IS the C1 cleanup)
+
+**Implications:**
+- rc.21. [CEO] publish v0.7.0-rc.21 -> then clud-bug-app deletes its buildVerifierPrompt/VERIFIER_SYSTEM copies + imports core's with outputMode:'structured' (C1 app side)
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (80 decisions)
+## 2026-06 (81 decisions)
 
-- **2026-06-29** — re-pin: float the max-mode hook to @next (auto-update; last manual re-pin) *(repin-next-floating)* — [decisions-branches/repin-next-floating.md](decisions-branches/repin-next-floating.md)
-- *... 78 more decisions ...*
+- **2026-06-29** — rc.21 (C1): parameterize buildVerifierPrompt + VERIFIER_SYSTEM by outputMode (json|structured) *(cl2-rc21)* — [decisions-branches/cl2-rc21.md](decisions-branches/cl2-rc21.md)
+- *... 79 more decisions ...*
 - **2026-06-01** — chore: self-propagate v0.6.30 (cross-review aggregation) *(chore/self-propagate-v0.6.30)* — [decisions-branches/chore__self-propagate-v0.6.30.md](decisions-branches/chore__self-propagate-v0.6.30.md)
 
 ## 2026-05 (108 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.20",
+  "version": "0.7.0-rc.21",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -201,8 +201,10 @@ export {
 } from './auto-resolve.js';
 export {
   VERIFIER_SYSTEM,
+  buildVerifierSystem,
   buildVerifierPrompt,
   parseVerifierResponse,
+  type VerifierOutputMode,
   type VerifySingleFindingInput,
 } from './resolve-verifier.js';
 // SPEC §7 canonical-ruleset applier. Pure diff + idempotent-PATCH logic;

--- a/src/core/resolve-verifier.ts
+++ b/src/core/resolve-verifier.ts
@@ -27,7 +27,7 @@ import type { PriorFinding, VerifyOutcome } from './auto-resolve.js';
 // System prompt — hard-coded, NOT derived from user content (anti-injection)
 // ---------------------------------------------------------------------------
 
-export const VERIFIER_SYSTEM = [
+const VERIFIER_SYSTEM_BODY = [
   'You are a code-review fix verifier. Your only job is to decide whether a',
   'specific code change addressed a specific prior reviewer concern.',
   '',
@@ -51,12 +51,33 @@ export const VERIFIER_SYSTEM = [
   'judging the finding. You are judging whether the new code resolves what it',
   'said. If the finding asked for X and the change does X, mark ADDRESSED even',
   'if X is unnecessary.',
-  '',
-  'Reply with a JSON object on a single line, no markdown fence, no surrounding',
-  'prose. Shape:',
-  '  {"verdict":"ADDRESSED"|"NOT_ADDRESSED"|"UNCERTAIN","rationale":"<one sentence>"}',
-  'Rationale MUST be one sentence, max 500 characters.',
-].join('\n');
+];
+
+/** Output contract for the verifier prompt + system message (C1 dedup). */
+export type VerifierOutputMode = 'json' | 'structured';
+
+// The verdict-shape tail differs by surface: the CLI/raw path asks the model to
+// emit the JSON itself; the hosted App constrains output via an AI-SDK schema, so
+// its prompt only names the verdict + rationale. Everything above is shared.
+function verifierSystemTail(outputMode: VerifierOutputMode): string[] {
+  if (outputMode === 'structured') {
+    return ['Reply with the structured object only. Rationale must be one sentence.'];
+  }
+  return [
+    'Reply with a JSON object on a single line, no markdown fence, no surrounding',
+    'prose. Shape:',
+    '  {"verdict":"ADDRESSED"|"NOT_ADDRESSED"|"UNCERTAIN","rationale":"<one sentence>"}',
+    'Rationale MUST be one sentence, max 500 characters.',
+  ];
+}
+
+/** Build the verifier system prompt for the given output mode. */
+export function buildVerifierSystem(outputMode: VerifierOutputMode = 'json'): string {
+  return [...VERIFIER_SYSTEM_BODY, '', ...verifierSystemTail(outputMode)].join('\n');
+}
+
+/** Raw-JSON system prompt — the CLI default. Back-compat for existing consumers. */
+export const VERIFIER_SYSTEM = buildVerifierSystem('json');
 
 // ---------------------------------------------------------------------------
 // Input shape
@@ -89,7 +110,10 @@ export interface VerifySingleFindingInput {
  *     A model coerced to emit "ADDRESSED!" outside the JSON shape
  *     gets routed to UNCERTAIN+api-error (fail-closed).
  */
-export function buildVerifierPrompt(input: VerifySingleFindingInput): string {
+export function buildVerifierPrompt(
+  input: VerifySingleFindingInput,
+  opts: { outputMode?: VerifierOutputMode } = {},
+): string {
   const f = input.finding;
   const anchor = f.line !== undefined ? `${f.file}:${f.line}` : f.file;
   const sev = f.severity === 'critical' ? '🔴 critical' : '🟡 minor';
@@ -129,7 +153,9 @@ export function buildVerifierPrompt(input: VerifySingleFindingInput): string {
   parts.push('');
   parts.push('Did this change ADDRESS the original finding?');
   parts.push(
-    'Reply with the JSON object only — single line, no markdown fence, no prose.',
+    (opts.outputMode ?? 'json') === 'structured'
+      ? 'Reply with the structured verdict + one-sentence rationale.'
+      : 'Reply with the JSON object only — single line, no markdown fence, no prose.',
   );
 
   return parts.join('\n');

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.20
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.21
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.20
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.21
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -717,7 +717,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.20
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.21
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow


### PR DESCRIPTION
The last core-dup gap. `buildVerifierPrompt` gains `outputMode: 'json' | 'structured'` (default json — CLI unchanged); `VERIFIER_SYSTEM` refactored into a shared body + mode tail via `buildVerifierSystem(mode)`, with `VERIFIER_SYSTEM = buildVerifierSystem('json')` for back-compat. Verified byte-identical CLI output. Lockstep rc.21. **[CEO]** publish `v0.7.0-rc.21` → then clud-bug-app deletes its copies + imports core's. 🤖