### PR TITLE
Phase S: /docs self-service pages (skills, config, auto-fix, multi-pass)

### DIFF
--- a/docs/decisions-branches/phase-s-docs.md
+++ b/docs/decisions-branches/phase-s-docs.md
@@ -1,0 +1,11 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 14:42 - Phase S: /docs self-service pages (skills, config, auto-fix, multi-pass)
+
+**Reasoning:** The GitHub Marketplace SUPPORT policy references /docs pages. Added the /docs subtree to the marketing site: five field-guide .doc-style pages grounded in the real modules (skills=SKILL.md/base-ref load/slugs; config=every .clud-bug.json option incl. the new invariants; auto-fix=fix-push re-verification + the resolve rule table; multi-pass=Beetle/Wasp/Mantis + reproduction-as-grounding + the 20-scenario benchmark). Added a .doc-body pre code-block style (doc pages lacked one). Authored by a finish-agent grounded in the code; build green, all 5 routes prerender.
+
+**Implications:**
+- The prior code commit used plain git (to avoid logmind's add-all sweeping strays), so this decision entry backfills the check-decisions gate for the branch
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (12 decisions)
+## 2026-07 (13 decisions)
 
-- **2026-07-03** — Phase R7: 20-scenario benchmark scoreboard — 100% recall + 100% precision (60 reviews) *(phase-r7-scoreboard-20)* — [decisions-branches/phase-r7-scoreboard-20.md](decisions-branches/phase-r7-scoreboard-20.md)
-- *... 10 more decisions ...*
+- **2026-07-03** — Phase S: /docs self-service pages (skills, config, auto-fix, multi-pass) *(phase-s-docs)* — [decisions-branches/phase-s-docs.md](decisions-branches/phase-s-docs.md)
+- *... 11 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/site/app/docs/auto-fix/page.tsx
+++ b/site/app/docs/auto-fix/page.tsx
@@ -1,0 +1,234 @@
+import type { Metadata } from 'next';
+
+const REPO_URL = 'https://github.com/thrillmade/clud-bug';
+
+export const metadata: Metadata = {
+  title: 'Auto-fix & auto-resolve — Clud Bug docs',
+  description:
+    'How a fix-push is re-verified thread by thread: the per-thread verdict (ADDRESSED / NOT_ADDRESSED / UNCERTAIN, fail-closed to human review) and the rule table that resolves, keeps open, or escalates each prior finding.',
+  alternates: { canonical: '/docs/auto-fix' },
+};
+
+export default function DocsAutoFix() {
+  return (
+    <main className="page">
+      <header className="folio">
+        <span>A Field Guide to Code Specimens</span>
+        <span>Auto-resolve · MMXXVI</span>
+      </header>
+
+      <div className="doc">
+        <a className="doc-back" href="/docs">← Field manual</a>
+
+        <header className="doc-head">
+          <span className="doc-eyebrow">§ Auto-fix &amp; Auto-resolve</span>
+          <h1 className="doc-title">Closing its own findings.</h1>
+          <p className="doc-lede">
+            When you push a fix, Clud Bug does not re-run a fresh review and bury
+            you in new comments. It revisits each thread it already opened and
+            asks one question of each: did this commit address the concern I
+            raised? Then it resolves, keeps open, or escalates — and never
+            silently dismisses a critical.
+          </p>
+        </header>
+
+        <div className="doc-body">
+          <h2>1. A fix-push reopens the conversation</h2>
+          <p>
+            On every fix-push — a <code>pull_request.synchronize</code> — the bot
+            gathers the threads it posted on a prior pass that are still open. For
+            each one it reconstructs the code at the finding&rsquo;s anchor{' '}
+            <strong>before</strong> and <strong>after</strong> the new commit,
+            plus the diff at that spot, and hands the trio to a per-thread
+            verifier. Threads a human already resolved are left alone; only the
+            bot&rsquo;s own open findings are revisited.
+          </p>
+
+          <h2>2. The per-thread verdict</h2>
+          <p>
+            The verifier is a single, narrow question — not a new review. It is
+            told the prior finding, shown the before / after / diff, and asked
+            whether the change resolved <em>that</em> concern. Its answer is
+            exactly one of three verdicts:
+          </p>
+          <table className="doc-table">
+            <thead>
+              <tr>
+                <th>Verdict</th>
+                <th>Meaning</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <code>ADDRESSED</code>
+                </td>
+                <td>
+                  The after-code unambiguously resolves the original concern. A
+                  partial fix that leaves the core problem standing is not
+                  ADDRESSED.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>NOT_ADDRESSED</code>
+                </td>
+                <td>
+                  The problem still stands, the change is unrelated to the
+                  concern, or it made things worse.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>UNCERTAIN</code>
+                </td>
+                <td>
+                  The before / after alone cannot settle it. Never a guess — the
+                  verifier says UNCERTAIN whenever it would be guessing.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            Two properties make this safe to trust. The verifier&rsquo;s system
+            prompt is fixed in the module, never derived from the diff or the
+            finding, so a hostile commit cannot rewrite the question it is being
+            asked. And it treats the prior finding as a black box: it judges only
+            whether the new code resolves what the finding said, not whether the
+            finding was right in the first place. Both live in{' '}
+            <a href={`${REPO_URL}/blob/main/src/core/resolve-verifier.ts`} rel="noopener">
+              src/core/resolve-verifier.ts
+            </a>
+            .
+          </p>
+          <p>
+            The verdict is <strong>fail-closed</strong>. The model is asked for a
+            one-line JSON object; anything malformed — empty text, invalid JSON,
+            an unknown verdict, a missing rationale — is parsed straight to{' '}
+            <code>UNCERTAIN</code>, tagged as an API error. A model coerced into
+            emitting the word ADDRESSED outside the required shape never lands as
+            a pass. The only way to <code>ADDRESSED</code> is a well-formed model
+            verdict that says so.
+          </p>
+
+          <h2>3. The rule table</h2>
+          <p>
+            The verdict, crossed with the finding&rsquo;s severity, decides the
+            action. This is the whole table, pure and grounded in{' '}
+            <a href={`${REPO_URL}/blob/main/src/core/auto-resolve.ts`} rel="noopener">
+              src/core/auto-resolve.ts
+            </a>
+            :
+          </p>
+          <table className="doc-table">
+            <thead>
+              <tr>
+                <th>Verdict</th>
+                <th>Severity</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <code>ADDRESSED</code>
+                </td>
+                <td>any</td>
+                <td>Resolve the thread; post &ldquo;Auto-resolved (verified)&rdquo;.</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>NOT_ADDRESSED</code>
+                </td>
+                <td>🟡 minor</td>
+                <td>Keep open; post &ldquo;Re-review found this still applies&rdquo;.</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>NOT_ADDRESSED</code>
+                </td>
+                <td>🔴 critical</td>
+                <td>Keep open and flag REQUEST_CHANGES.</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>UNCERTAIN</code>
+                </td>
+                <td>🟡 minor</td>
+                <td>Keep open; recommend a human look.</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>UNCERTAIN</code>
+                </td>
+                <td>🔴 critical</td>
+                <td>
+                  Keep open, flag REQUEST_CHANGES, and escalate — never silently
+                  dismiss.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            The last row is the load-bearing one. An uncertain verdict on a
+            critical finding is the case where a careless tool would guess its way
+            to green; here it is kept open and escalated. The{' '}
+            <code>uncertain_critical_action</code> option in{' '}
+            <a href="/docs/config">the manifest</a> can soften the escalation to a
+            plain keep-open, but the thread is never resolved on uncertainty — the
+            floor is human review, not a pass.
+          </p>
+
+          <h2>4. Resolving, honestly</h2>
+          <p>
+            Actually closing a review thread needs a token that can — the
+            Actions&rsquo; default <code>GITHUB_TOKEN</code> cannot resolve
+            threads. With a dedicated{' '}
+            <code>CLUD_BUG_RESOLVE_PAT</code> present, a verified-addressed thread
+            is auto-closed. Without one, the bot will not <em>claim</em> to have
+            closed it: it posts &ldquo;Verified fixed — not auto-closed&rdquo; and
+            leaves you the <strong>Resolve conversation</strong> button. The badge
+            always matches what actually happened.
+          </p>
+          <p>
+            Each reply carries a hidden marker recording the verdict and a
+            signature of the post-fix anchor. A later fix-push that finds the
+            anchor unmoved skips re-verifying and re-replying — one reply per
+            distinct outcome, not one per push. So a noisy branch with many small
+            commits does not accrete a stack of identical auto-resolve notes.
+          </p>
+
+          <h2>5. Turning it off</h2>
+          <p>
+            The whole behavior is one manifest block. <code>mode: &quot;off&quot;</code>{' '}
+            leaves every prior thread open and makes no verifier calls at all;{' '}
+            <code>mode: &quot;verified&quot;</code> (the default) runs the table
+            above. See <a href="/docs/config">configuration</a> for the block and
+            its defaults.
+          </p>
+        </div>
+
+        <a className="doc-back" href="/docs">← Back to the field manual</a>
+      </div>
+
+      <footer className="colophon">
+        <span>
+          Open source.{' '}
+          <a href="https://github.com/thrillmade/clud-bug/blob/main/LICENSE">MIT</a>.
+        </span>
+        <span className="credit">
+          a{' '}
+          <a href="https://thrillmot.com" rel="noopener">
+            thrillmot
+          </a>{' '}
+          project
+        </span>
+        <span>
+          <a href="/docs">docs</a>
+          {' · '}
+          <a href="/docs/config">config</a>
+        </span>
+      </footer>
+    </main>
+  );
+}

--- a/site/app/docs/config/page.tsx
+++ b/site/app/docs/config/page.tsx
@@ -1,0 +1,350 @@
+import type { Metadata } from 'next';
+
+const REPO_URL = 'https://github.com/thrillmade/clud-bug';
+
+export const metadata: Metadata = {
+  title: 'Configuration — Clud Bug docs',
+  description:
+    'Every .clud-bug.json option, with a small example each: strictMode, reviewContext, reviewPasses, design, autoResolve, and the executable invariants — grounded in the modules that read them.',
+  alternates: { canonical: '/docs/config' },
+};
+
+export default function DocsConfig() {
+  return (
+    <main className="page">
+      <header className="folio">
+        <span>A Field Guide to Code Specimens</span>
+        <span>Configuration · MMXXVI</span>
+      </header>
+
+      <div className="doc">
+        <a className="doc-back" href="/docs">← Field manual</a>
+
+        <header className="doc-head">
+          <span className="doc-eyebrow">§ Configuration</span>
+          <h1 className="doc-title">The manifest.</h1>
+          <p className="doc-lede">
+            Everything Clud Bug reads from a repository lives in one optional
+            file — <code>.clud-bug.json</code> at the root. Six blocks, each with
+            a safe default when absent, each grounded in a module you can open.
+          </p>
+        </header>
+
+        <div className="doc-body">
+          <p>
+            No block is required; an empty file, or no file at all, gives you the
+            defaults below. Each option maps to a module in{' '}
+            <a href={`${REPO_URL}/tree/main/src/core`} rel="noopener">
+              src/core
+            </a>{' '}
+            that reads and normalizes it — a malformed value is tolerated and
+            falls back to its default rather than failing the review.
+          </p>
+
+          <table className="doc-table">
+            <thead>
+              <tr>
+                <th>Block</th>
+                <th>Default</th>
+                <th>What it governs</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <code>strictMode</code>
+                </td>
+                <td>
+                  <code>false</code>
+                </td>
+                <td>Whether a critical finding blocks the merge or only advises.</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>reviewContext</code>
+                </td>
+                <td>none</td>
+                <td>Trusted standing instructions that focus the review.</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>reviewPasses</code>
+                </td>
+                <td>
+                  <code>1</code> · cross-check
+                </td>
+                <td>How many passes run and how their findings are aggregated.</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>design</code>
+                </td>
+                <td>off</td>
+                <td>The optional visual design-critic pass.</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>autoResolve</code>
+                </td>
+                <td>verified</td>
+                <td>How prior threads are re-checked on a fix-push.</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>invariants</code>
+                </td>
+                <td>off</td>
+                <td>Executable probes that ground a finding by running RED.</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h2>strictMode</h2>
+          <p>
+            A boolean gate on merges. When a review turns up a{' '}
+            <code>critical</code> finding, <code>strictMode: true</code> makes the{' '}
+            <code>clud-bug-review</code> check fail — branch protection blocks the
+            merge until the finding is resolved. Left off (the default), the same
+            finding posts as an advisory: the check goes <em>neutral</em>, never
+            red, and the merge is never blocked.
+          </p>
+          <pre>
+            <code>{`{
+  "strictMode": true
+}`}</code>
+          </pre>
+          <p>
+            The value is read from the pull request&rsquo;s <strong>base ref</strong>{' '}
+            — the branch being merged into, not the PR&rsquo;s own head — so a
+            pull request cannot disable strict mode on itself in the same diff.
+            The mapping from verdict to check conclusion lives in{' '}
+            <a href={`${REPO_URL}/blob/main/src/core/check-verdict.ts`} rel="noopener">
+              src/core/check-verdict.ts
+            </a>
+            : clean is <em>success</em>, critical under strict mode is{' '}
+            <em>failure</em>, and a review that could not run is <em>neutral</em>{' '}
+            — the bot never blocks a merge on its own inability to run.
+          </p>
+
+          <h2>reviewContext</h2>
+          <p>
+            Standing, repo-level guidance that focuses every review — &ldquo;scrutinize
+            the auth migration&rdquo;, &ldquo;the generated files under{' '}
+            <code>gen/</code> are intentional&rdquo;. Because it is committed to the
+            manifest by a maintainer and read from the base ref, it is{' '}
+            <strong>trusted</strong>: it may direct the review freely.
+          </p>
+          <pre>
+            <code>{`{
+  "reviewContext": "Scrutinize any change under src/auth/**. The files under gen/ are generated and intentional — do not flag them for style."
+}`}</code>
+          </pre>
+          <p>
+            The object form is equivalent, and is the shape to reach for when you
+            want the key to read as a block:
+          </p>
+          <pre>
+            <code>{`{
+  "reviewContext": { "instructions": "Prefer table-driven tests for parsers." }
+}`}</code>
+          </pre>
+          <p>
+            The text is trimmed and capped at 4&nbsp;KB so a runaway config cannot
+            dominate the prompt (see{' '}
+            <a href={`${REPO_URL}/blob/main/src/core/review-context.ts`} rel="noopener">
+              src/core/review-context.ts
+            </a>
+            ). This trusted channel is distinct from the{' '}
+            <strong>untrusted</strong> per-PR marker: a{' '}
+            <code>&lt;!-- clud-bug: … --&gt;</code> comment in a pull request&rsquo;s{' '}
+            <em>description</em> may point the review at a file, but it is fenced
+            so it can never suppress a finding, lower a severity, relax a skill,
+            or touch the merge gate. Whoever opens the PR authors that marker, so
+            it is treated as a hint, never an instruction.
+          </p>
+
+          <h2>reviewPasses</h2>
+          <p>
+            Configures the multi-pass plan — how many independent passes the
+            reviewer runs per skill, and how their findings are aggregated. Two
+            layouts are accepted. The flat form sets one repo-wide policy:
+          </p>
+          <pre>
+            <code>{`{
+  "reviewPasses": {
+    "count": 2,
+    "mode": "cross-check",
+    "applyTo": "all"
+  }
+}`}</code>
+          </pre>
+          <p>
+            The split form sets a default and overrides individual skills — useful
+            when one skill (a security audit, say) earns deeper scrutiny than the
+            rest:
+          </p>
+          <pre>
+            <code>{`{
+  "reviewPasses": {
+    "default": { "count": 1, "mode": "cross-check" },
+    "perSkill": { "security-audit": { "count": 3 } }
+  }
+}`}</code>
+          </pre>
+          <p>
+            <code>count</code> is clamped to a hard ceiling of{' '}
+            <strong>three</strong> passes; there is no escape hatch, since a
+            fourth Claude call per skill is where cost turns user-hostile.{' '}
+            <code>mode</code> is <code>cross-check</code> (the default),{' '}
+            <code>consensus</code>, or <code>independent</code>;{' '}
+            <code>applyTo</code> may be narrowed to <code>shared-only</code> so
+            only shared skills multi-pass. Precedence runs perSkill → the skill&rsquo;s
+            own <code>review_passes</code> frontmatter → the repo default →
+            the built-in single pass, resolved in{' '}
+            <a href={`${REPO_URL}/blob/main/src/core/review-plan.ts`} rel="noopener">
+              src/core/review-plan.ts
+            </a>
+            . What the modes actually mean is the subject of{' '}
+            <a href="/docs/multi-pass">the multi-pass entry</a>.
+          </p>
+
+          <h2>design</h2>
+          <p>
+            An optional visual review. When enabled, the bot renders each changed
+            UI surface on the pull request&rsquo;s deploy-preview and critiques the
+            screenshots against your <code>kind: design</code> skills. It is off
+            by default and gated tightly — it only ever runs, and only ever costs,
+            on a repo that opted in, with at least one design skill installed, on
+            a pull request.
+          </p>
+          <pre>
+            <code>{`{
+  "design": {
+    "enabled": true,
+    "gate": "advisory",
+    "themes": ["light", "dark"],
+    "viewports": ["desktop", "mobile"]
+  }
+}`}</code>
+          </pre>
+          <p>
+            <code>gate</code> is <code>advisory</code> by default — design
+            findings post as comments and never block. Set it to{' '}
+            <code>strict</code> to make a design <code>critical</code> turn the
+            check red. <code>themes</code> defaults to both light and dark;{' '}
+            <code>viewports</code> to a single desktop width. A missing or
+            malformed block resolves to the off default, so a typo can never
+            silently enable the render (see{' '}
+            <a href={`${REPO_URL}/blob/main/src/core/design.ts`} rel="noopener">
+              src/core/design.ts
+            </a>
+            ).
+          </p>
+
+          <h2>autoResolve</h2>
+          <p>
+            Governs what happens on a fix-push. For each open thread the bot
+            raised on a prior pass, it re-verifies whether the new commit
+            addressed the original concern, then resolves, keeps open, or
+            escalates it.
+          </p>
+          <pre>
+            <code>{`{
+  "autoResolve": {
+    "mode": "verified",
+    "uncertain_critical_action": "request_changes"
+  }
+}`}</code>
+          </pre>
+          <p>
+            <code>mode</code> is <code>verified</code> (the default — call the
+            per-thread verifier) or <code>off</code> (leave every thread open,
+            make no verifier calls). <code>uncertain_critical_action</code>{' '}
+            decides the one genuinely hazardous case: a verifier that is{' '}
+            <em>uncertain</em> about a critical finding. Left at{' '}
+            <code>request_changes</code>, that thread is kept open and escalated;{' '}
+            <code>leave_open</code> keeps it open with a milder note. A critical
+            is never silently dismissed either way. The rule table lives in{' '}
+            <a href={`${REPO_URL}/blob/main/src/core/auto-resolve.ts`} rel="noopener">
+              src/core/auto-resolve.ts
+            </a>{' '}
+            and is walked through in{' '}
+            <a href="/docs/auto-fix">the auto-fix entry</a>.
+          </p>
+
+          <h2>invariants</h2>
+          <p>
+            The executable-probe field. An invariant is a behavioral property
+            paired with a shell <code>probe</code> that exits non-zero when the
+            property is violated. Where <code>reviewContext</code> is checked{' '}
+            <em>statically</em> against the diff, a probe is <em>run</em> — so it
+            can ground a bug that lives on no single changed line. A finding fires
+            only when a probe comes back RED, and that RED output stands equal to
+            a quoted diff line.
+          </p>
+          <pre>
+            <code>{`{
+  "invariants": [
+    {
+      "name": "the CLI prints usage without a network call",
+      "appliesTo": ["src/cli/**"],
+      "probe": "node dist/cli.js --help",
+      "expect": "usage: clud-bug"
+    }
+  ]
+}`}</code>
+          </pre>
+          <p>
+            Each invariant carries a <code>name</code> (shown in the probe-results
+            block and any finding), one or more <code>appliesTo</code> globs over
+            the changed paths (the probe runs only when the diff hits one), the{' '}
+            <code>probe</code> command itself, and an optional <code>expect</code>{' '}
+            golden reference. Declaring at least one valid invariant is the opt-in;
+            the block is off until then. An explicit <code>enabled: false</code>{' '}
+            on the wrapper form is a kill-switch that retains the set while turning
+            probes off:
+          </p>
+          <pre>
+            <code>{`{
+  "invariants": {
+    "enabled": false,
+    "list": [ { "name": "…", "appliesTo": ["…"], "probe": "…" } ]
+  }
+}`}</code>
+          </pre>
+          <p>
+            Probes run only on a pull request, and only on trusted work — the
+            reviewer never executes a probe exercised by an untrusted diff. The
+            config and its gate live in{' '}
+            <a href={`${REPO_URL}/blob/main/src/core/invariants.ts`} rel="noopener">
+              src/core/invariants.ts
+            </a>
+            ; why RED output grounds a finding as firmly as a quoted line is the
+            subject of <a href="/docs/multi-pass">the multi-pass entry</a>.
+          </p>
+        </div>
+
+        <a className="doc-back" href="/docs">← Back to the field manual</a>
+      </div>
+
+      <footer className="colophon">
+        <span>
+          Open source.{' '}
+          <a href="https://github.com/thrillmade/clud-bug/blob/main/LICENSE">MIT</a>.
+        </span>
+        <span className="credit">
+          a{' '}
+          <a href="https://thrillmot.com" rel="noopener">
+            thrillmot
+          </a>{' '}
+          project
+        </span>
+        <span>
+          <a href="/docs">docs</a>
+          {' · '}
+          <a href="/docs/skills">skills</a>
+        </span>
+      </footer>
+    </main>
+  );
+}

--- a/site/app/docs/multi-pass/page.tsx
+++ b/site/app/docs/multi-pass/page.tsx
@@ -1,0 +1,263 @@
+import type { Metadata } from 'next';
+
+const REPO_URL = 'https://github.com/thrillmade/clud-bug';
+
+export const metadata: Metadata = {
+  title: 'Multi-pass review — Clud Bug docs',
+  description:
+    'The three naturalists of a multi-pass review — Beetle, Wasp, Mantis — the cross-check, consensus, and independent modes, and why a reproduction you ran grounds a finding as firmly as a quoted line.',
+  alternates: { canonical: '/docs/multi-pass' },
+};
+
+export default function DocsMultiPass() {
+  return (
+    <main className="page">
+      <header className="folio">
+        <span>A Field Guide to Code Specimens</span>
+        <span>Multi-pass · MMXXVI</span>
+      </header>
+
+      <div className="doc">
+        <a className="doc-back" href="/docs">← Field manual</a>
+
+        <header className="doc-head">
+          <span className="doc-eyebrow">§ Multi-pass Review</span>
+          <h1 className="doc-title">Three naturalists.</h1>
+          <p className="doc-lede">
+            A single reviewer optimizing for recall will over-report. A single
+            reviewer optimizing for precision will miss the subtle ones. A
+            multi-pass review splits the work: one pass casts a wide net, a second
+            tries to tear the catch apart, and a third settles what they cannot
+            agree on.
+          </p>
+        </header>
+
+        <div className="doc-body">
+          <h2>1. Beetle, Wasp, Mantis</h2>
+          <p>
+            Three roles, in a fixed order. Each is a distinct reviewer with its
+            own tier — a fast model for the broad scan, a stronger model for the
+            adversarial work.
+          </p>
+          <table className="doc-table">
+            <thead>
+              <tr>
+                <th>Role</th>
+                <th>Tier</th>
+                <th>Its job</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <strong>Beetle</strong>
+                </td>
+                <td>Sonnet-class</td>
+                <td>
+                  The broad first scan. Reads the diff against every skill and
+                  optimizes for recall — surface every candidate.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Wasp</strong>
+                </td>
+                <td>Opus-class</td>
+                <td>
+                  The adversary. Re-reads the diff and tries to <em>refute</em>{' '}
+                  Beetle&rsquo;s findings — prove each a false positive, or add the
+                  real ones Beetle missed. Only findings that survive refutation
+                  are kept.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Mantis</strong>
+                </td>
+                <td>Opus-class</td>
+                <td>
+                  The arbiter. Dispatched only when two passes disagree on a
+                  gate-relevant finding; re-examines the disputed ones and records
+                  the deciding verdict.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            Skepticism is the point of the second pass — Wasp&rsquo;s job is to
+            disagree, not to nod. The defaults live in{' '}
+            <a href={`${REPO_URL}/blob/main/src/core/review-plan.ts`} rel="noopener">
+              src/core/review-plan.ts
+            </a>
+            . Multi-pass is App-tier: the hosted bot orchestrates the three roles
+            server-side. The open-source workflow runs the same skill engine and
+            the same grounding discipline described below.
+          </p>
+
+          <h2>2. Three modes of aggregation</h2>
+          <p>
+            How the passes combine is a choice, set by{' '}
+            <code>reviewPasses.mode</code> in{' '}
+            <a href="/docs/config">the manifest</a>. Each trades recall against
+            precision differently.
+          </p>
+          <table className="doc-table">
+            <thead>
+              <tr>
+                <th>Mode</th>
+                <th>How findings combine</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <code>cross-check</code>
+                </td>
+                <td>
+                  The default. Pass 1 scans broadly; each later pass is
+                  adversarial and tries to refute it. Keep only what survives
+                  refutation.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>consensus</code>
+                </td>
+                <td>
+                  Passes run independently; keep a finding only when two or more
+                  land on it — except a critical, which is never silently dropped:
+                  reproduce it to keep, or refute it with a clean check.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>independent</code>
+                </td>
+                <td>
+                  Passes run independently and their findings are unioned, each
+                  attributed to its pass — minus any a quick adversarial re-read
+                  refutes.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            Passes are capped at three. A two-pass cross-check escalates to a
+            third Mantis pass <em>only</em> when passes 1 and 2 disagree on a
+            critical or minor finding — if they agree, or only differ on a
+            pre-existing note, the arbiter is skipped. The prose the reviewer
+            actually follows is assembled in{' '}
+            <a href={`${REPO_URL}/blob/main/src/cli/review-prompt.ts`} rel="noopener">
+              src/cli/review-prompt.ts
+            </a>
+            .
+          </p>
+
+          <h2>3. Reproduction as grounding</h2>
+          <p>
+            The oldest rule against false positives is &ldquo;quote the exact line
+            or drop it&rdquo;. It is a good floor and a bad ceiling: an emergent,
+            combinatorial, or cross-cutting bug lives on no single changed line, so
+            the rule that kills noise also silences real bugs. Clud Bug widens the
+            gate. A finding must be grounded in <strong>any one</strong> of:
+          </p>
+          <ul>
+            <li>
+              <strong>a quoted line</strong> — the exact offending line from the
+              diff, with its line number;
+            </li>
+            <li>
+              <strong>a reproduction you ran</strong> — the command plus the
+              observed output that demonstrates the bug. A repro is{' '}
+              <em>stronger</em> evidence than a quote, not weaker;
+            </li>
+            <li>
+              <strong>a named violated invariant</strong> — a one-sentence
+              property the change breaks, plus the input that breaks it.
+            </li>
+          </ul>
+          <p>
+            A finding that none of these can ground is dropped; silence beats a
+            false positive. But a bug that lives between correct lines is not
+            waved through on suspicion — it is reproduced or named. A reproduction
+            or a named invariant satisfies even a skill whose letter says
+            &ldquo;quote the line&rdquo;: the wider grounding wins. This is the{' '}
+            <code>GROUNDING_RULE</code>, and it is paired with an execution-safety
+            boundary — a reproduction runs only against your own trusted work,
+            never against an untrusted contributor&rsquo;s diff, since running that
+            would be code execution with the reviewer&rsquo;s shell and tokens.
+          </p>
+
+          <h2>4. What the benchmark found</h2>
+          <p>
+            The grounding rule was measured against a seeded corpus of{' '}
+            <strong>20 scenarios</strong> — 14 planted bugs across the emergent,
+            combinatorial, and cross-cutting classes, plus 6 clean decoys: correct
+            code wearing a bug-prone shape. Each was scored by three independent
+            reviewers.
+          </p>
+          <table className="doc-table">
+            <thead>
+              <tr>
+                <th>Metric</th>
+                <th>Result</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Recall — buggy scenarios caught</td>
+                <td>100% (every planted bug, all reviewers)</td>
+              </tr>
+              <tr>
+                <td>Precision — clean scenarios not flagged</td>
+                <td>100% (zero false positives)</td>
+              </tr>
+              <tr>
+                <td>Grounding</td>
+                <td>Every catch grounded by a reproduction the reviewer ran</td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            The decoys are the interesting half. Reviewers reproduced the tricky
+            input, confirmed the invariant <em>held</em>, and reported nothing —
+            the same discipline that catches the emergent bug keeps the reviewer
+            quiet on code that merely looks dangerous. The full corpus and per-bug
+            notes are in{' '}
+            <a href={`${REPO_URL}/blob/main/benchmark/RESULTS.md`} rel="noopener">
+              benchmark/RESULTS.md
+            </a>
+            .
+          </p>
+          <p>
+            Executable invariants are how you carry this discipline into your own
+            repo — a probe that runs RED is a reproduction the review does not have
+            to improvise. See <a href="/docs/config">the invariants block</a> for
+            how to declare one.
+          </p>
+        </div>
+
+        <a className="doc-back" href="/docs">← Back to the field manual</a>
+      </div>
+
+      <footer className="colophon">
+        <span>
+          Open source.{' '}
+          <a href="https://github.com/thrillmade/clud-bug/blob/main/LICENSE">MIT</a>.
+        </span>
+        <span className="credit">
+          a{' '}
+          <a href="https://thrillmot.com" rel="noopener">
+            thrillmot
+          </a>{' '}
+          project
+        </span>
+        <span>
+          <a href="/docs">docs</a>
+          {' · '}
+          <a href="/docs/config">config</a>
+        </span>
+      </footer>
+    </main>
+  );
+}

--- a/site/app/docs/page.tsx
+++ b/site/app/docs/page.tsx
@@ -1,0 +1,109 @@
+import type { Metadata } from 'next';
+
+const REPO_URL = 'https://github.com/thrillmade/clud-bug';
+
+export const metadata: Metadata = {
+  title: 'Documentation — Clud Bug',
+  description:
+    'The clud-bug field manual: how review skills work, the .clud-bug.json options, auto-fix and auto-resolve, and the Beetle / Wasp / Mantis multi-pass review.',
+  alternates: { canonical: '/docs' },
+};
+
+export default function Docs() {
+  return (
+    <main className="page">
+      <header className="folio">
+        <span>A Field Guide to Code Specimens</span>
+        <span>Documentation · MMXXVI</span>
+      </header>
+
+      <div className="doc">
+        <a className="doc-back" href="/">← Field guide</a>
+
+        <header className="doc-head">
+          <span className="doc-eyebrow">§ Field Manual</span>
+          <h1 className="doc-title">The field manual.</h1>
+          <p className="doc-lede">
+            Four entries on how Clud Bug reviews a pull request — the skills it
+            reads, the manifest that configures it, how it verifies and closes
+            its own findings, and the three naturalists of a multi-pass review.
+          </p>
+        </header>
+
+        <div className="doc-body">
+          <p>
+            Every entry below is grounded in the open source. Each option maps
+            to a module you can read at{' '}
+            <a href={REPO_URL} rel="noopener">github.com/thrillmade/clud-bug</a>{' '}
+            — nothing here is a feature the code doesn&rsquo;t already carry.
+            Start anywhere.
+          </p>
+
+          <table className="doc-table">
+            <thead>
+              <tr><th>Entry</th><th>Field notes</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><a href="/docs/skills">Review skills</a></td>
+                <td>
+                  What a <code>SKILL.md</code> is, how the bot loads one at the
+                  PR base ref and cites it by slug, and where the baseline kit
+                  and community skills come from.
+                </td>
+              </tr>
+              <tr>
+                <td><a href="/docs/config">Configuration</a></td>
+                <td>
+                  Every <code>.clud-bug.json</code> option —{' '}
+                  <code>strictMode</code>, <code>reviewContext</code>,{' '}
+                  <code>reviewPasses</code>, <code>design</code>,{' '}
+                  <code>autoResolve</code>, and the executable{' '}
+                  <code>invariants</code> — with a small example each.
+                </td>
+              </tr>
+              <tr>
+                <td><a href="/docs/auto-fix">Auto-fix &amp; auto-resolve</a></td>
+                <td>
+                  How a fix-push is verified thread-by-thread, and the rule
+                  table that resolves, keeps open, or escalates each finding
+                  the bot raised.
+                </td>
+              </tr>
+              <tr>
+                <td><a href="/docs/multi-pass">Multi-pass review</a></td>
+                <td>
+                  Beetle, Wasp, and Mantis; the cross-check, consensus, and
+                  independent modes; and why a reproduction grounds a finding
+                  as firmly as a quoted line.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <p>
+            The <a href="/pricing">pricing page</a> covers which tiers unlock
+            multi-pass and the design critique. For what the App reads and
+            retains, see <a href="/privacy">privacy &amp; data handling</a>.
+          </p>
+        </div>
+
+        <a className="doc-back" href="/">← Back to the field guide</a>
+      </div>
+
+      <footer className="colophon">
+        <span>
+          Open source. <a href="https://github.com/thrillmade/clud-bug/blob/main/LICENSE">MIT</a>.
+        </span>
+        <span className="credit">
+          a <a href="https://thrillmot.com" rel="noopener">thrillmot</a> project
+        </span>
+        <span>
+          <a href="/pricing">pricing</a>
+          {' · '}
+          <a href="/privacy">privacy</a>
+        </span>
+      </footer>
+    </main>
+  );
+}

--- a/site/app/docs/skills/page.tsx
+++ b/site/app/docs/skills/page.tsx
@@ -1,0 +1,184 @@
+import type { Metadata } from 'next';
+
+const REPO_URL = 'https://github.com/thrillmade/clud-bug';
+const SKILLS_SH_URL = 'https://skills.sh';
+
+export const metadata: Metadata = {
+  title: 'Review skills — Clud Bug docs',
+  description:
+    'How clud-bug review skills work: a .claude/skills/<slug>/SKILL.md file with YAML frontmatter, loaded at the PR base ref and cited by slug — kind, applies_to, review_passes, and where skills come from.',
+  alternates: { canonical: '/docs/skills' },
+};
+
+export default function DocsSkills() {
+  return (
+    <main className="page">
+      <header className="folio">
+        <span>A Field Guide to Code Specimens</span>
+        <span>Review Skills · MMXXVI</span>
+      </header>
+
+      <div className="doc">
+        <a className="doc-back" href="/docs">← Field manual</a>
+
+        <header className="doc-head">
+          <span className="doc-eyebrow">§ Review Skills</span>
+          <h1 className="doc-title">How review skills work.</h1>
+          <p className="doc-lede">
+            A skill is a plain Markdown file. Clud Bug reads the skills in a
+            repository on every pull request and grades the diff against them,
+            citing each one by name. Your team&rsquo;s standards become the
+            reviewer.
+          </p>
+        </header>
+
+        <div className="doc-body">
+          <h2>1. A skill is a SKILL.md file</h2>
+          <p>
+            Each skill lives at{' '}
+            <code>.claude/skills/&lt;slug&gt;/SKILL.md</code> — a Markdown body
+            with a YAML frontmatter block at the head. The body is the
+            discipline the reviewer reads; the frontmatter is the routing
+            metadata. A minimal one:
+          </p>
+          <pre><code>{`---
+name: critical-issues-only
+description: PR review discipline — flag only correctness, security, and performance issues. Skip nits.
+---
+
+# Critical issues only
+
+When reviewing a pull request, only surface issues that fall into one of
+these buckets: correctness bugs, security vulnerabilities, performance
+problems, missing coverage for new code paths. Quote the specific line.
+`}</code></pre>
+          <p>
+            The frontmatter is parsed by <code>parseFrontmatter</code> in{' '}
+            <a href={`${REPO_URL}/blob/main/src/core/skills.ts`} rel="noopener">
+              src/core/skills.ts</a>. A malformed block is skipped, not fatal —
+            one bad skill never takes down the whole review.
+          </p>
+
+          <h2>2. Loaded at the base ref, cited by slug</h2>
+          <p>
+            On each review the bot loads the SKILL.md files from the PR&rsquo;s{' '}
+            <strong>base ref</strong> — the branch being merged into, not the
+            PR&rsquo;s own head. A pull request therefore cannot weaken the
+            skills it will be graded against by editing them in the same diff.
+          </p>
+          <p>
+            Every finding is attributed to the skill that raised it, and the
+            review summary carries a per-skill scan line for each loaded skill:
+          </p>
+          <pre><code>{`### Per-skill scan
+- [critical-issues-only]: scanned all paths. 2 critical findings below.
+- [brand-voice-review]: scanned 3 microcopy changes. 1 finding (below).
+- [pii-and-compliance]: scanned analytics + logging. 0 findings.`}</code></pre>
+          <p>
+            A review loads at most <strong>eight</strong> skills
+            (<code>MAX_SKILLS</code>). Baseline skills are pinned first; the
+            remaining slots fill by install count.
+          </p>
+
+          <h2>3. Frontmatter fields</h2>
+          <table className="doc-table">
+            <thead>
+              <tr><th>Field</th><th>Meaning</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>name</code></td><td>Required. Kebab-case slug — the identity cited in findings.</td></tr>
+              <tr><td><code>description</code></td><td>Required. One line on what the skill checks.</td></tr>
+              <tr><td><code>source</code></td><td><code>manual</code>, <code>logmind-derived</code>, <code>skills-sh</code>, or <code>clud-bug-baseline</code>.</td></tr>
+              <tr><td><code>kind</code></td><td><code>rule</code> (default), <code>voice</code>, or <code>design</code>.</td></tr>
+              <tr><td><code>review_mode</code></td><td><code>shared</code> (default) or <code>dedicated</code>.</td></tr>
+              <tr><td><code>applies_to</code></td><td>Path globs, extensions, and an optional author login. Absent = load always.</td></tr>
+              <tr><td><code>review_passes</code></td><td>Skill-author intent for pass depth — <code>count</code> and <code>mode</code>.</td></tr>
+            </tbody>
+          </table>
+
+          <h3>kind — what lens the skill speaks to</h3>
+          <p>
+            <code>rule</code> is an ordinary correctness/convention skill.{' '}
+            <code>voice</code> is a copy/brand-voice skill and requires a{' '}
+            <code>voice_scope</code> (<code>personal</code>, <code>team</code>,{' '}
+            <code>org</code>, or <code>community</code>). <code>design</code>{' '}
+            drives the visual design critique rather than the code review — the
+            bot renders the changed UI and critiques the screenshots against
+            it. See <a href="/docs/config">configuration</a> for the{' '}
+            <code>design</code> block that turns that pass on.
+          </p>
+
+          <h3>applies_to — scope a skill to the files it cares about</h3>
+          <p>
+            A skill with <code>applies_to</code> loads only when the diff
+            actually touches its territory:
+          </p>
+          <pre><code>{`applies_to:
+  paths:
+    - "src/ui/**"
+    - "lib/components/**"
+  extensions: [".tsx", ".jsx"]
+  author: "renovate-bot"`}</code></pre>
+          <p>
+            <code>paths</code> and <code>extensions</code> are OR&rsquo;d — a
+            single changed file matching either is enough. When{' '}
+            <code>author</code> is also set, it is AND&rsquo;d: the skill loads
+            only for PRs opened by that login. Globs are minimal — <code>*</code>{' '}
+            matches within a path segment, <code>**</code> matches across
+            slashes, <code>?</code> a single character. A skill with no{' '}
+            <code>applies_to</code> block is scope-universal and loads on every
+            review.
+          </p>
+
+          <h3>review_mode — one shared call, or a dedicated one</h3>
+          <p>
+            <code>shared</code> skills load together in a single reviewer call
+            so their findings cross-correlate. <code>dedicated</code> gives a
+            skill its own focused call — reserved for domain skills (brand
+            voice, compliance, API contracts) where attention dilution at high
+            skill counts is the real failure mode.
+          </p>
+
+          <h2>4. Where skills come from</h2>
+          <p>
+            <strong>The baseline kit.</strong> Four skills ship pinned on every
+            install — <code>critical-issues-only</code>,{' '}
+            <code>evidence-based-review</code>,{' '}
+            <code>respect-existing-conventions</code>, and{' '}
+            <code>clud-bug-collaboration</code>. They are the floor discipline
+            under every review.
+          </p>
+          <p>
+            <strong>The catalog.</strong> The bot can pull curated and
+            searched skills from{' '}
+            <a href={SKILLS_SH_URL} rel="noopener">skills.sh</a> and rank them
+            in alongside the baselines, capped at eight total.
+          </p>
+          <p>
+            <strong>Your own.</strong> Drop a Markdown file into{' '}
+            <code>.claude/skills/</code>, commit it, and Clud Bug cites it by
+            name on the next review. This is the moat — a generic reviewer
+            grades against generic best practices; a skill grades against{' '}
+            <em>your</em> conventions.
+          </p>
+        </div>
+
+        <a className="doc-back" href="/docs">← Back to the field manual</a>
+      </div>
+
+      <footer className="colophon">
+        <span>
+          Open source. <a href="https://github.com/thrillmade/clud-bug/blob/main/LICENSE">MIT</a>.
+        </span>
+        <span className="credit">
+          a <a href="https://thrillmot.com" rel="noopener">thrillmot</a> project
+        </span>
+        <span>
+          <a href="/docs">docs</a>
+          {' · '}
+          <a href="/docs/config">config</a>
+        </span>
+      </footer>
+    </main>
+  );
+}

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -979,6 +979,33 @@ main { position: relative; z-index: 1; }
 }
 .doc-body em.binomial { display: block; font-style: italic; color: var(--ink-faint); margin-top: 0.3rem; }
 
