### PR TITLE
Phase R (R1): executable-probe invariants — config module + gate (#87 keystone)

### DIFF
--- a/docs/decisions-branches/phase-r1-invariants-module.md
+++ b/docs/decisions-branches/phase-r1-invariants-module.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 10:24 - Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate
+
+**Reasoning:** clud-bug's grounding gate (quote the exact diff line or DROP) is a correct floor for nit-suppression but a ceiling: it structurally cannot represent an emergent / combinatorial / cross-cutting bug that lives in no single changed line (clud-bug-app #87, 3 real logmind misses). An INVARIANT pairs a behavioral property with an executable PROBE (a command that goes RED when violated); RED output is trusted machine evidence equal to a quoted line. This module is the shared pure brain (mirrors design.ts): tolerant config parse + a pr-only in-scope gate. Purely additive — not yet wired into the recipe (R2).
+
+**Alternatives considered:** Prose-only reviewContext invariants (rejected: checked statically against the diff, so they can never fire on a no-single-line bug — the exact ceiling #87 names), Per-skill SKILL.md frontmatter invariants (rejected: the frontmatter parser drops unknown nested keys; a manifest-level block is cleaner + matches design/reviewPasses)
+
+**Implications:**
+- R2 wires shouldRunProbes into review-prompt.ts + prompt-builder.ts (grounding gate = quoted line OR reproduction OR named invariant); execution differs per mode (local: run; hosted: static-degrade; Action: separate CI job)
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,6 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
+## 2026-07
+
+- **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
+
 ## 2026-06 (81 decisions)
 
 - **2026-06-29** — rc.21 (C1): parameterize buildVerifierPrompt + VERIFIER_SYSTEM by outputMode (json|structured) *(cl2-rc21)* — [decisions-branches/cl2-rc21.md](decisions-branches/cl2-rc21.md)

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -291,6 +291,17 @@ export {
   type DesignConfig,
   type DesignGate,
 } from './design.js';
+// Phase R (clud-bug-app #87) — executable-probe invariants: config + in-scope gate.
+// A probe is a repo-declared command that goes RED when a behavioral property is
+// violated; RED output grounds a finding equal to a quoted diff line, catching the
+// emergent / combinatorial / cross-cutting bugs the "quote-the-line" gate misses.
+export {
+  readInvariantsConfig,
+  shouldRunProbes,
+  BUILTIN_INVARIANTS_CONFIG,
+  type Invariant,
+  type InvariantsConfig,
+} from './invariants.js';
 export {
   readReviewContext,
   extractPrContext,

--- a/src/core/invariants.ts
+++ b/src/core/invariants.ts
@@ -1,0 +1,123 @@
+// Executable-probe invariants: config + run-gate (Phase R / clud-bug-app #87).
+//
+// An INVARIANT is a repo-declared behavioral property paired with an executable
+// PROBE: a shell command that exits non-zero (RED) when the property is violated.
+// Unlike a prose `reviewContext` instruction — which is checked *statically*
+// against the diff and so can never fire on a bug that lives in no single changed
+// line — a probe is *run*, so it can ground the emergent / combinatorial /
+// cross-cutting bugs the "quote-the-line" gate structurally misses. A finding
+// fires only when a probe runs RED; RED output is trusted machine evidence, equal
+// in standing to a quoted diff line.
+//
+// This module is the shared, pure brain (like `design.ts`): every surface resolves
+// config + the in-scope gate here so policy can't fork. Whether a probe can
+// actually be *executed* differs per surface (local/max: full shell; hosted
+// serverless: static-degrade, no checkout; Action: a separate CI job outside the
+// allowlist-sandboxed reviewer) — that is a consumer concern. This module only
+// decides *whether* probes are in scope for a given diff + trigger.
+
+import type { ReviewTrigger } from './plan-review.js';
+
+/** A repo-declared behavioral property with an executable probe. */
+export interface Invariant {
+  /** Human name, shown in the probe-results block + any resulting finding. */
+  name: string;
+  /** Glob(s) over changed paths; the probe is in scope only when the diff hits one. */
+  appliesTo: string[];
+  /** Shell command; a non-zero exit is RED (the property is violated). */
+  probe: string;
+  /** Optional expected-output / golden reference, surfaced in the prompt + transcript. */
+  expect?: string;
+}
+
+/** Resolved `.clud-bug.json` `invariants` config (defaults applied). */
+export interface InvariantsConfig {
+  /** Master switch. Default OFF — probes never run unless this is true. */
+  enabled: boolean;
+  /** The validated invariant set (malformed entries dropped). */
+  invariants: Invariant[];
+}
+
+/** Off-by-default builtin — the cost-control floor (probes build+run, so they cost). */
+export const BUILTIN_INVARIANTS_CONFIG: InvariantsConfig = {
+  enabled: false,
+  invariants: [],
+};
+
+/** Parse + validate one raw invariant entry. Tolerant; returns null if unusable. */
+function parseInvariant(raw: unknown): Invariant | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const o = raw as Record<string, unknown>;
+
+  const name = typeof o['name'] === 'string' && o['name'].trim() ? o['name'] : null;
+  const probe = typeof o['probe'] === 'string' && o['probe'].trim() ? o['probe'] : null;
+  if (!name || !probe) return null;
+
+  // appliesTo: accept a single glob string or an array of them; drop empties.
+  let appliesTo: string[] = [];
+  if (typeof o['appliesTo'] === 'string' && o['appliesTo'].trim()) {
+    appliesTo = [o['appliesTo']];
+  } else if (Array.isArray(o['appliesTo'])) {
+    appliesTo = o['appliesTo'].filter((g): g is string => typeof g === 'string' && g.trim().length > 0);
+  }
+  if (appliesTo.length === 0) return null; // no globs → cannot cost-gate → unusable
+
+  const invariant: Invariant = { name, appliesTo, probe };
+  if (typeof o['expect'] === 'string') invariant.expect = o['expect'];
+  return invariant;
+}
+
+/**
+ * Read + normalize the `invariants` config from a parsed `.clud-bug.json` manifest.
+ *
+ * Accepts two authoring forms (tolerant, mirroring `readReviewPassesConfig`):
+ *   - a bare array:      `"invariants": [ { name, appliesTo, probe, expect? }, … ]`
+ *   - a wrapper object:  `"invariants": { "enabled": false, "list": [ … ] }`  (a
+ *     kill-switch that retains the config while turning probes off)
+ *
+ * A missing/malformed block, or one with zero *valid* invariants, resolves to the
+ * off-by-default builtin — a typo can never silently enable the cost-bearing probe
+ * run. Declaring at least one valid invariant is the explicit opt-in.
+ */
+export function readInvariantsConfig(manifest: unknown): InvariantsConfig {
+  const raw = (manifest as { invariants?: unknown } | null | undefined)?.invariants;
+
+  let list: unknown;
+  let enabledOverride: boolean | undefined;
+  if (Array.isArray(raw)) {
+    list = raw;
+  } else if (raw && typeof raw === 'object') {
+    const o = raw as Record<string, unknown>;
+    list = o['list'] ?? o['invariants'];
+    if (typeof o['enabled'] === 'boolean') enabledOverride = o['enabled'];
+  } else {
+    return { enabled: false, invariants: [] };
+  }
+
+  const invariants = Array.isArray(list)
+    ? list.map(parseInvariant).filter((i): i is Invariant => i !== null)
+    : [];
+
+  // Default ON when invariants are present; an explicit `enabled: false` disables
+  // while retaining them (kill-switch). Never enabled with zero valid invariants.
+  const enabled = (enabledOverride ?? true) && invariants.length > 0;
+  return { enabled, invariants };
+}
+
+/**
+ * Consumer-agnostic in-scope gate for the probe run. Pure.
+ *
+ * True only when the repo opted in (`enabled`), at least one invariant's
+ * `appliesTo` matched the changed paths (`applicableCount`, computed by the caller
+ * with the existing glob matcher), and this is a PR-level review — build+run is
+ * too expensive for the per-commit / per-push triggers. Consumers layer their own
+ * runtime preconditions on top (local: a shell + toolchain present; hosted:
+ * static-degrade; Action: a dedicated CI job).
+ */
+export function shouldRunProbes(
+  config: InvariantsConfig,
+  applicableCount: number,
+  trigger: ReviewTrigger,
+): boolean {
+  return config.enabled && applicableCount > 0 && trigger === 'pr';
+}

--- a/test/core/invariants.test.js
+++ b/test/core/invariants.test.js
@@ -1,0 +1,101 @@
+// Tests for src/core/invariants.ts — the executable-probe invariants config + run-gate.
+// Phase R (clud-bug-app #87): an invariant is a repo-declared behavioral property with an
+// executable PROBE (a command that exits non-zero = RED when the property is violated).
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  readInvariantsConfig,
+  shouldRunProbes,
+  BUILTIN_INVARIANTS_CONFIG,
+} from '../../src/core/invariants.js';
+
+describe('readInvariantsConfig', () => {
+  it('defaults to off when no invariants block is present', () => {
+    expect(readInvariantsConfig({})).toEqual(BUILTIN_INVARIANTS_CONFIG);
+    expect(readInvariantsConfig({}).enabled).toBe(false);
+    expect(readInvariantsConfig(null)).toEqual(BUILTIN_INVARIANTS_CONFIG);
+    expect(readInvariantsConfig(undefined)).toEqual(BUILTIN_INVARIANTS_CONFIG);
+  });
+
+  it('a malformed invariants block resolves to off (a typo can never enable a cost-bearing probe)', () => {
+    expect(readInvariantsConfig({ invariants: 'yes' }).enabled).toBe(false);
+    expect(readInvariantsConfig({ invariants: 42 }).enabled).toBe(false);
+    expect(readInvariantsConfig({ invariants: 'yes' }).invariants).toEqual([]);
+  });
+
+  it('reads a bare array of valid invariants and enables when at least one is valid', () => {
+    const cfg = readInvariantsConfig({
+      invariants: [
+        { name: 'byte-parity', appliesTo: ['docs/**'], probe: 'npm run render:check', expect: 'no diff vs golden' },
+      ],
+    });
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.invariants).toEqual([
+      { name: 'byte-parity', appliesTo: ['docs/**'], probe: 'npm run render:check', expect: 'no diff vs golden' },
+    ]);
+  });
+
+  it('coerces a single-string appliesTo to an array and omits an absent expect', () => {
+    const cfg = readInvariantsConfig({
+      invariants: [{ name: 'no-token-push', appliesTo: '.github/**', probe: 'grep -rq X' }],
+    });
+    expect(cfg.invariants).toHaveLength(1);
+    expect(cfg.invariants[0].appliesTo).toEqual(['.github/**']);
+    expect(cfg.invariants[0].expect).toBeUndefined();
+  });
+
+  it('drops malformed entries (missing name, probe, or appliesTo) but keeps valid ones', () => {
+    const cfg = readInvariantsConfig({
+      invariants: [
+        { name: 'ok', appliesTo: ['a/**'], probe: 'run-a' },
+        { appliesTo: ['b/**'], probe: 'run-b' }, // no name → drop
+        { name: 'no-probe', appliesTo: ['c/**'] }, // no probe → drop
+        { name: 'no-globs', probe: 'run-d' }, // no appliesTo → drop
+        'garbage', // not an object → drop
+      ],
+    });
+    expect(cfg.invariants.map((i) => i.name)).toEqual(['ok']);
+    expect(cfg.enabled).toBe(true);
+  });
+
+  it('an array with zero VALID invariants is disabled', () => {
+    const cfg = readInvariantsConfig({ invariants: [{ probe: 'x' }, 'garbage'] });
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.invariants).toEqual([]);
+  });
+
+  it('supports a wrapper form { enabled, list } as a kill-switch that retains the invariants', () => {
+    const off = readInvariantsConfig({
+      invariants: { enabled: false, list: [{ name: 'x', appliesTo: ['a/**'], probe: 'run-x' }] },
+    });
+    expect(off.enabled).toBe(false); // explicitly disabled...
+    expect(off.invariants).toHaveLength(1); // ...but the config is retained
+
+    const on = readInvariantsConfig({
+      invariants: { enabled: true, list: [{ name: 'x', appliesTo: ['a/**'], probe: 'run-x' }] },
+    });
+    expect(on.enabled).toBe(true);
+  });
+});
+
+describe('shouldRunProbes', () => {
+  const on = { enabled: true, invariants: [{ name: 'x', appliesTo: ['a/**'], probe: 'run-x' }] };
+
+  it('runs only when enabled + at least one invariant applies + pr trigger', () => {
+    expect(shouldRunProbes(on, 1, 'pr')).toBe(true);
+  });
+
+  it('does NOT run when disabled', () => {
+    expect(shouldRunProbes(BUILTIN_INVARIANTS_CONFIG, 1, 'pr')).toBe(false);
+  });
+
+  it('does NOT run when no invariant applies to the changed paths', () => {
+    expect(shouldRunProbes(on, 0, 'pr')).toBe(false);
+  });
+
+  it('does NOT run on commit or push triggers (build+run is too expensive)', () => {
+    expect(shouldRunProbes(on, 1, 'commit')).toBe(false);
+    expect(shouldRunProbes(on, 1, 'push')).toBe(false);
+  });
+});


### PR DESCRIPTION
First slice of the review-hardening (**clud-bug-app #87** — retire the manual adversarial panel).

**What:** a new pure module `src/core/invariants.ts` (mirrors `design.ts`) that resolves an `.clud-bug.json` `invariants` block into `{ enabled, invariants[] }` and exposes `shouldRunProbes(cfg, applicableCount, trigger)` — the in-scope gate (opt-in · ≥1 invariant applies to the changed paths · pr trigger).

**Why:** the current gate grounds a finding only by quoting the exact diff line, so it structurally can't fire on an *emergent / combinatorial / cross-cutting* bug (the 3 real logmind misses in #87). An **invariant** pairs a property with an executable **probe**; RED output grounds a finding equal to a quoted line.

**Scope:** purely additive — NOT yet wired into the recipe (that's R2). Tolerant parse (bare array or a `{enabled, list}` kill-switch; malformed entries dropped; a typo can't enable a cost-bearing probe).

**Tests:** 11 new (`test/core/invariants.test.js`), full suite **913 green**, `tsc` clean. 🤖