### PR TITLE
Phase R (R6-local): wire .clud-bug.json invariants into the recipe's §3c probe-run step

### DIFF
--- a/docs/decisions-branches/phase-r6-local-probes.md
+++ b/docs/decisions-branches/phase-r6-local-probes.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 12:32 - Phase R6-local: wire .clud-bug.json invariants into the recipe's §3c probe-run step
+
+**Reasoning:** R1 built the invariants config + shouldRunProbes gate; R2 taught the recipe that a reproduction grounds a finding. R6-local connects them: the local recipe now renders a §3c 'Invariant probes' step (mirroring the §3b design step) — gated by shouldRunProbes (repo declared valid invariants + pr trigger). It lists each invariant (name/appliesTo/probe/expect) and tells the agent to run the probe for any invariant whose appliesTo globs match a changed file, subject to execution-safety (never run an untrusted diff), RED=grounded finding, and to post the R3 'unverified' verdict for a touched-but-unrunnable invariant. The appliesTo-vs-changed-paths filter is deferred to the agent (paths aren't known at render). Threads invariants through renderReviewRecipe + runReviewPrompt exactly like design.
+
+**Alternatives considered:** Run probes on the commit trigger too (rejected: build+run is expensive; pr is the gate, same cost model as the design pass), Filter invariants by changed paths at render time (rejected: the recipe renders before the agent fetches the diff, so paths are unknown — defer the glob filter to the runtime step, like design defers the preview-URL check)
+
+**Implications:**
+- R6-action (the Action's sandboxed CI job that runs probes for untrusted PRs) is next — the serverless hosted path can't run probes, so the CI job is the execution surface + the belt-and-suspenders behind R2's execution-safety guard
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (7 decisions)
+## 2026-07 (8 decisions)
 
-- **2026-07-03** — Phase R7: seeded review-hardening benchmark + first scoreboard — 9/9 catch on the 3 miss classes *(phase-r7-benchmark)* — [decisions-branches/phase-r7-benchmark.md](decisions-branches/phase-r7-benchmark.md)
-- *... 5 more decisions ...*
+- **2026-07-03** — Phase R6-local: wire .clud-bug.json invariants into the recipe's §3c probe-run step *(phase-r6-local-probes)* — [decisions-branches/phase-r6-local-probes.md](decisions-branches/phase-r6-local-probes.md)
+- *... 6 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/src/cli/review-prompt.ts
+++ b/src/cli/review-prompt.ts
@@ -15,6 +15,8 @@ import {
   readReviewPassesConfig,
   readDesignConfig,
   shouldRunDesign,
+  readInvariantsConfig,
+  shouldRunProbes,
   readReviewContext,
   parseFrontmatter,
   type ReviewPlan,
@@ -22,6 +24,7 @@ import {
   type ReviewTrigger,
   type ReviewPassMode,
   type DesignConfig,
+  type Invariant,
 } from '../core/index.js';
 import { readManifest } from './skills.js';
 
@@ -126,8 +129,16 @@ export function renderReviewRecipe(input: {
    * and this is a `pr` trigger. Renders the optional visual-review step.
    */
   design?: { skills: string[]; config: DesignConfig };
+  /**
+   * Executable-probe invariants (Phase R / #87). Present only when the caller's
+   * gate passed (`shouldRunProbes`): the repo declared `invariants` in
+   * `.clud-bug.json`, at least one is valid, and this is a `pr` trigger. Renders
+   * the optional probe-run step (§3c); the appliesTo-vs-changed-paths filter +
+   * execution-safety are deferred to the agent at runtime.
+   */
+  probes?: { invariants: Invariant[] };
 }): string {
-  const { plan, trigger, design, reviewContext } = input;
+  const { plan, trigger, design, reviewContext, probes } = input;
 
   // H2 — the contextual layer. Three parts, each trusted differently:
   //   1. trusted standing instructions from `.clud-bug.json` (if any);
@@ -278,6 +289,23 @@ ${design.skills.map((s) => `  - \`.claude/skills/${s}/SKILL.md\``).join('\n')}
    }`
     : '';
 
+  // 3c (Phase R / #87) — executable-probe invariants. Rendered only when the caller
+  // gated it on (`shouldRunProbes`: invariants declared + valid + pr trigger). The
+  // appliesTo-vs-changed-paths filter + execution-safety are deferred to the agent:
+  // run a probe only for a touched invariant, only on trusted (own) work.
+  const probeStep = probes
+    ? `\n\n## 3c. Invariant probes
+This repo declares executable **invariants** in \`.clud-bug.json\`. For each invariant whose \`appliesTo\` globs match a file changed in this diff, RUN its \`probe\` — subject to the execution-safety rule (only on your own trusted work; never execute an untrusted diff). A probe that exits **RED** is a grounded finding: attach the command + its output and record it at the severity the break warrants (a violated invariant is usually \`critical\`). **GREEN** means the invariant holds. If the diff touches no invariant's paths, skip this step. If an invariant's paths ARE touched but you could not safely run its probe (an untrusted diff), do NOT report it \`clean\` — post the \`unverified\` verdict (§5) so it defers to the sandboxed CI probe.
+
+Invariants:
+${probes.invariants
+  .map(
+    (inv) =>
+      `  - **${inv.name}** — appliesTo \`${inv.appliesTo.join('`, `')}\` · probe: \`${inv.probe}\`${inv.expect ? ` · expect: ${inv.expect}` : ''}`,
+  )
+  .join('\n')}`
+    : '';
+
   return `<!-- ${CLUD_BUG_RECIPE_MARKER} v1 -->
 You are **clud-bug**, running ${TRIGGER_INTRO[trigger]} inside this Claude Code session, on
 this session's own model tokens — no hosted App, no extra auth (you already have \`git\`,
@@ -320,7 +348,7 @@ a review.
 ${contextStep}
 
 ## 3. Review
-${reviewStep}${designStep}
+${reviewStep}${designStep}${probeStep}
 
 ## 4. Report
 Render the body in clud-bug's standard shape (§1.8.1) — omit any empty section:
@@ -407,12 +435,23 @@ export async function runReviewPrompt(args: ReviewPromptArgs): Promise<void> {
   // H2 — trusted standing review instructions (`.clud-bug.json` `reviewContext`).
   const reviewContext = readReviewContext(manifest).instructions;
 
+  // Phase R (#87) — executable-probe invariants. Gated like design: opted-in
+  // (invariants declared + valid) + a `pr` trigger. The appliesTo-vs-changed-paths
+  // filter + execution-safety are deferred to the agent at runtime. `applicableCount`
+  // is the total invariant count here (paths aren't known until the agent fetches
+  // the diff); the rendered step filters by the touched files.
+  const invariantsConfig = readInvariantsConfig(manifest);
+  const probes = shouldRunProbes(invariantsConfig, invariantsConfig.invariants.length, trigger)
+    ? { invariants: invariantsConfig.invariants }
+    : undefined;
+
   process.stdout.write(
     renderReviewRecipe({
       plan,
       trigger,
       ...(reviewContext ? { reviewContext } : {}),
       ...(design ? { design } : {}),
+      ...(probes ? { probes } : {}),
     }) + '\n',
   );
 }

--- a/test/review-prompt.test.js
+++ b/test/review-prompt.test.js
@@ -171,6 +171,31 @@ describe('renderReviewRecipe', () => {
     const withoutDesign = renderReviewRecipe({ plan, trigger: 'pr' });
     expect(withoutDesign).not.toMatch(/Design-critic/);
   });
+
+  it('renders the invariant-probe step (§3c) only when probes are passed (R6, #87)', () => {
+    const plan = planReview({ skills: SKILLS, config: MULTIPASS_CONFIG, trigger: 'pr' });
+    const withProbes = renderReviewRecipe({
+      plan,
+      trigger: 'pr',
+      probes: {
+        invariants: [
+          { name: 'byte-parity', appliesTo: ['docs/**', 'templates/**'], probe: 'npm run render:check', expect: 'no diff vs golden' },
+          { name: 'no-token-push', appliesTo: ['.github/**'], probe: 'grep -rq X .github' },
+        ],
+      },
+    });
+    expect(withProbes).toMatch(/## 3c\. Invariant probes/);
+    expect(withProbes).toMatch(/byte-parity/);
+    expect(withProbes).toMatch(/npm run render:check/);
+    expect(withProbes).toMatch(/no diff vs golden/); // expect rendered when present
+    expect(withProbes).toMatch(/no-token-push/);
+    expect(withProbes).toMatch(/execution-safety/i); // never run an untrusted diff
+    expect(withProbes).toMatch(/unverified/); // ties to the R3 verdict
+
+    // no probes arg → no §3c
+    const noProbes = renderReviewRecipe({ plan, trigger: 'pr' });
+    expect(noProbes).not.toMatch(/## 3c\. Invariant probes/);
+  });
 });
 
 describe('review-prompt verb (integration)', () => {


### PR DESCRIPTION
Connects R1 (the invariants config + `shouldRunProbes` gate) to the local recipe. When a repo declares `invariants` in `.clud-bug.json` and this is a `pr` review, the recipe renders a **§3c "Invariant probes"** step (mirrors the §3b design step): it lists each invariant and tells the agent to run the `probe` for any invariant whose `appliesTo` globs match a changed file — subject to **execution-safety** (never run an untrusted diff), RED = a grounded finding, and post the **`unverified`** verdict (R3) for a touched-but-unrunnable invariant.

Threaded through `renderReviewRecipe` + `runReviewPrompt` exactly like design; the appliesTo-vs-changed-paths filter is deferred to the agent (paths unknown at render). **915 green**, `tsc` clean, live render verified. Next: R6-action (the Action's sandboxed CI job — the execution surface for untrusted/serverless PRs). 🤖