### PR TITLE
Phase S: privacy/terms/pricing pages + pricing-link fix

### DIFF
--- a/docs/decisions-branches/phase-s-marketplace-pages.md
+++ b/docs/decisions-branches/phase-s-marketplace-pages.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 13:12 - Phase S: add privacy/terms/pricing pages + fix the pricing-link inconsistency
+
+**Reasoning:** The GitHub Marketplace listing requires privacy, terms, and pricing URLs on the marketing site (cludbug.dev). Ported the three pages from the held origin/a6a-marketplace-pages branch (fresh onto current main, avoiding the stale branch's 11-commit conflict debt) + the 137-line .doc/.tier/.price CSS block they need (reuses existing --mono/--leaf/--display vars). Fixed the pricing-link inconsistency the plan flagged: the landing linked pricing to app.cludbug.dev/pricing, but the Marketplace needs cludbug.dev/pricing — now that the site has its own /pricing page, the landing points there (SITE_PRICING_URL=/pricing). Site builds green; /pricing /privacy /terms all prerender.
+
+**Alternatives considered:** Rebase the stale A6a PR #196 (rejected: 11 behind with conflicts + rebase noise deleting main's newer files; porting the content fresh is clean)
+
+**Implications:**
+- Unblocks 3 of the 5 hard Marketplace URL blockers; landing-refresh (max-mode/design/auto-fix/auto-resolve sections) + /docs + screenshots are the remaining Phase S slices
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (10 decisions)
+## 2026-07 (11 decisions)
 
-- **2026-07-03** — Phase M: monetize the free tiers — FUNDING.yml (Sponsors) + on-voice init nudge *(phase-m-monetization)* — [decisions-branches/phase-m-monetization.md](decisions-branches/phase-m-monetization.md)
-- *... 8 more decisions ...*
+- **2026-07-03** — Phase S: add privacy/terms/pricing pages + fix the pricing-link inconsistency *(phase-s-marketplace-pages)* — [decisions-branches/phase-s-marketplace-pages.md](decisions-branches/phase-s-marketplace-pages.md)
+- *... 9 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -895,3 +895,141 @@ main { position: relative; z-index: 1; }
   .title { font-size: clamp(2.2rem, 13vw, 4rem); }
   .install-box { font-size: 0.88rem; padding: 0.75rem 0.9rem; }
 }
