### PR TITLE
Phase R (R3): the 'unverified' verdict — no false-green 'clean' on an unverified invariant change

### DIFF
--- a/docs/decisions-branches/phase-r3-unverified-verdict.md
+++ b/docs/decisions-branches/phase-r3-unverified-verdict.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 11:39 - Phase R3: add the 'unverified' review verdict — no 'clean' without verification on an invariant-touching change
+
+**Reasoning:** R2's severity rule already leans on this: when a MAJOR can't be reproduced (an untrusted diff the reviewer must not execute) or a probe didn't run, the outcome must NOT be a false-green 'clean'. Add 'unverified' to ReviewVerdict + deriveCheck (→ neutral: never success/false-green, never a hard block/outage on our own inability to verify) + normalizeVerdict + the recipe's post-check-run --verdict options + guidance ('do NOT post clean on an invariant-touching change you did not verify'). unverified defers to the sandboxed CI/Action probe (R6), which resolves it to clean or critical. Mirrors the existing 'failed → neutral' precedent (add signal, not outages).
+
+**Alternatives considered:** unverified → failure/blocking in strict mode (rejected: could deadlock when no local probe + no CI yet; the authoritative gate is the CI probe check, which waits on branch protection — unverified is the transient defer-to-CI signal), Reuse 'failed' for unverified (rejected: 'failed' means the review couldn't RUN; 'unverified' means it ran but couldn't confirm an invariant surface — distinct signals)
+
+**Implications:**
+- R6 wires the sandboxed CI/Action probe that turns unverified → clean/critical; the hosted prompt-builder gets a no-shell grounding adaptation next
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (4 decisions)
+## 2026-07 (5 decisions)
 
-- **2026-07-03** — Phase R2 adversarial-panel fixes: trust-gate reproduction (security), MAJOR precedence, coverage + coherence *(phase-r2-grounding-gate)* — [decisions-branches/phase-r2-grounding-gate.md](decisions-branches/phase-r2-grounding-gate.md)
-- *... 2 more decisions ...*
+- **2026-07-03** — Phase R3: add the 'unverified' review verdict — no 'clean' without verification on an invariant-touching change *(phase-r3-unverified-verdict)* — [decisions-branches/phase-r3-unverified-verdict.md](decisions-branches/phase-r3-unverified-verdict.md)
+- *... 3 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/src/cli/post-check-run.ts
+++ b/src/cli/post-check-run.ts
@@ -3,7 +3,7 @@
 // merge on those surfaces too (the hosted bot already posts it).
 //
 // Usage:
-//   clud-bug post-check-run --sha <sha> --verdict clean|critical|failed \
+//   clud-bug post-check-run --sha <sha> --verdict clean|critical|failed|unverified \
 //     [--critical-count N] [--source local|ci] [--strict|--no-strict] \
 //     [--owner O --repo R] [--details-url URL] [--dry-run]
 //

