### PR TITLE
Phase S: landing refresh — max-mode, hardened review, auto-fix/resolve, design-critic

### DIFF
--- a/docs/decisions-branches/phase-s-landing.md
+++ b/docs/decisions-branches/phase-s-landing.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 14:54 - Phase S: landing-page refresh — surface max-mode, hardened review, auto-fix/resolve, design-critic
+
+**Reasoning:** The Marketplace listing sells four capabilities the homepage never showed. Added them as 4 new field-guide sections (additive; existing hero + sections untouched, renumbered §I-§X): §IV Weight of Evidence (reproduction-as-grounding + the 3 bug classes + the 20-scenario 100%/100% benchmark — the strongest differentiator, placed before the live observation); §VII Return Visit (auto-fix + auto-resolve fix-push re-verification); §VIII A Second Lens (optional design-critic, off-by-default/Team); §IX Max Mode (the free local tier: review in your own Claude Code session on your subscription, no API key, init --with-hooks + /clud-bug-review). All copy grounded in the real modules; verified init --with-hooks is a real flag. Build green, / prerenders, zero exclamations, on brand-voice.
+
+**Alternatives considered:** Rewrite the hero to lead with max-mode free tier (rejected: the hero + managed-tier framing is well-crafted; additive sections surface the free tier + differentiators without disturbing what works)
+
+**Implications:**
+- Remaining Phase S: the 5 Marketplace screenshots (need the live hosted bot on a fixture) + the tagline/category branding decisions (CEO)
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (13 decisions)
+## 2026-07 (14 decisions)
 
-- **2026-07-03** — Phase S: /docs self-service pages (skills, config, auto-fix, multi-pass) *(phase-s-docs)* — [decisions-branches/phase-s-docs.md](decisions-branches/phase-s-docs.md)
-- *... 11 more decisions ...*
+- **2026-07-03** — Phase S: landing-page refresh — surface max-mode, hardened review, auto-fix/resolve, design-critic *(phase-s-landing)* — [decisions-branches/phase-s-landing.md](decisions-branches/phase-s-landing.md)
+- *... 12 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -430,7 +430,7 @@ main { position: relative; z-index: 1; }
    Mono fonts ship visually larger than serif body text; without this the
    inline tokens overpower their surroundings. Applies to every `code` that
    isn't inside a `pre` (terminal blocks have their own scaling). */
-:where(.section-prose, .marginalia, .observation, .actions, .specimen-desc, .specimens-footer) code {
+:where(.section-prose, .section-prose-lead, .marginalia, .observation, .actions, .specimen-desc, .specimens-footer) code {
   font-family: var(--mono);
   font-size: 0.86em;
   background: var(--paper-warm);

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -249,10 +249,53 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* ─────────── §IV — FIELD OBSERVATION ─────────── */}
+      {/* ─────────── §IV — HARDENED REVIEW (reproduction-grounded) ─────────── */}
+      <section className="section" id="hardened">
+        <header className="section-head">
+          <span className="section-num">§ IV — Weight of Evidence</span>
+          <h2 className="section-title">A finding carries the evidence that caught it.</h2>
+        </header>
+        <div className="section-body">
+          <aside className="marginalia">
+            Reproductions run only on trusted, self-authored work. An untrusted
+            contributor&rsquo;s diff is grounded from the quoted line, or deferred
+            to a sandbox &mdash; never executed with the reviewer&rsquo;s shell.
+          </aside>
+          <div className="section-prose">
+            <p>
+              Most review tools can only point at one suspicious line, so those
+              are the only bugs they catch. Clud Bug grounds every finding one
+              of three ways &mdash; a line quoted from the diff, a reproduction it
+              actually runs, or a named invariant the change breaks. The
+              reproduction is the sharp end: a real bug often lives on{' '}
+              <em>no</em> single changed line.
+            </p>
+            <p>
+              That reaches three classes a line-scanner walks past.{' '}
+              <strong>Emergent</strong> &mdash; bad data flowing through
+              individually-correct lines, like a shared default mutated across
+              calls. <strong>Combinatorial</strong> &mdash; an invariant broken
+              only by a constructed input, like a duplicate key on a collision.{' '}
+              <strong>Cross-cutting</strong> &mdash; a cause in another file the
+              diff merely exposes, like a date-only sort read from a module the
+              change never touched.
+            </p>
+            <p>
+              <strong>The measurement.</strong> On a seeded corpus of 20
+              scenarios &mdash; 14 planted defects across those three classes plus
+              6 clean look-alikes as precision controls, each scored by three
+              independent reviewers &mdash; the hardened recipe caught every bug
+              and false-flagged none: 100% recall, 100% precision, every catch
+              grounded by a reproduction the reviewer wrote and ran.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ─────────── §V — FIELD OBSERVATION ─────────── */}
       <section className="section" id="observations">
         <header className="section-head">
-          <span className="section-num">§ IV — Recorded Observation</span>
+          <span className="section-num">§ V — Recorded Observation</span>
           <h2 className="section-title">From Clud Bug&rsquo;s notebook.</h2>
         </header>
         <div className="section-body">
@@ -281,10 +324,10 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* ─────────── §V — REVIEW BUDGET ─────────── */}
+      {/* ─────────── §VI — REVIEW BUDGET ─────────── */}
       <section className="section">
         <header className="section-head">
-          <span className="section-num">§ V — Field Economy</span>
+          <span className="section-num">§ VI — Field Economy</span>
           <h2 className="section-title">Even the largest specimens get a full examination.</h2>
         </header>
         <div className="section-body">