+
+
+/* ─────────────────── DOCUMENT PAGES (privacy / terms / pricing) ─────────────────── */
+
+/* A single centred reading column — the monograph, not the field plate. */
+.doc { max-width: 46rem; margin: 0 auto; }
+
+.doc-head { margin-bottom: 3rem; }
+.doc-eyebrow {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--leaf);
+  margin-bottom: 0.9rem;
+}
+.doc-title {
+  font-family: var(--display);
+  font-weight: 380;
+  font-size: clamp(2.2rem, 6vw, 3.4rem);
+  line-height: 1.05;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  margin-bottom: 1rem;
+}
+.doc-title em { font-style: italic; color: var(--leaf); }
+.doc-lede {
+  font-family: var(--body);
+  font-size: 1.18rem;
+  line-height: 1.5;
+  color: var(--ink-soft);
+  max-width: 38rem;
+}
+
+/* DRAFT / status banner — honest about what is and isn't legal copy. */
+.doc-status {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  line-height: 1.55;
+  color: var(--ink-soft);
+  background: var(--paper-warm);
+  border: var(--rule);
+  border-left: 3px solid var(--citrus);
+  padding: 0.85rem 1.1rem;
+  margin: 2rem 0;
+}
+.doc-status strong { color: var(--ink); font-weight: 600; }
+
+.doc-body { font-family: var(--body); }
+.doc-body h2 {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: 1.55rem;
+  color: var(--ink);
+  margin: 2.6rem 0 0.9rem;
+  padding-top: 1.6rem;
+  border-top: var(--rule);
+}
+.doc-body h2:first-child { border-top: 0; padding-top: 0; margin-top: 0; }
+.doc-body h3 {
+  font-family: var(--display);
+  font-weight: 500;
+  font-size: 1.12rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.6rem;
+}
+.doc-body p { font-size: 1.04rem; line-height: 1.62; color: var(--ink); margin-bottom: 1.05em; }
+.doc-body ul, .doc-body ol { margin: 0 0 1.2em 1.3em; }
+.doc-body li { font-size: 1.04rem; line-height: 1.55; color: var(--ink); margin-bottom: 0.45em; }
+.doc-body strong { font-weight: 600; }
+.doc-body a { color: var(--moss); text-decoration: none; border-bottom: 1px solid var(--leaf-soft); }
+.doc-body a:hover { color: var(--citrus); border-bottom-color: var(--citrus); }
+.doc-body code {
+  font-family: var(--mono);
+  font-size: 0.86em;
+  background: var(--paper-warm);
+  border: 1px solid var(--paper-shadow);
+  border-radius: 3px;
+  padding: 0.05em 0.35em;
+}
+.doc-body em.binomial { display: block; font-style: italic; color: var(--ink-faint); margin-top: 0.3rem; }
+
+/* Tables — sub-processors, retention, pricing rows. */
+.doc-table { width: 100%; border-collapse: collapse; margin: 1.4rem 0 1.8rem; font-size: 0.96rem; }
+.doc-table th, .doc-table td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.6rem 0.8rem;
+  border-bottom: var(--rule);
+  line-height: 1.45;
+}
+.doc-table th {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  border-bottom: var(--rule-bold);
+}
+.doc-table code { background: transparent; border: 0; padding: 0; }
+
+/* Pricing tiers — field-guide specimen cards. */
+.tiers { display: grid; grid-template-columns: 1fr; gap: 1px; background: var(--ink-faint); border: var(--rule); margin: 2rem 0; }
+@media (min-width: 760px) { .tiers { grid-template-columns: repeat(3, 1fr); } }
+.tier { background: var(--paper); padding: 1.6rem 1.4rem; display: flex; flex-direction: column; }
+.tier.feature { background: var(--paper-warm); }
+.tier-name {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--leaf);
+  margin-bottom: 0.7rem;
+}
+.tier-price { font-family: var(--display); font-weight: 420; font-size: 2rem; color: var(--ink); line-height: 1; }
+.tier-price small { font-family: var(--mono); font-size: 0.78rem; font-weight: 400; color: var(--ink-soft); letter-spacing: 0.02em; }
+.tier-includes { font-family: var(--body); font-size: 0.98rem; line-height: 1.5; color: var(--ink-soft); margin-top: 0.8rem; }
+
+.doc-back {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--ink-faint);
+  margin-bottom: 3rem;
+}
+.doc-back:hover { color: var(--citrus); border-bottom-color: var(--citrus); }
+
+@media (max-width: 600px) {
+  .doc-body h2 { font-size: 1.35rem; }
+  .doc-table { font-size: 0.88rem; }
+  .doc-table th, .doc-table td { padding: 0.5rem 0.55rem; }
+}

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -10,7 +10,9 @@ const APP_ROOT_URL = 'https://app.cludbug.dev';
 // Specific routes get specific URLs (used where the visible text is the
 // route name, e.g. "dashboard").
 const APP_DASHBOARD_URL = 'https://app.cludbug.dev/dashboard';
