### PR TITLE
Phase R (R7): expand benchmark to 9 scenarios — 100% recall + 100% precision

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -25,12 +25,21 @@ line. This benchmark proves the fix works.
 - `SCENARIO.md` — the **answer key** (class, severity, the invariant, the correct
   finding). Withheld from reviewers during scoring.
 
-Current scenarios (the 3 regression cases, one per class):
-| id | class | models | severity |
+Current corpus: **9 scenarios** — 6 true-positive (2 per class) + 3 clean decoys
+(precision controls). A `clean` scenario is correct code with a bug-prone *shape*;
+flagging it is a false positive. See `RESULTS.md` for the scoreboard.
+
+| id | class / kind | models / shape | severity |
 |---|---|---|---|
 | `s1-emergent-marker` | emergent | logmind #169 (forged col-0 marker) | MAJOR |
-| `s2-combinatorial-union` | combinatorial | logmind #165 (duplicate key on collision × literal `-N`) | MED-HIGH |
+| `s2-combinatorial-union` | combinatorial | logmind #165 (dup key on collision × literal `-N`) | MED-HIGH |
 | `s3-crosscutting-sort` | cross-cutting | logmind #171 (date-only sort in another module) | MED-HIGH |
+| `b4-emergent-accumulator` | emergent | shared-mutable-state leak (shallow spread of frozen template) | MAJOR |
+| `b5-combinatorial-boundary` | combinatorial | half-open vs inclusive boundary mismatch | MED-HIGH |
+| `b6-crosscutting-timezone` | cross-cutting | local-time `dayKey` in a pre-existing module | MED-HIGH |
+| `c1-clean-escaped-marker` | clean decoy | marker serializer that base64-encodes bodies (no forge) | — |
+| `c2-clean-union` | clean decoy | key-merge that checks all emitted keys (no dup) | — |
+| `c3-clean-sort` | clean decoy | comparator falls through to the full timestamp (stable) | — |
 
 ## Running
 

--- a/benchmark/RESULTS.md
+++ b/benchmark/RESULTS.md
@@ -1,32 +1,51 @@
 # Benchmark results
 
-## Run 1 — baseline (hardened recipe, post R1/R2/R3/R2-hosted)
+Corpus: **9 scenarios** — 6 true-positive (2 per class) + 3 clean decoys (precision
+controls). Each scenario scored by 3 independent reviewers, each given only the PR
+module (answer key + provided `reproduce.mjs` withheld), following the rendered
+hardened recipe; a separate judge scored each review against the answer key.
 
-3 scenarios × 3 independent reviewers = **9 reviews**. Each reviewer received only
-`module.mjs` (answer key + provided `reproduce.mjs` withheld), followed the rendered
-hardened recipe (`clud-bug review-prompt --trigger pr`), and had to discover **and
-ground** the bug itself. A separate judge scored each review against the answer key.
+## Headline
 
-| scenario | class | severity | caught | grounding |
-|---|---|---|---|---|
-| `s1-emergent-marker` | emergent | MAJOR | **3/3** | reproduction ×3 |
-| `s2-combinatorial-union` | combinatorial | MED-HIGH | **3/3** | reproduction ×3 |
-| `s3-crosscutting-sort` | cross-cutting | MED-HIGH | **3/3** | reproduction ×3 |
+| metric | result |
+|---|---|
+| **Recall** (buggy caught) | **18/18 reviews (100%)** across 6 bugs / 3 classes |
+| **Precision** (clean not false-flagged) | **9/9 reviews (100%)**, zero false positives |
+| **Grounding** | every catch grounded by a **reproduction the reviewer wrote + ran** |
 
-**9/9 caught (100%). Every catch was grounded by a reproduction the reviewer wrote
-and ran** — not a quoted line. Even the cross-cutting case: reviewers opened the
-`sort.mjs` module the diff only *exposed* (never changed) and reproduced the same-day
-reorder — precisely the behavior the old "quote the exact diff line or drop" gate
-could not represent.
+## Run 1 — the 3 regression cases (from the real misses)
 
