### PR TITLE
chore: bump to 0.7.0-rc.22 (ships the Phase R hardening batch)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.21
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.22
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/decisions-branches/chore-bump-rc22.md
+++ b/docs/decisions-branches/chore-bump-rc22.md
@@ -9,3 +9,12 @@
 
 ---
 
+## 2026-07-03 15:04 - chore: sync the strict-mode-gate composite pin to v0.7.0-rc.22 (release discipline)
+
+**Reasoning:** The rc.22 bump left the strict-mode-gate@vX composite pin stale in the 3 rendered workflow templates + .github/actions/strict-mode-gate/action.yml. The release-discipline + prompts tests assert those pins match package.json version, so a bare version bump fails CI until they're synced. Bumped all four rc.21→rc.22. This is the required manual release chore (no auto-sync script — gen-version.mjs only derives the CLI version).
+
+**Implications:**
+- Release-discipline is now: bump package.json + sync the 4 strict-mode-gate pins together. A future improvement could script this sync.
+
+---
+

--- a/docs/decisions-branches/chore-bump-rc22.md
+++ b/docs/decisions-branches/chore-bump-rc22.md
@@ -1,0 +1,11 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 15:00 - chore: bump clud-bug to 0.7.0-rc.22 (ships the Phase R review-hardening batch)
+
+**Reasoning:** rc.22 publishes the full Phase R review-hardening batch merged this session: R1 invariants + R2 reproduction-as-grounding (+ the panel-caught RCE fix) + R3 unverified verdict + R2-hosted grounding + R6-local probe-run step + the 20-scenario benchmark (100% recall/precision). The npm-publish.yml workflow publishes package.json's version on a v* tag push and auto-routes a -rc version to the 'next' dist-tag, which every repo's floating @next hook picks up. Bumping package.json is the source of truth (gen-version.mjs derives the CLI version from it).
+
+**Implications:**
+- After this merges, cut the release by pushing the tag: git tag v0.7.0-rc.22 && git push origin v0.7.0-rc.22 → npm-publish.yml ships clud-bug@0.7.0-rc.22 to @next
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (14 decisions)
+## 2026-07 (15 decisions)
 
-- **2026-07-03** — Phase S: landing-page refresh — surface max-mode, hardened review, auto-fix/resolve, design-critic *(phase-s-landing)* — [decisions-branches/phase-s-landing.md](decisions-branches/phase-s-landing.md)
-- *... 12 more decisions ...*
+- **2026-07-03** — chore: bump clud-bug to 0.7.0-rc.22 (ships the Phase R review-hardening batch) *(chore-bump-rc22)* — [decisions-branches/chore-bump-rc22.md](decisions-branches/chore-bump-rc22.md)
+- *... 13 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (15 decisions)
+## 2026-07 (16 decisions)
 
-- **2026-07-03** — chore: bump clud-bug to 0.7.0-rc.22 (ships the Phase R review-hardening batch) *(chore-bump-rc22)* — [decisions-branches/chore-bump-rc22.md](decisions-branches/chore-bump-rc22.md)
-- *... 13 more decisions ...*
+- **2026-07-03** — chore: sync the strict-mode-gate composite pin to v0.7.0-rc.22 (release discipline) *(chore-bump-rc22)* — [decisions-branches/chore-bump-rc22.md](decisions-branches/chore-bump-rc22.md)
+- *... 14 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.21",
+  "version": "0.7.0-rc.22",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.21
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.21
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -717,7 +717,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.21
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow


### PR DESCRIPTION
Bumps `package.json` 0.7.0-rc.21 → **0.7.0-rc.22**. Publishing this ships the full Phase R review-hardening batch (R1–R7 + benchmark). After merge, cut the release with a tag push (`v0.7.0-rc.22`) — `npm-publish.yml` builds/tests/publishes and auto-routes the `-rc` version to the `next` dist-tag. 🤖