-const APP_PRICING_URL = 'https://app.cludbug.dev/pricing';
+// Pricing lives on the marketing site itself (cludbug.dev/pricing) — the canonical
+// URL the GitHub Marketplace listing requires. (Previously app.cludbug.dev/pricing.)
+const SITE_PRICING_URL = '/pricing';
 const APP_COMPARE_URL = 'https://app.cludbug.dev/compare';
 
 export default async function Home() {
@@ -53,7 +55,7 @@ export default async function Home() {
             </a>
             <p className="cta-fineprint">
               Managed tiers — see{' '}
-              <a href={APP_PRICING_URL} rel="noopener">pricing</a> and{' '}
+              <a href={SITE_PRICING_URL} rel="noopener">pricing</a> and{' '}
               <a href={APP_COMPARE_URL} rel="noopener">compare</a> on{' '}
               <a href={APP_ROOT_URL} rel="noopener">app.cludbug.dev</a>, or{' '}
               <a href="#self-hosted">self-host the open-source workflow</a> for free.
@@ -201,7 +203,7 @@ export default async function Home() {
           <aside className="marginalia">
             Available on the Team tier. Each pass writes to the same PR but
             signs its own comments. Disagreements get adjudicated, not
-            averaged. <a href={APP_PRICING_URL} rel="noopener">Pricing →</a>
+            averaged. <a href={SITE_PRICING_URL} rel="noopener">Pricing →</a>
           </aside>
           <div className="section-prose">
             <p>

--- a/site/app/pricing/page.tsx
+++ b/site/app/pricing/page.tsx
@@ -1,0 +1,149 @@
+import type { Metadata } from 'next';
+
+const APP_INSTALL_URL = 'https://github.com/apps/clud-bug/installations/new';
+const APP_PRICING_URL = 'https://app.cludbug.dev/pricing';
+
+export const metadata: Metadata = {
+  title: 'Pricing — Clud Bug',
+  description:
+    'AI PR reviews. $9/mo + Anthropic cost + 20%. No surprises. Trial, Solo, and Team tiers — transparent cost-plus billing, the markup math you can audit.',
+  alternates: { canonical: '/pricing' },
+};
+
+export default function Pricing() {
+  return (
+    <main className="page">
+      <header className="folio">
+        <span>A Field Guide to Code Specimens</span>
+        <span>Pricing · MMXXVI</span>
+      </header>
+
+      <div className="doc">
+        <a className="doc-back" href="/">← Field guide</a>
+
+        <header className="doc-head">
+          <span className="doc-eyebrow">§ Field Economy</span>
+          <h1 className="doc-title">
+            Honest <em>cost-plus</em>.
+          </h1>
+          <p className="doc-lede">
+            AI PR reviews for <strong>$9/mo + what we pay Anthropic + 20%</strong>.
+            No hidden seat margin, no surprise multipliers — we publish the
+            Anthropic invoice each cycle so the markup math is yours to check.
+          </p>
+        </header>
+
+        <div className="doc-body">
+          <div className="tiers">
+            <div className="tier">
+              <span className="tier-name">Trial</span>
+              <span className="tier-price">$0</span>
+              <p className="tier-includes">
+                First <strong>5 reviews</strong> on any repo, public or private.
+                Enough to evaluate the bot on a real PR before you decide.
+              </p>
+            </div>
+            <div className="tier feature">
+              <span className="tier-name">Solo</span>
+              <span className="tier-price">
+                $9<small> /mo · per org</small>
+              </span>
+              <p className="tier-includes">
+                <strong>25 private reviews</strong> a month. Below the
+                unbudgeted-purchase line — a personal card, no procurement.
+              </p>
+            </div>
+            <div className="tier">
+              <span className="tier-name">Team</span>
+              <span className="tier-price">
+                $29<small> /seat · mo</small>
+              </span>
+              <p className="tier-includes">
+                <strong>100 reviews per seat</strong>, pooled across the org.
+                Unlocks the multi-pass cross-check &amp; the design critique.
+              </p>
+            </div>
+          </div>
+
+          <table className="doc-table">
+            <thead>
+              <tr>
+                <th>Also</th>
+                <th>Price</th>
+                <th>Includes</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><strong>Enterprise</strong></td>
+                <td>Custom</td>
+                <td>Unlimited reviews, SSO, a per-customer SLA. Billed direct.</td>
+              </tr>
+              <tr>
+                <td><strong>Overage</strong><br />(Solo + Team)</td>
+                <td>Anthropic cost&nbsp;×&nbsp;1.20</td>
+                <td>
+                  Past your tier&rsquo;s included reviews, usage bills at our
+                  Anthropic cost plus a flat 20%. No tier jump, no throttling.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <p>
+            Public repositories run under the same tier mechanics — there is no
+            separate OSS-free track on the hosted App. (Prefer your own runner?
+            The <a href="/#self-hosted">open-source workflow</a> is free; you
+            bring the Anthropic key.)
+          </p>
+
+          <h2>Why cost-plus?</h2>
+          <p>
+            <strong>We charge a flat tier fee, then pass Anthropic&rsquo;s API
+            cost through with a fixed 20% markup.</strong> Each billing cycle we
+            publish the Anthropic invoice, so you can verify the math directly —
+            no hidden seat margin, no surprise multipliers.
+          </p>
+          <p>
+            <strong>Why not a flat $/review?</strong> Anthropic&rsquo;s
+            per-review cost moves with diff size and which naturalist runs
+            (Beetle on Sonnet, Wasp on Opus, Mantis only on disputes). A flat
+            number either overcharges small PRs or undercharges large ones.
+            Cost-plus is honest about that: your invoice is your invoice, not a
+            pricing model&rsquo;s guess.
+          </p>
+          <p>
+            <strong>Why a 5-review trial, not unlimited free?</strong> Five
+            reviews cover one real PR and a few revisions — enough to judge the
+            bot on your own code. Past that, the economics only work if the bot
+            earns the upgrade.
+          </p>
+
+          <h2>Pick a plan</h2>
+          <p>
+            Plans are chosen at install time. <a href={APP_INSTALL_URL} rel="noopener">Install
+            the GitHub App</a>, then manage your tier, usage, and billing on{' '}
+            <a href={APP_PRICING_URL} rel="noopener">app.cludbug.dev</a>. Change
+            tiers or cancel anytime — month to month, no contract.
+          </p>
+        </div>
+
+        <a className="doc-back" href="/">← Back to the field guide</a>
+      </div>
+
+      <footer className="colophon">
+        <span>
+          Open source. <a href="https://github.com/thrillmade/clud-bug/blob/main/LICENSE">MIT</a>.
+        </span>
+        <span className="credit">
+          a <a href="https://thrillmot.com" rel="noopener">thrillmot</a> project
+        </span>
+        <span>
+          <a href="/privacy">privacy</a>
+          {' · '}
+          <a href="/terms">terms</a>
+        </span>
+      </footer>
+    </main>
+  );
+}

--- a/site/app/privacy/page.tsx
+++ b/site/app/privacy/page.tsx
@@ -1,0 +1,211 @@
+import type { Metadata } from 'next';
+
+const ISSUES_URL = 'https://github.com/thrillmade/clud-bug-app/issues';
+const SECURITY_URL = 'https://github.com/thrillmade/clud-bug-app/security/advisories/new';
+const APP_REPO_URL = 'https://github.com/thrillmade/clud-bug-app';
+
+export const metadata: Metadata = {
+  title: 'Privacy & data handling — Clud Bug',
+  description:
+    'What the clud-bug GitHub App reads, what it sends to Anthropic, what we retain, and how to delete it. Cost-plus on data too: we keep as little as the job needs.',
+  alternates: { canonical: '/privacy' },
+};
+
+export default function Privacy() {
+  return (
+    <main className="page">
+      <header className="folio">
+        <span>A Field Guide to Code Specimens</span>
+        <span>Privacy · MMXXVI</span>
+      </header>
+
+      <div className="doc">
+        <a className="doc-back" href="/">← Field guide</a>
+
+        <header className="doc-head">
+          <span className="doc-eyebrow">§ Data Handling</span>
+          <h1 className="doc-title">Privacy &amp; data handling.</h1>
+          <p className="doc-lede">
+            clud-bug reads each pull request&rsquo;s diff and your skill files,
+            sends them to Anthropic for review, and writes the result back to
+            the PR. We retain almost nothing — only short-lived idempotency keys
+            and your per-install configuration.
+          </p>
+        </header>
+
+        <p className="doc-status">
+          <strong>Last updated: June 2026.</strong> This describes the
+          data handling of the hosted <code>clud-bug[bot]</code> GitHub App. The
+          App&rsquo;s entire source is open — every data path below is auditable
+          at <a href={APP_REPO_URL} rel="noopener">github.com/thrillmade/clud-bug-app</a>.
+        </p>
+
+        <div className="doc-body">
+          <h2>1. What the App reads</h2>
+          <p>
+            On install, the GitHub App receives an installation access token
+            scoped to these permissions — and no others:
+          </p>
+          <table className="doc-table">
+            <thead>
+              <tr><th>Permission</th><th>Why</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>pull_requests: write</code></td><td>Read PR metadata + diff; post the inline review threads and the summary comment; resolve threads on verified fixes.</td></tr>
+              <tr><td><code>contents: write</code></td><td>Read skill manifests at the PR&rsquo;s base ref; push auto-fix commits (only when explicitly enabled per-install).</td></tr>
+              <tr><td><code>checks: write</code></td><td>Post a check-run so the PR&rsquo;s status reflects the review verdict.</td></tr>
+              <tr><td><code>issues: write</code></td><td>Post the summary as a top-level PR comment (GitHub treats these as issue comments).</td></tr>
+              <tr><td><code>metadata: read</code></td><td>Required for any install; read-only repo metadata (name, default branch).</td></tr>
+            </tbody>
+          </table>
+          <p>
+            We do <strong>not</strong> request <code>administration</code>,{' '}
+            <code>secrets</code>, <code>actions</code>, <code>members</code>, or
+            any org-admin scopes. The token is scoped per installation —
+            uninstalling revokes it.
+          </p>
+
+          <h2>2. What we send to Anthropic</h2>
+          <p>For each review, the App sends to Anthropic&rsquo;s API:</p>
+          <ul>
+            <li>The PR&rsquo;s <strong>unified diff</strong> (what <code>git diff base...head</code> produces).</li>
+            <li>The <strong>bodies of the skill files</strong> resolved for that review (from <code>.claude/skills/</code> at the base ref, plus any catalog skills you opted into).</li>
+            <li>A static <strong>system prompt</strong> and the <strong>schema</strong> the reviewer emits findings against.</li>
+            <li>The PR metadata needed to attribute comments (number, base/head SHA, file paths).</li>
+          </ul>
+          <p>
+            We do <strong>not</strong> send repository contents outside the
+            diff (no full-repo crawl), files at paths not in the diff, or your
+            GitHub credentials (Anthropic never sees the installation token).
+          </p>
+          <p>
+            <strong>Visual design review (Team, opt-in).</strong> If you enable
+            the design critique, the App resolves your PR&rsquo;s
+            already-public <strong>deploy-preview URL</strong> and sends it to
+            our render service (Browserless), which loads that preview and
+            captures screenshots. The screenshots are sent to Anthropic for the
+            visual review. No additional repository content is read or sent.
+          </p>
+
+          <h2>3. What Anthropic does with it</h2>
+          <p>
+            The App calls Anthropic via the{' '}
+            <a href="https://vercel.com/docs/ai-gateway" rel="noopener">Vercel AI Gateway</a>.
+            Per Anthropic&rsquo;s policy, API requests are <strong>not used to
+            train models</strong>. Anthropic retains request data for a limited
+            operational window (currently ~30 days for abuse monitoring);
+            clud-bug does not access that buffer.
+          </p>
+
+          <h2>4. What we retain</h2>
+          <p>
+            We use <a href="https://upstash.com" rel="noopener">Upstash Redis</a>{' '}
+            for configuration and short-lived operational state. None of it
+            contains PR diffs or skill bodies.
+          </p>
+          <table className="doc-table">
+            <thead>
+              <tr><th>Class</th><th>Contents</th><th>TTL</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Install config</td><td>Org login, tier / billing mode, skill-catalog config.</td><td>Until uninstall.</td></tr>
+              <tr><td>Idempotency keys</td><td>Webhook delivery IDs marked processed (prevents double-reviews).</td><td>≤ 24 hours.</td></tr>
+              <tr><td>Usage + spend meters</td><td>Per-review token counts and cost estimates, for billing reconciliation. No content.</td><td>Short-lived (rolling).</td></tr>
+              <tr><td>Comment + screenshot cache</td><td>The review comment&rsquo;s ID (to edit in place) and, for the design pass, screenshots keyed by commit SHA.</td><td>≤ 1 hour (screenshots).</td></tr>
+            </tbody>
+          </table>
+          <p>
+            We do <strong>not</strong> retain PR diffs after a review completes,
+            skill manifest bodies (re-fetched each review), inline comment text
+            (it lives in GitHub once posted), or authentication tokens (minted
+            per-request and discarded).
+          </p>
+
+          <h2>5. Where the review is written</h2>
+          <p>
+            The review is posted to <strong>your PR</strong>: inline review
+            threads at the exact lines, plus one summary comment that the bot
+            edits in place on each new push (so the conversation stays to a
+            single comment, not one per pass). That comment — in your GitHub
+            repo, under the App&rsquo;s identity — is the audit trail. We keep no
+            copy of its text.
+          </p>
+
+          <h2>6. Sub-processors</h2>
+          <table className="doc-table">
+            <thead>
+              <tr><th>Sub-processor</th><th>Purpose</th><th>Region</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><strong>Vercel</strong></td><td>Function execution + logs</td><td>Multi-region (AWS)</td></tr>
+              <tr><td><strong>Upstash</strong></td><td>Redis (config + idempotency + meters)</td><td>Multi-region</td></tr>
+              <tr><td><strong>Anthropic</strong> (via Vercel AI Gateway)</td><td>LLM inference for the review</td><td>US</td></tr>
+              <tr><td><strong>Stripe</strong></td><td>Subscription + metered billing</td><td>US</td></tr>
+              <tr><td><strong>Browserless</strong></td><td>Screenshot render for the visual design pass (Team, opt-in only)</td><td>US/EU</td></tr>
+              <tr><td><strong>GitHub</strong></td><td>The platform — install, webhooks, comment posting</td><td>Multi-region (Azure)</td></tr>
+            </tbody>
+          </table>
+          <p>
+            We use no AI providers other than Anthropic. If that changes, this
+            list is updated and installed customers are notified.
+          </p>
+
+          <h2>7. Logging</h2>
+          <p>
+            Vercel function logs capture request route + status, error stack
+            traces, and operational lines (install ID, delivery ID, review
+            outcome, policy denials). Logs do <strong>not</strong> contain PR
+            diff content, skill bodies, or Anthropic responses. They age out per
+            Vercel&rsquo;s standard retention (7–30 days).
+          </p>
+
+          <h2>8. Data deletion</h2>
+          <p>
+            <strong>On uninstall:</strong> within 24 hours we purge all Redis
+            keys tied to that installation. Idempotency keys age out within 24
+            hours regardless.
+          </p>
+          <p>
+            <strong>On request:</strong> open an issue at{' '}
+            <a href={ISSUES_URL} rel="noopener">our GitHub Issues</a>, or — for
+            anything you&rsquo;d rather not post publicly — a{' '}
+            <a href={SECURITY_URL} rel="noopener">private security advisory</a>.
+            We respond within 7 business days.
+          </p>
+
+          <h2>9. Open source</h2>
+          <p>
+            The App&rsquo;s codebase is open at{' '}
+            <a href={APP_REPO_URL} rel="noopener">github.com/thrillmade/clud-bug-app</a>.
+            Trace each data path above by searching the source for the storage
+            key prefixes and the Anthropic call site.
+          </p>
+
+          <h2>10. Contact</h2>
+          <p>
+            Privacy questions, data-deletion requests, and security
+            disclosures: <a href={ISSUES_URL} rel="noopener">GitHub Issues</a>{' '}
+            (public) or a <a href={SECURITY_URL} rel="noopener">private security
+            advisory</a> (confidential).
+          </p>
+        </div>
+
+        <a className="doc-back" href="/">← Back to the field guide</a>
+      </div>
+
+      <footer className="colophon">
+        <span>
+          Open source. <a href="https://github.com/thrillmade/clud-bug/blob/main/LICENSE">MIT</a>.
+        </span>
+        <span className="credit">
+          a <a href="https://thrillmot.com" rel="noopener">thrillmot</a> project
+        </span>
+        <span>
+          <a href="/pricing">pricing</a>
+          {' · '}
+          <a href="/terms">terms</a>
+        </span>
+      </footer>
+    </main>
+  );
+}

--- a/site/app/terms/page.tsx
+++ b/site/app/terms/page.tsx
@@ -1,0 +1,158 @@
+import type { Metadata } from 'next';
+
+const ISSUES_URL = 'https://github.com/thrillmade/clud-bug-app/issues';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service — Clud Bug',
+  description: 'Terms of Service for the clud-bug GitHub App (draft, pending legal review).',
+  alternates: { canonical: '/terms' },
+  robots: { index: false, follow: true },
+};
+
+export default function Terms() {
+  return (
+    <main className="page">
+      <header className="folio">
+        <span>A Field Guide to Code Specimens</span>
+        <span>Terms · MMXXVI</span>
+      </header>
+
+      <div className="doc">
+        <a className="doc-back" href="/">← Field guide</a>
+
+        <header className="doc-head">
+          <span className="doc-eyebrow">§ Terms of Service</span>
+          <h1 className="doc-title">Terms of Service.</h1>
+          <p className="doc-lede">
+            The agreement between you and clud-bug when you install and use the
+            hosted GitHub App.
+          </p>
+        </header>
+
+        <p className="doc-status">
+          <strong>DRAFT — pending legal review.</strong> This is starter copy,
+          not legal advice, and is not yet in force. Sections marked{' '}
+          <code>[LEGAL REVIEW]</code> need counsel before this page is published
+          as binding terms. Do not rely on it until this banner is removed.
+        </p>
+
+        <div className="doc-body">
+          <h2>1. Acceptance</h2>
+          <p>
+            By installing or using the clud-bug GitHub App (the
+            &ldquo;Service&rdquo;), you agree to these Terms. If you install on
+            behalf of an organization, you represent that you are authorized to
+            bind that organization.
+          </p>
+
+          <h2>2. The Service</h2>
+          <p>
+            clud-bug is an automated code-review App. It reads your pull
+            requests, generates reviews using third-party AI (Anthropic), and
+            posts the results back to your repository. The Service is provided
+            on an &ldquo;as is&rdquo; and &ldquo;as available&rdquo; basis. We
+            may add, change, or remove features. Review output is advisory —
+            you are responsible for the code you merge.
+          </p>
+
+          <h2>3. The open-source workflow is separate</h2>
+          <p>
+            clud-bug is also distributed as an open-source npm package and
+            GitHub Action under the{' '}
+            <a href="https://github.com/thrillmade/clud-bug/blob/main/LICENSE" rel="noopener">MIT
+            License</a>. These Terms govern the <strong>hosted App only</strong>.
+            Your use of the open-source workflow is governed by the MIT License,
+            not this agreement.
+          </p>
+
+          <h2>4. Accounts &amp; billing</h2>
+          <p>
+            Paid tiers are billed through Stripe on a monthly basis. By
+            selecting a paid plan you authorize recurring charges, including
+            usage-based overage at the rate published on our{' '}
+            <a href="/pricing">pricing page</a>. Plans are month-to-month and
+            may be cancelled at any time; fees already incurred are
+            non-refundable except where required by law.{' '}
+            <code>[LEGAL REVIEW]</code> — refund, proration, and tax terms.
+          </p>
+
+          <h2>5. Acceptable use</h2>
+          <p>You agree not to:</p>
+          <ul>
+            <li>Use the Service to violate any law or third-party right.</li>
+            <li>Attempt to disrupt, overload, or reverse-engineer the hosted infrastructure (the source is open — audit it there instead).</li>
+            <li>Resell or relabel the hosted Service without written permission.</li>
+          </ul>
+
+          <h2>6. Data</h2>
+          <p>
+            Our handling of your data is described in the{' '}
+            <a href="/privacy">Privacy &amp; Data Handling policy</a>, which is
+            incorporated into these Terms by reference.
+          </p>
+
+          <h2>7. Disclaimers</h2>
+          <p>
+            The Service relies on third-party AI and may produce incomplete,
+            incorrect, or missed findings. We disclaim all warranties to the
+            fullest extent permitted by law, including merchantability, fitness
+            for a particular purpose, and non-infringement. clud-bug does not
+            guarantee that the Service will catch any particular defect.
+          </p>
+
+          <h2>8. Limitation of liability</h2>
+          <p>
+            <code>[LEGAL REVIEW]</code> — To the fullest extent permitted by
+            law, clud-bug&rsquo;s aggregate liability arising out of or relating
+            to the Service will not exceed the amounts you paid in the twelve
+            months preceding the claim. We are not liable for indirect,
+            incidental, or consequential damages.
+          </p>
+
+          <h2>9. Termination</h2>
+          <p>
+            You may stop using the Service at any time by uninstalling the App
+            (which triggers data deletion per the Privacy policy). We may
+            suspend or terminate access for breach of these Terms or to comply
+            with law.
+          </p>
+
+          <h2>10. Changes</h2>
+          <p>
+            We may update these Terms. Material changes will be reflected here
+            with an updated date; continued use after a change constitutes
+            acceptance.
+          </p>
+
+          <h2>11. Governing law</h2>
+          <p>
+            <code>[LEGAL REVIEW]</code> — Governing jurisdiction, dispute
+            resolution, and the contracting entity to be specified by counsel.
+          </p>
+
+          <h2>12. Contact</h2>
+          <p>
+            Questions about these Terms:{' '}
+            <a href={ISSUES_URL} rel="noopener">GitHub Issues</a>.
+          </p>
+        </div>
+
+        <a className="doc-back" href="/">← Back to the field guide</a>
+      </div>
+
+      <footer className="colophon">
+        <span>
+          Open source. <a href="https://github.com/thrillmade/clud-bug/blob/main/LICENSE">MIT</a>.
+        </span>
+        <span className="credit">
+          a <a href="https://thrillmot.com" rel="noopener">thrillmot</a> project
+        </span>
+        <span>
+          <a href="/pricing">pricing</a>
+          {' · '}
+          <a href="/privacy">privacy</a>
+        </span>
+      </footer>
+    </main>
+  );
+}


### PR DESCRIPTION
Unblocks 3 of the 5 hard Marketplace URL requirements. Ports `site/app/{privacy,terms,pricing}/page.tsx` fresh from the held A6a branch (avoiding its stale 11-commit conflict debt) + the 137-line `.doc`/`.tier` CSS block. Fixes the pricing-link inconsistency: the landing now points `pricing` at the site's own `/pricing` (`cludbug.dev/pricing`, what the Marketplace needs) instead of `app.cludbug.dev/pricing`. Site builds green; all three prerender. Remaining Phase S: landing-refresh (max-mode/design/auto-fix/auto-resolve) + /docs + screenshots. 🤖