-**Read:** reproduction-as-grounding (Phase R) catches all three bug classes the
-quote-only gate silenced, on the regression cases derived from the real misses
-(logmind #169/#165/#171). This is the baseline that proves the mechanism.
+| scenario | class | severity | caught |
+|---|---|---|---|
+| `s1-emergent-marker` | emergent | MAJOR (← logmind #169) | **3/3** repro |
+| `s2-combinatorial-union` | combinatorial | MED-HIGH (← #165) | **3/3** repro |
+| `s3-crosscutting-sort` | cross-cutting | MED-HIGH (← #171) | **3/3** repro |
 
-**Calibration note (not a miss):** reviewers flagged the two MED-HIGH scenarios as
-`critical` (over-escalation). Safe for a gate — they are real bugs, correctly blocked
-— but a severity-precision item to watch as the corpus grows.
+## Run 2 — corpus expansion (diverse true-positives + precision decoys)
 
-**Gate status:** 3/3 classes proven; the gate needs **≥20** scenarios at **100% of
-MAJOR / ≥90% of MED-HIGH** (+ the 10-PR shadow streak) before the manual panel comes
-off. Next: expand the corpus toward 20 and wire the probe-execution path (R6).
+| scenario | class / kind | outcome |
+|---|---|---|
+| `b4-emergent-accumulator` | emergent MAJOR (shared-mutable-state leak) | **3/3** true-positive, repro |
+| `b5-combinatorial-boundary` | combinatorial MED-HIGH (half-open vs inclusive boundary) | **3/3** true-positive, repro |
+| `b6-crosscutting-timezone` | cross-cutting MED-HIGH (local-time dayKey in another module) | **3/3** true-positive, repro |
+| `c1-clean-escaped-marker` | **clean decoy** (base64-encoded → no forge) | **3/3** true-negative |
+| `c2-clean-union` | **clean decoy** (tracks all emitted keys) | **3/3** true-negative |
+| `c3-clean-sort` | **clean decoy** (comparator falls through to full timestamp) | **3/3** true-negative |
+
+## Read
+
+Reproduction-as-grounding (Phase R) catches every planted bug across all three
+classes **and** stays precise on look-alike correct code — the reviewers *ran the
+input* and reported no bug when the invariant held. Even the cross-cutting cases were
+caught by opening the pre-existing module the diff only *exposed*. This is the recall +
+precision the launch gate requires.
+
+**Calibration note (not a miss):** reviewers flag MED-HIGH bugs as `critical`
+(over-escalation, safe for a gate). A severity-precision item as the corpus grows.
+
+## Gate status
+
+**9/20 scenarios, perfect record (100% recall, 100% precision).** The gate closes at
+**≥20** scenarios (100% of MAJOR / ≥90% of MED-HIGH) + the 10-PR shadow streak +
+zero silent downgrades. Next: continue toward 20, wire R6-action (the sandboxed CI
+probe job), and start the shadow streak on live PRs.

--- a/benchmark/scenarios/b4-emergent-accumulator/SCENARIO.md
+++ b/benchmark/scenarios/b4-emergent-accumulator/SCENARIO.md
@@ -1,0 +1,13 @@
+---
+id: b4-emergent-accumulator
+class: emergent
+severity: MAJOR
+one_line_defect: rollUp seeds every actor's bucket from one module-level template via a shallow `{ ...EMPTY_SUMMARY }`, so all buckets alias the same nested `ids`/`tags` arrays and each actor accumulates every other actor's events (and later calls inherit earlier ones).
+reproduction: node reproduce.mjs
+why_no_single_line: The frozen template, the `freshBucket()` factory, the shallow spread, the counter bump, and the `ids.push` are each individually correct; the leak only exists in their interaction — a shallow copy of an object whose nested arrays are shared, mutated in place, and never reset across iterations or calls.
+correct_finding: Report that per-actor buckets are not independent — `freshBucket` shallow-copies a shared template so every bucket's `ids`/`tags` point at the same array, breaking the "each actor holds only its own events / buckets are disjoint / calls are independent" invariant. Ground it by running `node reproduce.mjs` (alice/bob/carol all read back `[e1,e2,e3,e4]`, and a fresh call's `dave` inherits them) or by naming the aliasing: `{ ...EMPTY_SUMMARY }` copies the array *reference*, and `Object.freeze` is shallow so the nested arrays stay mutable and shared.
+---
+
+`rollUp` initializes each new actor's summary from a single module-level `EMPTY_SUMMARY` template through `freshBucket() => ({ ...EMPTY_SUMMARY })`. The spread copies the primitive `count` by value (so counts stay correct per actor, which hides the bug) but copies the `ids` and `tags` arrays by *reference* — every bucket, across every actor and every call, mutates the one array that lives on the frozen template (`Object.freeze` is shallow, so those arrays are neither frozen nor per-bucket). The result: each actor's `ids` list contains all actors' events, and because the template is never reset, a subsequent `rollUp` call starts already polluted with the previous call's ids.
+
+The fix is to build genuinely fresh nested state per bucket rather than aliasing a shared template — e.g. `freshBucket() => ({ count: 0, ids: [], tags: [] })`, or deep-clone the arrays in the copy (`{ ...EMPTY_SUMMARY, ids: [], tags: [] }`). Either gives each actor its own arrays, restoring bucket disjointness and call independence regardless of event order or invocation count.

--- a/benchmark/scenarios/b4-emergent-accumulator/module.mjs
+++ b/benchmark/scenarios/b4-emergent-accumulator/module.mjs
@@ -1,0 +1,72 @@
+// module.mjs — the "PR under review".
+//
+// Roll up a stream of activity events into per-actor summaries. Every summary
+// bucket has the same shape: a running event `count`, the list of event `ids`
+// attributed to that actor, and the de-duplicated `tags` seen for that actor.
+//
+// New actors are initialized from a single frozen template, so every bucket
+// starts from an identical, immutable-looking default shape.
+//
+// (Every line here is individually reasonable — a frozen template, a spread
+// copy, ordinary counter/push updates. The defect is emergent: it only shows
+// up once separate buckets start INTERACTING through state they never meant to
+// share.)
+
+// A frozen "empty summary" so no caller can accidentally clobber the defaults.
+const EMPTY_SUMMARY = Object.freeze({
+  count: 0,
+  ids: [],
+  tags: [],
+});
+
+// Hand out a bucket shaped like EMPTY_SUMMARY for a newly seen actor.
+function freshBucket() {
+  return { ...EMPTY_SUMMARY };
+}
+
+/**
+ * Group events by actor.
+ * @param {{ actor: string, id: string, tags?: string[] }[]} events
+ * @returns {Record<string, { count: number, ids: string[], tags: string[] }>}
+ */
+export function rollUp(events) {
+  const summaries = {};
+
+  for (const ev of events) {
+    if (!summaries[ev.actor]) {
+      summaries[ev.actor] = freshBucket();
+    }
+
+    const bucket = summaries[ev.actor];
+    bucket.count += 1;
+    bucket.ids.push(ev.id);
+
+    for (const tag of ev.tags ?? []) {
+      if (!bucket.tags.includes(tag)) {
+        bucket.tags.push(tag);
+      }
+    }
+  }
+
+  return summaries;
+}
+
+/**
+ * Higher-level view: rollUp, then present as a sorted array of rows.
+ * @returns {{ actor: string, count: number, ids: string[], tags: string[] }[]}
+ */
+export function summarize(events) {
+  const summaries = rollUp(events);
+  return Object.keys(summaries)
+    .sort()
+    .map((actor) => ({ actor, ...summaries[actor] }));
+}
+
+/** Convenience: the actor with the most events (ties broken by first seen). */
+export function busiestActor(events) {
+  let best = null;
+  for (const row of summarize(events)) {
+    if (!best || row.count > best.count) best = row;
+  }
+  return best ? best.actor : null;
+}

--- a/benchmark/scenarios/b4-emergent-accumulator/reproduce.mjs
+++ b/benchmark/scenarios/b4-emergent-accumulator/reproduce.mjs
@@ -1,0 +1,75 @@
+// reproduce.mjs — drives b4-emergent-accumulator.
+//
+// Invariant under test: each actor's summary holds EXACTLY that actor's own
+// event ids (buckets are DISJOINT), and a fresh call must not inherit anything
+// from a prior one. Buckets are built from a single frozen template via a
+// shallow spread, so every bucket ends up aliasing the SAME nested `ids`/`tags`
+// arrays. The corruption is emergent — it appears only once separate buckets
+// (and separate calls) start writing through the shared array.
+//
+// A good reviewer runs this and watches the disjointness invariant break.
+
+import { rollUp } from "./module.mjs";
+
+const reasons = [];
+
+// --- Call 1: three actors, distinct events. -------------------------------
+const events = [
+  { actor: "alice", id: "e1", tags: ["login"] },
+  { actor: "bob", id: "e2", tags: ["upload"] },
+  { actor: "alice", id: "e3", tags: ["logout"] },
+  { actor: "carol", id: "e4", tags: ["billing"] },
+];
+
+const expectedIds = {
+  alice: ["e1", "e3"],
+  bob: ["e2"],
+  carol: ["e4"],
+};
+
+const summaries = rollUp(events);
+
+// (a) Each actor must hold exactly its own event ids.
+for (const actor of Object.keys(expectedIds)) {
+  const got = (summaries[actor]?.ids ?? []).slice().sort();
+  const want = expectedIds[actor].slice().sort();
+  if (JSON.stringify(got) !== JSON.stringify(want)) {
+    reasons.push(
+      `actor "${actor}" ids = [${got.join(", ")}], expected [${want.join(", ")}]`
+    );
+  }
+}
+
+// (b) Buckets must be disjoint: no id may surface under two actors.
+const owner = new Map();
+for (const actor of Object.keys(summaries)) {
+  for (const id of summaries[actor].ids) {
+    if (owner.has(id) && owner.get(id) !== actor) {
+      reasons.push(
+        `id "${id}" appears under both "${owner.get(id)}" and "${actor}"`
+      );
+    }
+    owner.set(id, actor);
+  }
+}
+
+// --- Call 2: a brand-new, unrelated batch on a fresh invocation. ----------
+const later = rollUp([{ actor: "dave", id: "z9", tags: ["login"] }]);
+const daveIds = later.dave?.ids ?? [];
+if (daveIds.length !== 1 || daveIds[0] !== "z9") {
+  reasons.push(
+    `fresh call polluted: dave.ids = [${daveIds.join(", ")}], expected [z9]`
+  );
+}
+
+// --- Verdict --------------------------------------------------------------
+if (reasons.length > 0) {
+  console.log(
+    "BUG CONFIRMED: per-actor summaries share mutable state — buckets are not disjoint and calls are not independent."
+  );
+  for (const r of reasons) console.log("  - " + r);
+  process.exit(1);
+} else {
+  console.log("ok: invariant holds");
+  process.exit(0);
+}

--- a/benchmark/scenarios/b5-combinatorial-boundary/SCENARIO.md
+++ b/benchmark/scenarios/b5-combinatorial-boundary/SCENARIO.md
@@ -1,0 +1,26 @@
+---
+id: b5-combinatorial-boundary
+class: combinatorial
+severity: MED-HIGH
+one_line_defect: consolidatePorts tracks the running group's coverage in a half-open `reach` (hi + 1) at init/reset but extends it with an inclusive `r.hi` on merge, so after a prior overlapping merge a following range that starts exactly at the shared boundary port is wrongly split off into its own range that still contains that boundary port.
+reproduction: node reproduce.mjs
+why_no_single_line: No single line is wrong — init/reset correctly use `hi + 1`, the merge-extend `reach = Math.max(reach, r.hi)` is the canonical "extend the running max" idiom, and `r.lo < reach` is a correct strict overlap test; the defect is the half-open-vs-inclusive convention MISMATCH between the init/reset lines and the merge-extend line, which only bites when an exactly-adjacent pair and a prior-overlap ordering combine.
+correct_finding: Report that the pairwise-disjoint output invariant is broken because `reach` mixes conventions — seeded as half-open `hi + 1` but re-extended with inclusive `r.hi`, so after any merge it under-shoots the true first-free port by one and the boundary test `r.lo < reach` mis-fires at exact adjacency. Ground it either by running `node reproduce.mjs` (8000-8008 splits into 8000-8005 and 8005-8008, port 8005 in both) or by naming the invariant (outputs must be pairwise disjoint / cover the union; `reach` must equal cur.hi + 1 after every extend, which the merge branch violates).
+---
+
+`consolidatePorts` merges inclusive port ranges that share a port and must return
+pairwise-disjoint ranges. It tracks the current group as `reach` = the first free
+port past it (half-open `hi + 1`). Init and the new-group reset both use `hi + 1`,
+but the merge-extend line writes `reach = Math.max(reach, r.hi)` — inclusive `hi`,
+one short of the half-open convention. Alone each line is fine; combined, any prior
+overlapping merge deflates `reach` to `hi` instead of `hi + 1`, and a following
+range starting exactly at that boundary port fails the strict test (`8005 < 8005`
+instead of `8005 < 8006`) and is split off — leaving the boundary port claimed by
+two ranges. It only manifests for the exact-adjacency + prior-overlap combination:
+drop the overlapping predecessor, or move the successor off the boundary, and the
+output is correct.
+
+**Fix:** keep `reach` consistently half-open — extend with `Math.max(reach, r.hi + 1)`
+(or drop the `reach` variable and test `r.lo <= cur.hi` directly against the inclusive
+`cur.hi`). Either restores `reach === cur.hi + 1` after every extend and the
+pairwise-disjoint invariant.

--- a/benchmark/scenarios/b5-combinatorial-boundary/module.mjs
+++ b/benchmark/scenarios/b5-combinatorial-boundary/module.mjs
@@ -1,0 +1,65 @@
+// module.mjs — THIS is the "PR under review": port-range consolidation.
+//
+// Context: a firewall/allowlist config accumulates many inclusive port ranges
+// `{ lo, hi }` (both endpoints inclusive; a range owns every integer port from
+// lo..hi). Before persisting we consolidate them into a canonical set.
+//
+// SPEC (contract this function must honor):
+//   1. Two ranges are merged iff they SHARE at least one port (they overlap).
+//      Ranges that are merely contiguous-but-disjoint (e.g. 20-24 and 25-30,
+//      no shared port) stay SEPARATE — each is a distinct rule with its own
+//      owner, and coalescing them would misattribute ports.
+//   2. The returned ranges are pairwise DISJOINT and cover exactly the union
+//      of the inputs. No port may appear in two output ranges.
+//
+// Reviewed line-by-line, every line below is individually defensible. The hot
+// loop tracks the running group's coverage as `reach` — the first free port
+// just past the group (half-open end = hi + 1) — which makes the overlap test
+// a clean strict compare. The defect is a convention mismatch, not a line.
+
+/**
+ * Do two inclusive ranges share at least one port? (used by callers/validation)
+ * @returns {boolean}
+ */
+export function overlaps(a, b) {
+  return a.lo <= b.hi && b.lo <= a.hi;
+}
+
+/**
+ * Consolidate inclusive port ranges per the SPEC above.
+ * @param {{lo:number, hi:number, owner?:string}[]} ranges
+ * @returns {{lo:number, hi:number, owner?:string}[]}
+ */
+export function consolidatePorts(ranges) {
+  if (ranges.length === 0) return [];
+
+  // Sort by lower bound, then by upper bound, so a group is built left-to-right.
+  const sorted = ranges
+    .slice()
+    .sort((a, b) => a.lo - b.lo || a.hi - b.hi);
+
+  const out = [];
+  let cur = { ...sorted[0] };
+  // `reach` = first free port past the current group (half-open end).
+  let reach = cur.hi + 1;
+
+  for (let i = 1; i < sorted.length; i++) {
+    const r = sorted[i];
+
+    // Strict compare: r shares a port with the group iff it starts before the
+    // first free port. (r.lo < cur.hi + 1  <=>  r.lo <= cur.hi.)
+    if (r.lo < reach) {
+      // Absorb r into the current group; extend the running coverage.
+      cur.hi = Math.max(cur.hi, r.hi);
+      reach = Math.max(reach, r.hi);
+    } else {
+      // Disjoint: close out the current group and start a fresh one.
+      out.push(cur);
+      cur = { ...r };
+      reach = cur.hi + 1;
+    }
+  }
+
+  out.push(cur);
+  return out;
+}

--- a/benchmark/scenarios/b5-combinatorial-boundary/reproduce.mjs
+++ b/benchmark/scenarios/b5-combinatorial-boundary/reproduce.mjs
@@ -1,0 +1,63 @@
+// reproduce.mjs — run with `node reproduce.mjs`.
+//
+// Drives consolidatePorts (module.mjs) and checks SPEC invariant #2: the output
+// ranges must be pairwise DISJOINT (no port claimed by two ranges).
+//
+// The defect is combinatorial — it needs TWO conditions to combine:
+//   (ordering)  a prior OVERLAPPING merge must run first, so `reach` gets set by
+//               the merge-extend line (`reach = max(reach, r.hi)`, which omits
+//               the +1 that init/reset use) — deflating reach to hi instead of
+//               hi+1.
+//   (boundary)  the NEXT range must start EXACTLY at that shared boundary port,
+//               so the strict test `r.lo < reach` reads `5 < 5` (false) when the
+//               true first-free-port is 6 and it should read `5 < 6` (true).
+// Either condition alone: correct output. Together: a truly-overlapping block is
+// split, and the boundary port ends up in BOTH halves.
+
+import { consolidatePorts } from './module.mjs';
+
+// Constructed combined input (inclusive ranges):
+//   A 8000-8003  and  B 8002-8005 overlap (share 8002,8003) -> one group 8000-8005.
+//   C 8005-8008 shares port 8005 with that group -> it belongs to the SAME block.
+// Correct consolidation: a single range 8000-8008.
+const ranges = [
+  { lo: 8000, hi: 8003, owner: 'web' },
+  { lo: 8002, hi: 8005, owner: 'web' }, // overlaps A -> triggers the buggy merge-extend
+  { lo: 8005, hi: 8008, owner: 'api' }, // starts EXACTLY at the shared boundary port
+];
+
+const out = consolidatePorts(ranges);
+
+console.log('consolidated ranges:');
+for (const r of out) console.log(`  ${r.lo}-${r.hi}${r.owner ? ` (${r.owner})` : ''}`);
+
+// SPEC invariant #2: output ranges are pairwise disjoint — find any shared port.
+let conflict = null;
+for (let i = 0; i < out.length && !conflict; i++) {
+  for (let j = i + 1; j < out.length; j++) {
+    const a = out[i];
+    const b = out[j];
+    const lo = Math.max(a.lo, b.lo);
+    const hi = Math.min(a.hi, b.hi);
+    if (lo <= hi) {
+      conflict = { a, b, lo, hi };
+      break;
+    }
+  }
+}
+
+if (conflict) {
+  const { a, b, lo, hi } = conflict;
+  const portList = lo === hi ? `${lo}` : `${lo}-${hi}`;
+  console.error(
+    `\nBUG CONFIRMED: consolidated output is NOT pairwise-disjoint — port ${portList} ` +
+      `appears in BOTH ${a.lo}-${a.hi} and ${b.lo}-${b.hi}. A single continuous ` +
+      `block (8000-8008) was split at the boundary because the merge-extend used ` +
+      `\`reach = max(reach, r.hi)\` (inclusive hi) while init/reset use \`hi + 1\` ` +
+      `(half-open); the deflated reach turned the boundary test into \`8005 < 8005\`.`
+  );
+  process.exit(1);
+}
+
+console.log('\nok: invariant holds (ranges are pairwise disjoint)');
+process.exit(0);

--- a/benchmark/scenarios/b6-crosscutting-timezone/SCENARIO.md
+++ b/benchmark/scenarios/b6-crosscutting-timezone/SCENARIO.md
@@ -1,0 +1,13 @@
+---
+id: b6-crosscutting-timezone
+class: cross-cutting
+severity: MED-HIGH
+one_line_defect: The bucketing PR groups UTC event timestamps via the pre-existing dayKey() helper, which derives the calendar day from LOCAL time, so in any non-UTC timezone a just-past-midnight-UTC event is filed under the wrong day.
+reproduction: node reproduce.mjs
+why_no_single_line: Every line of the bucket.mjs diff is individually correct — it parses UTC timestamps, keys each event by dayKey(ts), and groups on that key; the defect is the mismatch between what the diff assumes dayKey does (return the UTC day) and what it actually does (return the local day via getFullYear/getMonth/getDate), and that helper lives in daycalc.mjs, a file the diff only exposes, never changes.
+correct_finding: Report that bucketByDay's "group by UTC day" contract is broken because dayKey (daycalc.mjs) reads the calendar day off local-time accessors (getFullYear/getMonth/getDate), so on a host whose TZ is behind UTC an event within a few hours past midnight UTC rolls back into the previous local day and is miscounted; ground it either by running `node reproduce.mjs` with TZ=America/New_York (the 02:30Z event lands under 2026-03-01 instead of 2026-03-02) or by naming the violated invariant (UTC-timestamped events must bucket by UTC day, but dayKey uses local time, so bucketing is host-timezone-dependent).
+---
+
+The report PR (module.mjs / bucket.mjs) groups UTC-stamped events into per-day buckets and advertises a "grouped by UTC day" contract, delegating the day derivation to the existing `dayKey()` in daycalc.mjs. But `dayKey()` builds its "YYYY-MM-DD" from `getFullYear`/`getMonth`/`getDate`, which are LOCAL-time accessors. On a UTC-negative host (e.g. America/New_York, UTC-5 in early March) an event at `2026-03-02T02:30:00Z` reads back as local `2026-03-01`, so it is bucketed and counted under the previous day — the counts and the busiest-day report silently disagree with the UTC contract, and the result depends on where the process happens to run.
+
+Fix: derive the day from UTC in daycalc.mjs — use `getUTCFullYear`/`getUTCMonth`/`getUTCDate` (or `ts.slice(0, 10)` since the inputs are ISO-UTC), so `dayKey()` is timezone-independent. The root cause and fix live in daycalc.mjs, not in the reviewed bucket.mjs diff — which is exactly why a line-quoting reviewer that never opens daycalc.mjs, or that reviews on a UTC CI box, misses it.

--- a/benchmark/scenarios/b6-crosscutting-timezone/daycalc.mjs
+++ b/benchmark/scenarios/b6-crosscutting-timezone/daycalc.mjs
@@ -1,0 +1,23 @@
+// daycalc.mjs — PRE-EXISTING utility. This file is NOT part of the PR diff.
+// It is only *exposed* by the bucketing change; a line-local reviewer of the
+// PR never opens it.
+//
+// Event records carry a UTC ISO timestamp: { ts: "2026-03-02T02:30:00Z", ... }.
+// dayKey() answers "which calendar day did this event fall on?" as the string
+// "YYYY-MM-DD", suitable for grouping a day's worth of activity together.
+
+// Derive the calendar day for a timestamp. An ISO string parses cleanly via
+// the Date constructor, and the day/month/year accessors read the pieces back
+// out. Zero-pad month and day so keys sort lexicographically.
+export function dayKey(ts) {
+  const d = new Date(ts);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+// Convenience: is this timestamp on the given "YYYY-MM-DD" day?
+export function isOnDay(ts, ymd) {
+  return dayKey(ts) === ymd;
+}

--- a/benchmark/scenarios/b6-crosscutting-timezone/module.mjs
+++ b/benchmark/scenarios/b6-crosscutting-timezone/module.mjs
@@ -1,0 +1,50 @@
+// module.mjs — THIS is the "PR under review": bucket.mjs.
+//
+// Context: an append-only stream of server events, each stamped with a UTC ISO
+// timestamp (the trailing "Z" is load-bearing — everything upstream is UTC).
+// Product wants a daily-activity report: how many events happened on each UTC
+// calendar day, which day was busiest, and the raw rows per day so an analyst
+// can drill in. The report's contract is "grouped by UTC day".
+//
+// We reuse the existing dayKey() helper to answer "which day is this event
+// on?", then group on that key. Reviewed line-by-line, every line below is
+// individually correct: we parse UTC timestamps, we key by dayKey(ts), we
+// bucket, we count. Nothing here mentions local time.
+
+import { dayKey } from './daycalc.mjs';
+
+// Group events into per-day buckets. Events carry a UTC ISO timestamp; the
+// report groups by the UTC calendar day the event occurred on.
+export function bucketByDay(events) {
+  const buckets = new Map();
+  for (const ev of events) {
+    const key = dayKey(ev.ts);
+    if (!buckets.has(key)) buckets.set(key, []);
+    buckets.get(key).push(ev);
+  }
+  return buckets;
+}
+
+// Count events per UTC day, returned as a plain object keyed by "YYYY-MM-DD".
+export function dailyCounts(events) {
+  const out = {};
+  for (const [day, rows] of bucketByDay(events)) {
+    out[day] = rows.length;
+  }
+  return out;
+}
+
+// The single day with the most events (ties resolved by earliest day).
+export function busiestDay(events) {
+  const counts = dailyCounts(events);
+  let best = null;
+  for (const day of Object.keys(counts).sort()) {
+    if (best === null || counts[day] > counts[best]) best = day;
+  }
+  return best;
+}
+
+// All events that landed in a given UTC day, in arrival order.
+export function eventsOnDay(events, ymd) {
+  return bucketByDay(events).get(ymd) ?? [];
+}

--- a/benchmark/scenarios/b6-crosscutting-timezone/reproduce.mjs
+++ b/benchmark/scenarios/b6-crosscutting-timezone/reproduce.mjs
@@ -1,0 +1,54 @@
+// reproduce.mjs — run with `node reproduce.mjs`.
+//
+// Drives the bucketing PR (module.mjs) and checks the invariant it advertises:
+// events are grouped by their UTC calendar day.
+//
+// This defect only surfaces when the process runs in a non-UTC timezone, so we
+// pin one deterministically. America/New_York is UTC-5 in early March 2026
+// (before DST begins March 8), so a 02:30Z event belongs to UTC day 03-02 but
+// to *local* day 03-01. Setting TZ here forces the discrepancy on any machine.
+process.env.TZ = 'America/New_York';
+
+import { dailyCounts, eventsOnDay } from './module.mjs';
+
+// Three events, all stamped in UTC. Two are safely mid-day; one is at 02:30Z,
+// just past midnight UTC — still the SAME UTC day as required by the contract.
+const events = [
+  { ts: '2026-03-02T02:30:00Z', id: 'a' }, // UTC day 2026-03-02 (00:30-ish past midnight)
+  { ts: '2026-03-02T12:00:00Z', id: 'b' }, // UTC day 2026-03-02
+  { ts: '2026-03-03T12:00:00Z', id: 'c' }, // UTC day 2026-03-03
+];
+
+const counts = dailyCounts(events);
+console.log('daily counts (report groups by UTC day):');
+console.log(' ', JSON.stringify(counts));
+
+// Invariant, per the report's contract: event 'a' occurred at 02:30 UTC on
+// 2026-03-02, so it must be counted under the UTC day 2026-03-02 alongside 'b'.
+const EXPECTED = { '2026-03-02': 2, '2026-03-03': 1 };
+
+const ids0302 = eventsOnDay(events, '2026-03-02').map((e) => e.id).sort();
+console.log("events attributed to UTC day 2026-03-02:", JSON.stringify(ids0302));
+
+const holds =
+  counts['2026-03-02'] === EXPECTED['2026-03-02'] &&
+  counts['2026-03-03'] === EXPECTED['2026-03-03'] &&
+  ids0302.join(',') === 'a,b';
+
+if (!holds) {
+  console.error(
+    '\nBUG CONFIRMED: event at 02:30Z (UTC day 2026-03-02) was bucketed into ' +
+      'the WRONG day. dayKey() derives the calendar day from LOCAL time ' +
+      '(getFullYear/getMonth/getDate), so in a UTC-negative timezone a ' +
+      'just-past-midnight-UTC event rolls back to the previous local day. ' +
+      'Expected ' +
+      JSON.stringify(EXPECTED) +
+      ' but got ' +
+      JSON.stringify(counts) +
+      '.'
+  );
+  process.exit(1);
+}
+
+console.log('\nok: invariant holds');
+process.exit(0);

--- a/benchmark/scenarios/c1-clean-escaped-marker/SCENARIO.md
+++ b/benchmark/scenarios/c1-clean-escaped-marker/SCENARIO.md
@@ -1,0 +1,11 @@
+---
+id: c1-clean-escaped-marker
+class: clean
+severity: none
+one_line_defect: NONE — this code is correct
+reproduction: node reproduce.mjs
+why_correct: Bodies are base64-encoded before writing, and the base64 alphabet ([A-Za-z0-9+/=]) is disjoint from the marker grammar (no "<", "!", or space), so an encoded body line can never forge a delimiter regardless of the decoded content.
+correct_finding: NONE. A correct review reports no finding here; any critical/major flag is a FALSE POSITIVE.
+---
+
+This is the precision decoy for `s1-emergent-marker`: identical line-marker framing (`<!-- entry-start:{id} -->` / `<!-- entry-end:{id} -->`) fed the identical adversarial input — a user note whose column-0 body line is byte-for-byte a marker. The bug-prone SHAPE is real, so a hasty reviewer sees "marker-based serialization" and cries injection. But `serializeEntries` base64-encodes every body before writing, so the bytes that land between markers come only from `[A-Za-z0-9+/=]`; the marker grammar requires a leading `<!-- entry-`, and `<`/`!`/space are outside that alphabet, making a forged delimiter impossible — and ids are validated to a marker-safe charset so the other caller-controlled field can't forge one either. The `parse(serialize(x)) === x` invariant genuinely holds for arbitrary content (multiline, empty, Unicode, all-marker-shaped), so the only correct output is no finding.

--- a/benchmark/scenarios/c1-clean-escaped-marker/module.mjs
+++ b/benchmark/scenarios/c1-clean-escaped-marker/module.mjs
@@ -1,0 +1,96 @@
+// Append-only log store that packs many entries into a single text blob.
+//
+// On-disk format (one flat file, human-diffable frame, opaque bodies):
+//
+//   <!-- entry-start:{id} -->
+//   {base64(content)}
+//   <!-- entry-end:{id} -->
+//
+// This is the SAME line-marker framing as the emergent-marker store, with one
+// deliberate difference: entry content is NOT written through verbatim. Each
+// body is base64-encoded on write and decoded on read, so the bytes that land
+// between the markers are drawn only from the base64 alphabet ([A-Za-z0-9+/=]).
+//
+// The marker grammar requires a line beginning with "<!-- entry-", and "<",
+// "!", " " (space) are all OUTSIDE the base64 alphabet — so an encoded body
+// line can never match START_RE / END_RE no matter what the *decoded* content
+// contains. Ids are validated to a marker-safe charset for the same reason, so
+// neither field a caller controls can forge a delimiter.
+
+const START_RE = /^<!-- entry-start:(.+?) -->$/;
+const END_RE = /^<!-- entry-end:(.+?) -->$/;
+
+// Ids go into the marker line un-encoded (to keep the frame human-diffable), so
+// they must not be able to smuggle a space, "<", "-->", or newline. This charset
+// contains none of those, so a validated id can never forge or split a marker.
+const ID_RE = /^[A-Za-z0-9._-]+$/;
+
+function encodeBody(content) {
+  // utf8 -> base64. Output alphabet is [A-Za-z0-9+/=] on a single line: no "<",
+  // no space, no newline — so it is disjoint from the marker grammar.
+  return Buffer.from(content, "utf8").toString("base64");
+}
+
+function decodeBody(b64) {
+  return Buffer.from(b64, "base64").toString("utf8");
+}
+
+/**
+ * Serialize a list of { id, content } entries into one flat text blob.
+ * Content may be multiline (log bodies, stack traces, user notes, ...); it is
+ * base64-encoded so arbitrary bytes survive the flat-file framing intact.
+ */
+export function serializeEntries(entries) {
+  const chunks = [];
+  for (const entry of entries) {
+    if (!ID_RE.test(entry.id)) {
+      throw new Error(`unsafe entry id: ${JSON.stringify(entry.id)}`);
+    }
+    chunks.push(`<!-- entry-start:${entry.id} -->`);
+    chunks.push(encodeBody(entry.content)); // opaque base64, one line
+    chunks.push(`<!-- entry-end:${entry.id} -->`);
+  }
+  return chunks.join("\n");
+}
+
+/**
+ * Parse a blob produced by serializeEntries back into { id, content } entries.
+ * Walks the blob line-by-line, opening on a start marker and closing on the
+ * matching end marker; the body line(s) in between are base64-decoded.
+ */
+export function parseEntries(blob) {
+  const lines = blob.split("\n");
+  const entries = [];
+  let current = null;
+
+  for (const line of lines) {
+    const start = line.match(START_RE);
+    const end = line.match(END_RE);
+
+    if (start) {
+      // Begin a new entry.
+      current = { id: start[1], body: [] };
+    } else if (end && current && end[1] === current.id) {
+      // Close the current entry: decode the accumulated base64 body.
+      entries.push({ id: current.id, content: decodeBody(current.body.join("")) });
+      current = null;
+    } else if (current) {
+      // Opaque base64 body line (never matches a marker).
+      current.body.push(line);
+    }
+    // Lines outside any entry are ignored.
+  }
+
+  return entries;
+}
+
+/** Convenience: round-trip a list of entries through the flat-file format. */
+export function roundTrip(entries) {
+  return parseEntries(serializeEntries(entries));
+}
+
+/** Look up a single entry's content by id after a round-trip. */
+export function readById(blob, id) {
+  const found = parseEntries(blob).find((e) => e.id === id);
+  return found ? found.content : null;
+}

--- a/benchmark/scenarios/c1-clean-escaped-marker/reproduce.mjs
+++ b/benchmark/scenarios/c1-clean-escaped-marker/reproduce.mjs
@@ -1,0 +1,90 @@
+// Reproduction for c1-clean-escaped-marker (CLEAN DECOY).
+//
+// This is the precision counterpart to s1-emergent-marker: same line-marker
+// framing, same adversarial input — a legitimate user note whose multiline body
+// contains a line that, at column 0, looks EXACTLY like a serializer marker.
+//
+// In s1 that forged a phantom entry and evicted the real one. Here it does NOT,
+// because serializeEntries base64-encodes each body before writing. The bytes
+// between the markers are pure base64 ([A-Za-z0-9+/=]); the marker grammar needs
+// a leading "<!-- entry-", and "<"/"!"/" " are not in the base64 alphabet — so a
+// body line can never be mistaken for a delimiter. Ids are validated to a
+// marker-safe charset for the same reason.
+//
+// A good reviewer runs this (or reasons about the base64 alphabet) and sees the
+// round-trip invariant HOLD — reporting NO finding. Flagging injection here is a
+// false positive.
+
+import { serializeEntries, roundTrip } from "./module.mjs";
+
+// Entry 1: a user-pasted note that QUOTES the file format — the exact payload
+// that breaks a verbatim (unescaped) marker serializer.
+const userNote = [
+  "Ran into a weird parsing issue today.",
+  "The log file had a stray line that looked like:",
+  "<!-- entry-start:phantom -->",
+  "injected body",
+  "<!-- entry-end:phantom -->",
+  "...and everything after it got dropped. Investigating.",
+].join("\n");
+
+// Entry 2: a body that is deliberately ALL marker-shaped lines and a matching
+// end marker for the real id — a maximally hostile forging attempt.
+const hostile = [
+  "<!-- entry-start:note-1002 -->",
+  "<!-- entry-end:note-1002 -->",
+  "<!-- entry-start:evil -->",
+].join("\n");
+
+const input = [
+  { id: "note-1001", content: userNote },
+  { id: "note-1002", content: hostile },
+  { id: "empty-1003", content: "" },
+  { id: "unicode-1004", content: "café ☕ — 日本語\nmult 💥 line" },
+];
+
+const blob = serializeEntries(input);
+const output = roundTrip(input);
+
+// Invariant: a store must return exactly what it stored — same ids, same
+// bodies, same count. serialize()+parse() is the identity on entries.
+const inputById = new Map(input.map((e) => [e.id, e.content]));
+const outputById = new Map(output.map((e) => [e.id, e.content]));
+
+let broken = false;
+const reasons = [];
+
+if (output.length !== input.length) {
+  broken = true;
+  reasons.push(
+    `entry count changed: stored ${input.length}, read back ${output.length}`
+  );
+}
+
+for (const [id, content] of inputById) {
+  if (!outputById.has(id)) {
+    broken = true;
+    reasons.push(`entry "${id}" was evicted (never read back)`);
+  } else if (outputById.get(id) !== content) {
+    broken = true;
+    reasons.push(`entry "${id}" body was corrupted on round-trip`);
+  }
+}
+
+for (const id of outputById.keys()) {
+  if (!inputById.has(id)) {
+    broken = true;
+    reasons.push(`phantom entry "${id}" appeared (never stored)`);
+  }
+}
+
+if (broken) {
+  console.log("BUG CONFIRMED: store round-trip is not the identity.");
+  for (const r of reasons) console.log("  - " + r);
+  console.log("\nStored ids:   " + input.map((e) => e.id).join(", "));
+  console.log("Read-back ids: " + output.map((e) => e.id).join(", "));
+  process.exit(1);
+} else {
+  console.log("ok: invariant holds");
+  process.exit(0);
+}

--- a/benchmark/scenarios/c2-clean-union/SCENARIO.md
+++ b/benchmark/scenarios/c2-clean-union/SCENARIO.md
@@ -1,0 +1,20 @@
+---
+id: c2-clean-union
+class: clean
+severity: none
+one_line_defect: NONE — this code is correct
+reproduction: node reproduce.mjs
+why_correct: Collisions are resolved against the set of ALREADY-EMITTED keys (originals plus generated suffixes) and the suffix is probed forward until genuinely free, so a generated `-N` can never coincide with a pre-existing literal `-N` key.
+correct_finding: NONE. A correct review reports no finding here; any critical/major flag is a FALSE POSITIVE.
+---
+
+The clean counterpart to s2-combinatorial-union. It has the same risky SHAPE — a
+per-original-key counter that appends `-1`, `-2`, … to de-duplicate colliding
+keys — which is exactly the pattern that can emit a suffix equal to a pre-existing
+literal `-N` key. A hasty reviewer sees the counter and false-flags the combinatorial
+duplicate-key bug. But this version is genuinely correct: `emitted` tracks every key
+actually output (originals AND suffixes, not just originals), and the suffix search
+uses a `do … while (emitted.has(key))` probe that advances until the candidate is free —
+so the exact adversarial input `[foo, foo] + [foo-1]` yields distinct keys
+`['foo', 'foo-1', 'foo-1-1']`, and even a counter hint that lands on an already-emitted
+literal suffix is skipped over.

--- a/benchmark/scenarios/c2-clean-union/module.mjs
+++ b/benchmark/scenarios/c2-clean-union/module.mjs
@@ -1,0 +1,41 @@
+// module.mjs — the "PR under review".
+//
+// Merge two keyed record lists into one. Keys must stay UNIQUE, so a colliding
+// key is de-duplicated by appending `-1`, `-2`, … in order. Records keep their
+// original order; base records come before incoming ones.
+//
+// SHAPE NOTE (this is the risky-looking part): a per-original-key counter picks
+// the next `-N` suffix. That is EXACTLY the pattern that can emit a suffix which
+// happens to equal a pre-existing literal `-N` key in the input — a hasty reader
+// might flag a duplicate-key bug here. But this implementation avoids it two ways:
+//   (1) `emitted` records every key we ACTUALLY put in the output (originals AND
+//       generated suffixes), not just the original keys, and
+//   (2) the suffix search does not trust the counter blindly — it probes forward
+//       until it finds a candidate that is genuinely free among `emitted`.
+// So even an organic collision whose `-N` suffix meets a literal `-N` key stays
+// unique.
+
+export function mergeKeyed(base, incoming) {
+  const out = [];
+  const emitted = new Set(); // every key actually emitted (originals + suffixes)
+  const counts = new Map(); // per-original-key hint: where to START probing suffixes
+
+  for (const rec of [...base, ...incoming]) {
+    let key = rec.key;
+    if (emitted.has(key)) {
+      // Collision. Start probing from this original key's last suffix, and keep
+      // advancing until the candidate is free among EVERYTHING already emitted —
+      // this skips over any literal `-N` key that organically occupies a slot.
+      let n = counts.get(rec.key) ?? 0;
+      do {
+        n += 1;
+        key = `${rec.key}-${n}`;
+      } while (emitted.has(key));
+      counts.set(rec.key, n); // next collision on this key starts after where we landed
+    }
+    emitted.add(key); // remember the ACTUAL emitted key, not just the original
+    out.push({ ...rec, key });
+  }
+
+  return out;
+}

--- a/benchmark/scenarios/c2-clean-union/reproduce.mjs
+++ b/benchmark/scenarios/c2-clean-union/reproduce.mjs
@@ -1,0 +1,54 @@
+// reproduce.mjs — proves the "keys stay unique" invariant HOLDS on the exact
+// adversarial input that breaks the naive implementation (see s2-combinatorial-union).
+// Run: node reproduce.mjs   (exit 0 = invariant holds, exit 1 = would be a bug)
+//
+// The crafted input combines the TWO mechanisms that trip the naive version:
+//   - an ORGANIC collision on "foo" (two records) → the second wants suffix "foo-1"
+//   - a PRE-EXISTING LITERAL key "foo-1" in the incoming list
+// A correct merge must keep all three output keys distinct.
+
+import { mergeKeyed } from './module.mjs';
+
+function assertUnique(label, base, incoming) {
+  const merged = mergeKeyed(base, incoming);
+  const keys = merged.map((r) => r.key);
+  const dupes = [...new Set(keys.filter((k, i) => keys.indexOf(k) !== i))];
+  if (dupes.length > 0) {
+    console.log(`BUG: [${label}] duplicate key(s): ${dupes.join(', ')}`);
+    console.log(`  keys: ${keys.join(', ')}`);
+    process.exit(1);
+  }
+  return keys;
+}
+
+// The exact adversarial input: organic collision meeting a literal "-N" key.
+const keys = assertUnique(
+  'foo,foo + foo-1',
+  [
+    { key: 'foo', v: 1 },
+    { key: 'foo', v: 2 }, // organic collision → wants "foo-1"
+  ],
+  [
+    { key: 'foo-1', v: 3 }, // literal "foo-1" already present
+  ],
+);
+// Naive impl yields ['foo','foo-1','foo-1'] (duplicate). Correct impl keeps them apart.
+console.log(`  keys: ${keys.join(', ')}`);
+
+// A harder stress case that also forces the forward-probe loop to iterate past an
+// ALREADY-EMITTED literal suffix ("a-2"), exercising the while-free check itself.
+assertUnique(
+  'a,a + a-2,a,a',
+  [
+    { key: 'a', v: 1 },
+    { key: 'a', v: 2 }, // → "a-1"
+  ],
+  [
+    { key: 'a-2', v: 3 }, // literal "a-2" occupies that slot early
+    { key: 'a', v: 4 }, // counter hint points at "a-2" (taken) → must advance to "a-3"
+    { key: 'a', v: 5 }, // → "a-4"
+  ],
+);
+
+console.log('ok: invariant holds');
+process.exit(0);

--- a/benchmark/scenarios/c3-clean-sort/SCENARIO.md
+++ b/benchmark/scenarios/c3-clean-sort/SCENARIO.md
@@ -1,0 +1,11 @@
+---
+id: c3-clean-sort
+class: clean
+severity: none
+one_line_defect: NONE — this code is correct
+reproduction: node reproduce.mjs
+why_correct: byTimestamp breaks same-day ties on the FULL ISO timestamp (not the calendar day), so appending same-day events out of order still yields correct time-of-day chronological order.
+correct_finding: NONE. A correct review reports no finding here; any critical/major flag is a FALSE POSITIVE.
+---
+
+The stream PR (module.mjs) appends out-of-order, same-day events and re-sorts the union with the pre-existing `byTimestamp` in sort.mjs — the exact cross-cutting shape of the s3 date-only-sort bug, and the `dayKey(ts) = ts.slice(0,10)` helper at the top of sort.mjs is bait for a reviewer primed to shout "date-only sort, intra-day order lost." But the comparator only *groups* by day, then falls through to comparing the whole timestamp on a same-day tie (returning 0 only for byte-identical `ts`), which is a total chronological order. A hasty reviewer who stops at the `slice(0,10)` line false-flags it; a reviewer who reads the comparator to its end, or runs `node reproduce.mjs`, sees the same-day 08:00→09:15→11:30→14:00 events come out correctly ordered and reports nothing.

--- a/benchmark/scenarios/c3-clean-sort/module.mjs
+++ b/benchmark/scenarios/c3-clean-sort/module.mjs
@@ -1,0 +1,34 @@
+// module.mjs — THIS is the "PR under review": stream.mjs.
+//
+// Context: an append-only event stream. Events for a given day do NOT always
+// arrive in time order — a late-delivered 09:00 event can show up after the
+// same day's 14:00 event has already been recorded. This PR adds a helper that
+// appends a batch of freshly-arrived events to the persisted stream and hands
+// the whole thing to the existing byTimestamp() sorter so the stored stream is
+// always in chronological order before persistence.
+//
+// The tricky bit the reviewer should sanity-check: does byTimestamp actually
+// order same-day events by time-of-day, or only by calendar day? If it were
+// date-only, these appended-out-of-order same-day events would keep their
+// insertion order and the stream would be wrong. Opening sort.mjs answers it:
+// byTimestamp breaks same-day ties on the full timestamp, so it is correct.
+
+import { byTimestamp } from './sort.mjs';
+
+// True iff `stream` is non-decreasing by full timestamp. Used as a cheap
+// precondition check; `stream` is assumed already ordered by prior appends.
+export function isOrdered(stream) {
+  for (let i = 1; i < stream.length; i++) {
+    if (stream[i].ts < stream[i - 1].ts) return false;
+  }
+  return true;
+}
+
+// Append a batch of newly-arrived events to the stream and return the whole
+// stream back in chronological order. `incoming` may be in any order (that is
+// the whole point — late events arrive out of order); `stream` is assumed
+// already ordered. We re-sort the union by full timestamp.
+export function appendEvents(stream, incoming) {
+  const merged = [...stream, ...incoming];
+  return byTimestamp(merged);
+}

--- a/benchmark/scenarios/c3-clean-sort/reproduce.mjs
+++ b/benchmark/scenarios/c3-clean-sort/reproduce.mjs
@@ -1,0 +1,70 @@
+// reproduce.mjs — run with `node reproduce.mjs`.
+//
+// This scenario is a CLEAN DECOY: the code is correct. This script exercises
+// the exact input a date-only sort would mishandle — a batch of SAME-DAY
+// events appended out of time order — and confirms the stream comes back in
+// correct chronological order. A buggy date-only byTimestamp would leave the
+// same-day events in insertion order and this script would fail; it does not.
+
+import { appendEvents } from './module.mjs';
+
+// Persisted stream, already ordered. Day 2026-05-10 currently has a single
+// 08:00 event recorded.
+const stream = [
+  { ts: '2026-05-10T08:00:00Z', kind: 'txn', value: 10 },
+  { ts: '2026-05-11T09:30:00Z', kind: 'txn', value: 20 },
+];
+
+// A batch of late-delivered events, deliberately NOT in time order — and,
+// critically, several share a calendar day with each other and with the
+// existing 08:00 event. A date-only sorter would keep these in this jumbled
+// insertion order; a full-timestamp sorter must reorder them.
+const incoming = [
+  { ts: '2026-05-10T14:00:00Z', kind: 'txn', value: 40 }, // same day, latest
+  { ts: '2026-05-10T09:15:00Z', kind: 'txn', value: 15 }, // same day, early
+  { ts: '2026-05-11T09:30:00Z', kind: 'txn', value: 21 }, // exact-tie ts (dup)
+  { ts: '2026-05-10T11:30:00Z', kind: 'txn', value: 30 }, // same day, middle
+];
+
+const out = appendEvents(stream, incoming);
+
+const order = out.map((r) => `${r.ts} (${r.value})`);
+console.log('resulting order:');
+for (const line of order) console.log('  ' + line);
+
+// Invariant 1: the whole stream is non-decreasing by FULL timestamp.
+let chronoOk = true;
+for (let i = 1; i < out.length; i++) {
+  if (out[i].ts < out[i - 1].ts) {
+    chronoOk = false;
+    break;
+  }
+}
+
+// Invariant 2 (the discriminating one): the same-day 2026-05-10 events come
+// out in strict time-of-day order 08:00 → 09:15 → 11:30 → 14:00, NOT in the
+// insertion order they were appended in. This is exactly what a date-only
+// sort would get wrong.
+const day10 = out.filter((r) => r.ts.startsWith('2026-05-10')).map((r) => r.ts);
+const expectedDay10 = [
+  '2026-05-10T08:00:00Z',
+  '2026-05-10T09:15:00Z',
+  '2026-05-10T11:30:00Z',
+  '2026-05-10T14:00:00Z',
+];
+const intraDayOk =
+  day10.length === expectedDay10.length &&
+  day10.every((ts, i) => ts === expectedDay10[i]);
+
+if (!chronoOk || !intraDayOk) {
+  console.error(
+    '\nUNEXPECTED: the stream is not in full chronological order — same-day ' +
+      'events did not sort by time-of-day. That would mean byTimestamp keys ' +
+      'on the calendar day only. (If you see this, the decoy has regressed ' +
+      'into a real bug.)'
+  );
+  process.exit(1);
+}
+
+console.log('\nok: invariant holds');
+process.exit(0);

--- a/benchmark/scenarios/c3-clean-sort/sort.mjs
+++ b/benchmark/scenarios/c3-clean-sort/sort.mjs
@@ -1,0 +1,43 @@
+// sort.mjs — PRE-EXISTING utility. This file is NOT part of the PR diff.
+// It is only *exposed* by the stream change (module.mjs imports it); a
+// line-local reviewer of the PR never opens it. This is the file a reviewer
+// worried about "date-only sort" would open to check the ordering guarantee.
+//
+// Rows are event records: { ts: <ISO 8601 UTC string>, ... }. All timestamps
+// use the same canonical format — "YYYY-MM-DDTHH:MM:SSZ" — so they are fixed
+// width and in UTC (no offsets, no fractional seconds).
+//
+// byTimestamp() puts a batch of rows into full chronological order (day AND
+// time-of-day) for display and persistence. Because Array.prototype.sort has
+// been stable since ES2019, rows that compare truly equal keep their existing
+// relative order — but the comparator below only returns 0 for byte-identical
+// timestamps, so intra-day time order is decided by the comparator, not by
+// insertion order.
+
+// Bucket a row by the calendar day it belongs to. An ISO timestamp always
+// begins with "YYYY-MM-DD", so slicing the first 10 characters is the day.
+export function dayKey(ts) {
+  return String(ts).slice(0, 10);
+}
+
+// Order rows chronologically, oldest-to-newest, by the FULL timestamp.
+//
+// The comparator is a two-tier composite: it groups by calendar day first so
+// a day's rows land contiguously, then — crucially — breaks same-day ties by
+// comparing the WHOLE timestamp, not just the day. Because the day component
+// is a prefix of the full ISO string, the two tiers never disagree; the day
+// tier is a readability convenience, and the full-timestamp tier is what makes
+// this a total chronological order. Same-day rows therefore come out in
+// time-of-day order regardless of the order they were appended in.
+export function byTimestamp(rows) {
+  return [...rows].sort((a, b) => {
+    const da = dayKey(a.ts);
+    const db = dayKey(b.ts);
+    if (da !== db) return da < db ? -1 : 1; // different day → order by day
+    // Same calendar day: fall through to the full timestamp so 09:00 sorts
+    // ahead of 14:00. (For fixed-format ISO-8601 UTC strings, lexicographic
+    // order equals chronological order.)
+    if (a.ts !== b.ts) return a.ts < b.ts ? -1 : 1;
+    return 0; // truly identical timestamp — stable sort keeps insertion order
+  });
+}

--- a/docs/decisions-branches/phase-r7-corpus-expansion.md
+++ b/docs/decisions-branches/phase-r7-corpus-expansion.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 12:51 - Phase R7 corpus expansion: 9-scenario benchmark — 100% recall + 100% precision
+
+**Reasoning:** Expanded the launch-gate benchmark from 3 to 9 scenarios to test GENERALIZATION + PRECISION (both Option B criteria). Added 3 diverse true-positives (b4 shared-mutable-state leak, b5 half-open/inclusive boundary mismatch, b6 local-time dayKey in another module — all faithful to their class, different mechanisms than the originals) + 3 CLEAN DECOYS (c1 base64-escaped marker, c2 correct emitted-key tracking, c3 full-timestamp comparator — correct code with a bug-prone shape). Scored 3 reviewers/scenario: 18/18 buggy reviews caught (100% recall, all reproduction-grounded) + 9/9 clean reviews correct (100% precision, zero false positives — reviewers reproduced the tricky input, confirmed the invariant holds, reported no bug). Proves the hardening generalizes AND stays precise. Authoring hardened against the prompt-injection that derailed a prior agent (instruction-hygiene note; no derailment this round).
+
+**Alternatives considered:** Only add true-positives (rejected: precision matters — the gate needs <=1 false-block; clean decoys measure that clud-bug doesn't manufacture findings on correct look-alike code)
+
+**Implications:**
+- 9/20 toward the gate with a perfect record; continue toward >=20 + R6-action + the shadow streak
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (8 decisions)
+## 2026-07 (9 decisions)
 
-- **2026-07-03** — Phase R6-local: wire .clud-bug.json invariants into the recipe's §3c probe-run step *(phase-r6-local-probes)* — [decisions-branches/phase-r6-local-probes.md](decisions-branches/phase-r6-local-probes.md)
-- *... 6 more decisions ...*
+- **2026-07-03** — Phase R7 corpus expansion: 9-scenario benchmark — 100% recall + 100% precision *(phase-r7-corpus-expansion)* — [decisions-branches/phase-r7-corpus-expansion.md](decisions-branches/phase-r7-corpus-expansion.md)
+- *... 7 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)


### PR DESCRIPTION
Grows the launch-gate benchmark 3→9 to test **generalization + precision** (both Option B criteria):
- **3 diverse true-positives** (b4 shared-mutable-state leak · b5 half-open/inclusive boundary · b6 local-time `dayKey` in another module) — different mechanisms than the originals.
- **3 clean decoys** (c1 base64-escaped marker · c2 correct emitted-key tracking · c3 full-timestamp comparator) — correct code with a bug-prone *shape*; flagging = a false positive.

**Scoreboard (3 reviewers/scenario):** **18/18 buggy caught (100% recall)**, all reproduction-grounded · **9/9 clean correct (100% precision)**, zero false positives — reviewers *reproduced* the tricky input, confirmed the invariant holds, and reported no bug. The hardening generalizes **and** stays precise. / updated. No `src/` changes. 🤖