--- a/src/cli/review-prompt.ts
+++ b/src/cli/review-prompt.ts
@@ -249,9 +249,9 @@ export function renderReviewRecipe(input: {
       ? `\n\n## 5. Post the merge-gate check
 After reporting, post the self-attested \`clud-bug-review\` check so branch protection can gate on it:
 \`\`\`bash
-clud-bug post-check-run --sha "$(git rev-parse HEAD)" --verdict <clean|critical> --critical-count <N> --source local
+clud-bug post-check-run --sha "$(git rev-parse HEAD)" --verdict <clean|critical|unverified> --critical-count <N> --source local
 \`\`\`
-\`clean\` → the check passes (merge unblocked); \`critical\` → it fails when the repo is in strict mode. This is a **self-attested** local review (this session), not independent CI — post it honestly from what you actually found. Skip silently if \`gh\` lacks \`checks: write\`.`
+\`clean\` → passes (merge unblocked); \`critical\` → fails when the repo is in strict mode; \`unverified\` → neutral (does not block, but is NOT a pass) — post it when the change touched a probe/invariant surface you could not verify here (no probe ran, or a MAJOR you could not safely reproduce under execution-safety), so it defers to the sandboxed CI probe. **Do NOT post \`clean\` on an invariant-touching change you did not actually verify.** This is a **self-attested** local review (this session), not independent CI — post it honestly from what you actually found. Skip silently if \`gh\` lacks \`checks: write\`.`
       : '';
 
   // 3b (rc.15) — the OPTIONAL design-critic visual pass. Rendered only when the

--- a/src/core/check-verdict.ts
+++ b/src/core/check-verdict.ts
@@ -20,7 +20,7 @@
 export const CLUD_BUG_CHECK_NAME = 'clud-bug-review';
 
 /** Outcome of a review, as the posting surface sees it. */
-export type ReviewVerdict = 'clean' | 'critical' | 'failed';
+export type ReviewVerdict = 'clean' | 'critical' | 'failed' | 'unverified';
 
 /** The narrowed check-run conclusion set we emit. */
 export type CheckConclusion = 'success' | 'neutral' | 'failure';
@@ -75,6 +75,18 @@ export function deriveCheck(input: DeriveCheckInput): DerivedCheck {
       title = `clud-bug review — ${n}critical (advisory)`;
       summary = `${n}critical finding(s); advisory only (strict mode off) — does not block merge.${selfAttested}`;
     }
+  } else if (verdict === 'unverified') {
+    // R3 (#87) — the review ran, but an invariant/probe-touching change could not be
+    // VERIFIED here (no probe ran, or a finding could not be safely reproduced —
+    // e.g. an untrusted diff the local reviewer must not execute). It is NOT clean
+    // (never a false-green) and NOT a hard block (never an outage on our own
+    // inability to verify): a `neutral` signal that defers to an independent
+    // sandbox/CI probe, which resolves it to clean or critical.
+    conclusion = 'neutral';
+    title = 'clud-bug review — unverified';
+    summary =
+      `This change touched a probe/invariant surface that could not be verified in this review; it ` +
+      `needs independent sandbox/CI verification. Not a pass, not a block.${selfAttested}`;
   } else {
     // failed — never block on our own inability to run.
     conclusion = 'neutral';
@@ -87,7 +99,7 @@ export function deriveCheck(input: DeriveCheckInput): DerivedCheck {
 
 /** Normalize a free-form verdict string (CLI input) to a `ReviewVerdict`. */
 export function normalizeVerdict(raw: string | undefined): ReviewVerdict {
-  if (raw === 'clean' || raw === 'critical' || raw === 'failed') return raw;
+  if (raw === 'clean' || raw === 'critical' || raw === 'failed' || raw === 'unverified') return raw;
   // Unknown/empty → 'failed' (safe: neutral check, never a false-green).
   return 'failed';
 }

--- a/test/check-verdict.test.js
+++ b/test/check-verdict.test.js
@@ -25,6 +25,15 @@ describe('deriveCheck', () => {
   it('failed → neutral (never block on our own inability to run)', () => {
     expect(deriveCheck({ verdict: 'failed', strictMode: true }).conclusion).toBe('neutral');
   });
+  it('unverified → neutral (invariant-touching change we could not verify; never a false-green, never a hard block)', () => {
+    // R3 (#87): no "clean" without a green probe on an invariant-touching PR — emit unverified instead
+    expect(deriveCheck({ verdict: 'unverified', strictMode: true }).conclusion).toBe('neutral');
+    expect(deriveCheck({ verdict: 'unverified', strictMode: false }).conclusion).toBe('neutral');
+    const d = deriveCheck({ verdict: 'unverified' });
+    expect(d.conclusion).not.toBe('success'); // MUST NOT read as clean
+    expect(d.title).toMatch(/unverified/i);
+    expect(d.summary).toMatch(/verif/i);
+  });
   it('local source appends a self-attested trust note; ci does not', () => {
     expect(deriveCheck({ verdict: 'clean', source: 'local' }).summary).toMatch(/self-attested/i);
     expect(deriveCheck({ verdict: 'clean', source: 'ci' }).summary).not.toMatch(/self-attested/i);
@@ -36,6 +45,7 @@ describe('normalizeVerdict', () => {
     expect(normalizeVerdict('clean')).toBe('clean');
     expect(normalizeVerdict('critical')).toBe('critical');
     expect(normalizeVerdict('failed')).toBe('failed');
+    expect(normalizeVerdict('unverified')).toBe('unverified'); // R3 (#87)
     expect(normalizeVerdict('garbage')).toBe('failed');
     expect(normalizeVerdict(undefined)).toBe('failed');
   });


### PR DESCRIPTION
Third slice of review-hardening (**clud-bug-app #87**).

**What:** adds `unverified` to `ReviewVerdict` (`src/core/check-verdict.ts`). `deriveCheck` maps it to a **neutral** check — never `success` (no false-green), never a hard block (no outage on inability to verify). Wired through `normalizeVerdict`, the recipe's `post-check-run --verdict` options, and its guidance (*do NOT post `clean` on an invariant-touching change you didn't verify*).

**Why:** R2's severity rule already leans on it — an untrusted MAJOR the local reviewer must not execute, or a probe that didn't run, must surface as **unverified**, deferring to the sandboxed CI/Action probe (R6) that resolves it to clean/critical. Mirrors the existing `failed → neutral` precedent.

**Tests:** unverified cases for `deriveCheck` + `normalizeVerdict`; **914 green**, `tsc` clean, live `--dry-run` → `neutral`. Note: the hosted app will add an `unverified` handler at the rc.22 lockstep bump. 🤖