+/* Code blocks — the JSON examples + recipe snippets in the docs entries.
+   The doc pages carried no `pre` style, so a bare <pre><code> fell through to
+   the inline-code pill (background + border) and let long lines spill past the
+   reading column. Give the block its own field-note frame and scroll long
+   lines internally; reset the inner <code> so it isn't re-pilled. */
+.doc-body pre {
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  line-height: 1.6;
+  color: var(--ink);
+  background: var(--paper-warm);
+  border: var(--rule);
+  border-left: 3px solid var(--leaf-soft);
+  padding: 1rem 1.15rem;
+  margin: 1.2rem 0 1.7rem;
+  overflow-x: auto;
+}
+.doc-body pre code {
+  font-family: inherit;
+  font-size: inherit;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  white-space: pre;
+}
+
 /* Tables — sub-processors, retention, pricing rows. */
 .doc-table { width: 100%; border-collapse: collapse; margin: 1.4rem 0 1.8rem; font-size: 0.96rem; }
 .doc-table th, .doc-table td {
@@ -1032,4 +1059,5 @@ main { position: relative; z-index: 1; }
   .doc-body h2 { font-size: 1.35rem; }
   .doc-table { font-size: 0.88rem; }
   .doc-table th, .doc-table td { padding: 0.5rem 0.55rem; }
+  .doc-body pre { font-size: 0.74rem; padding: 0.85rem 0.95rem; }
 }


### PR DESCRIPTION
Adds the `/docs` subtree the Marketplace SUPPORT policy references. Five pages in the field-guide `.doc` style, each grounded in the real modules (no invented options): the index + **skills** (SKILL.md, base-ref load, slugs), **config** (every `.clud-bug.json` option incl. the new `invariants`), **auto-fix** (fix-push re-verification + the resolve rule table), **multi-pass** (Beetle/Wasp/Mantis, the modes, reproduction-as-grounding + the 20-scenario benchmark). Adds a `.doc-body pre` code-block style. Build green; all 5 routes prerender. 🤖