@@ -314,10 +357,114 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* ─────────── §VI — SELF-HOSTED ALTERNATIVE ─────────── */}
+      {/* ─────────── §VII — AUTO-FIX & AUTO-RESOLVE ─────────── */}
+      <section className="section" id="auto-resolve">
+        <header className="section-head">
+          <span className="section-num">§ VII — Return Visit</span>
+          <h2 className="section-title">Push a fix; the reviewer comes back to check it.</h2>
+        </header>
+        <div className="section-body">
+          <aside className="marginalia">
+            Only the threads Clud Bug opened are revisited &mdash; the rest of the
+            conversation is left untouched. A thread it resolves is marked
+            verified, so the audit trail stays honest.
+          </aside>
+          <div className="section-prose">
+            <p>
+              Every finding lands with a one-line fix. Push the change, and on
+              the next commit Clud Bug re-reads each thread it opened &mdash;
+              comparing the code at the anchor before and after &mdash; and
+              decides, thread by thread, whether the concern was actually
+              addressed.
+            </p>
+            <p>
+              A thread that was <strong>addressed</strong> resolves itself and
+              says so. One that was <strong>not</strong> stays open, noted that
+              the re-review still applies &mdash; and if it was critical, the check
+              flips to request-changes. When the verdict is{' '}
+              <strong>uncertain</strong> on a critical finding, the thread stays
+              open and escalates: a critical is never silently dismissed. What
+              was genuinely fixed clears out; what still matters stays pinned.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ─────────── §VIII — DESIGN-CRITIC (optional visual review) ─────────── */}
+      <section className="section" id="design-critic">
+        <header className="section-head">
+          <span className="section-num">§ VIII — A Second Lens</span>
+          <h2 className="section-title">For UI changes, an eye on the rendered page.</h2>
+        </header>
+        <div className="section-body">
+          <aside className="marginalia">
+            Off by default, Team tier. Turned on per repo, and advisory unless
+            the gate is set to strict &mdash; then a critical design finding turns
+            the check red like any other.
+          </aside>
+          <div className="section-prose">
+            <p>
+              Code review reads the diff; it never sees the page. When a repo
+              carries design skills &mdash; a house style, a spacing scale, a set
+              of elite-UI standards &mdash; Clud Bug can open an optional visual
+              pass. On a pull request with a live preview, it renders each
+              changed surface in light and dark, then critiques the screenshots
+              against those skills, citing the element it sees and the standard
+              it reads against.
+            </p>
+            <p>
+              It flags what is <em>fine but not elite</em>, not only what is
+              broken. The pass stays off until a repo asks for it, and stays
+              advisory until it is told to gate &mdash; the render runs only on an
+              opted-in Team repo, only on a pull request, only when a design
+              skill is installed.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ─────────── §IX — MAX MODE (free local tier) ─────────── */}
+      <section className="section" id="max-mode">
+        <header className="section-head">
+          <span className="section-num">§ IX — Max Mode</span>
+          <h2 className="section-title">The review runs in the session you already pay for.</h2>
+        </header>
+        <div className="section-body">
+          <aside className="marginalia">
+            No API key, no hosted bill. Max mode reviews on your own Claude Code
+            subscription &mdash; the free tier, and the most local path of all.
+          </aside>
+          <div>
+            <p className="section-prose-lead">
+              The hosted App carries its own credentials and its own runner. Max
+              mode carries neither: the review runs <em>inside</em> the Claude
+              Code session already open on your machine, on the subscription you
+              already have. A commit hook surfaces the review recipe;{' '}
+              <code>/clud-bug-review</code> runs it on demand against the current
+              branch&rsquo;s open PR.
+            </p>
+            <pre className="terminal">
+              <span className="cmd">npx clud-bug init --with-hooks</span>{'\n'}
+              <span className="out">  🐛 commit hook wired into <span className="path">.claude/settings.json</span></span>{'\n'}
+              <span className="out">  reviews run on this session &mdash; no <span className="path">ANTHROPIC_API_KEY</span></span>{'\n\n'}
+              <span className="cmd">git commit -m &quot;Fix the parser&quot;</span>{'\n'}
+              <span className="out">  clud-bug review (max mode) &mdash; on your subscription</span>{'\n'}
+            </pre>
+            <p className="specimens-footer">
+              Same skill engine, same grounding. The recipe is rendered from the
+              shared review engine, so a commit gets a single fast pass and a
+              pull request gets the deeper review the diff calls for. The commit
+              is never blocked; the review lands back in the session as a note
+              you can act on.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ─────────── §X — SELF-HOSTED ALTERNATIVE ─────────── */}
       <section className="section" id="self-hosted">
         <header className="section-head">
-          <span className="section-num">§ VI — Self-hosted alternative</span>
+          <span className="section-num">§ X — Self-hosted alternative</span>
           <h2 className="section-title">Prefer your own runner? Ship the workflow.</h2>
         </header>
         <div className="section-body">


### PR DESCRIPTION
Surfaces the four Marketplace capabilities the homepage never showed, as additive field-guide sections (hero + existing sections untouched; renumbered §I–§X):
- **§IV Weight of Evidence** — reproduction-as-grounding + the 3 bug classes + the 20-scenario **100% recall / 100% precision** benchmark (the differentiator).
- **§VII Return Visit** — auto-fix + auto-resolve.
- **§VIII A Second Lens** — the optional design-critic.
- **§IX Max Mode** — the free local tier (review on your own Claude Code subscription, `init --with-hooks`).

All copy grounded in the real modules; `--with-hooks` verified real; build green, `/` prerenders, zero exclamations. Remaining Phase S: 5 screenshots (need the live bot) + tagline/category (yours). 🤖