### PR TITLE
Add designing-elite-ui as a 4th bundled kind: design skill (design-critic bar)

### DIFF
--- a/docs/decisions-branches/feat-design-kit-elite-ui.md
+++ b/docs/decisions-branches/feat-design-kit-elite-ui.md
@@ -1,0 +1,14 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-04 00:34 - Add designing-elite-ui as a 4th bundled kind: design skill in the CLI design-kit
+
+**Reasoning:** The hosted design-critic (design-pass.ts buildDesignPrompt) feeds every kind: design skill body verbatim into the visual critic prompt. The design-kit at templates/skills/design/ is directory-driven (loadDesignKit reads every .md and stamps kind: design + source: clud-bug-design), so dropping the file in makes the elite bar a bundled default that 'init --with-design' pins and the hosted pass measures against — no loader/code change. Gives the critic a concrete elite standard (one-axis color, APCA contrast, floating stable chrome, dark parity) instead of a vague 'looks fine'.
+
+**Alternatives considered:** Bundle it in clud-bug-app/lib/baseline-skills — rejected: baseline is the no-manifest code-review fallback (kind: baseline), not design; design defaults live only in the CLI design-kit (bundled-only, no agent-skills upstream per loadDesignKit doc)., Rewrite the body into terse critic instructions like the 3 siblings — rejected: fold it in verbatim; the principles + gotchas table + worked example ARE the measurable bar.
+
+**Implications:**
+- test/init-with-design.test.js now pins the exact 4-slug set (deepEqual) and >=4 count; the '3 kind: design skills' help/comment strings in main.ts bumped to 4.
+- Description flows only to the manifest/dashboard listing (buildDesignPrompt uses name+body only), so it was adapted to the sibling 'Visual review —' format while the SKILL body stays verbatim from ~/.claude/skills/designing-elite-ui.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (18 decisions)
+## 2026-07 (19 decisions)
 
-- **2026-07-03** — configure-github: one-stop repo setup — reporulez preset taxonomy (--preset) + restored universal repo-conveniences PATCH *(configure-github-rulesets)* — [decisions-branches/configure-github-rulesets.md](decisions-branches/configure-github-rulesets.md)
-- *... 16 more decisions ...*
+- **2026-07-04** — Add designing-elite-ui as a 4th bundled kind: design skill in the CLI design-kit *(feat-design-kit-elite-ui)* — [decisions-branches/feat-design-kit-elite-ui.md](decisions-branches/feat-design-kit-elite-ui.md)
+- *... 17 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -71,7 +71,7 @@ function parseArgs(argv) {
     withLocalReview: false,
     withHooks: false,
     // rc.16: `clud-bug init --with-design` installs the design-critic kit
-    // (3 `kind: design` skills) and flips the off-by-default `design` block to
+    // (4 `kind: design` skills) and flips the off-by-default `design` block to
     // enabled so the visual review lens runs (local recipe + hosted bot).
     withDesign: false,
     // rc.18: `clud-bug init --local-only` installs MAX MODE (skills + slash
@@ -243,7 +243,7 @@ Options:
                         \`git commit\` / \`logmind log\`, it fetches a review recipe and
                         surfaces it to the agent (on this session's subscription)
                         via asyncRewake. Implies --with-local-review. Off by default.
-  --with-design         (init) Install the design-critic kit (3 \`kind: design\`
+  --with-design         (init) Install the design-critic kit (4 \`kind: design\`
                         skills) and enable the off-by-default visual review
                         lens — renders changed UI and critiques it. Off by default.
   --local-only          (init) MAX MODE: install the slash command + commit hook
@@ -1388,7 +1388,7 @@ async function runInit(args) {
     }
   }
 
-  // rc.16: --with-design installs the bundled design-critic kit (3 `kind:
+  // rc.16: --with-design installs the bundled design-critic kit (4 `kind:
   // design` skills) and enables the off-by-default design lens. writeSkills
   // writes the SKILL.md files + merges the manifest entries; the `design` block
   // is flipped on the manifest read below so the local recipe + hosted bot both

--- a/templates/skills/design/designing-elite-ui.md
+++ b/templates/skills/design/designing-elite-ui.md
@@ -1,0 +1,57 @@
+---
+name: designing-elite-ui
+description: Visual review — hold the rendered UI to a concrete elite/Figma-grade bar (one-axis color, APCA-gated contrast, floating stable chrome, dark verified) instead of a vague "looks fine." The STANDARD a design-critic measures against.
+kind: design
+review_mode: dedicated
+applies_to:
+  paths: ["site/**", "app/**", "**/components/**", "**/ui/**"]
+  extensions: [".tsx", ".jsx", ".css", ".scss", ".vue", ".svelte"]
+---
+
+# Designing Elite UI
+
+## Overview
+
+The design *bar* is the standard; the QA loop is the enforcement (see `orchestrating-elite-agent-qa`). A critic with no encoded bar finds nothing — "looks fine." This skill is the bar: the transferable taste an agent designs *to* and critiques *against*. **Encode it explicitly** (a tokens file + a short design-system doc) so both builders and the critic share one source of truth.
+
+## The Principles
+
+1. **One semantic role → one meaning → one variation axis.** Give each role a band where *exactly one* dimension varies and the rest lock; it reads deliberate, not random. **Reserve a color for ONE meaning only.** (Example below: structures vary hue at locked L/C; power "draws" vary hue, never red; power *infrastructure* is red, reserved.)
+2. **Contrast is gated, not eyeballed.** APCA-check every text-on-fill. A theme flip needs its *own* ramp (a dark draw ramp, derived dark reds) — never reuse the light values on a dark surface.
+3. **Restraint beats richness.** Distinguish by hue-in-band + shape + label, not a rainbow. Plain text labels with a subtle active state, not boxy segmented controls. Tinted/outline active states over heavy solid fills. Retire decoration that doesn't carry meaning.
+4. **Type: one family + its mono.** Mono for data, codes, and labels; optical centering (`text-box-trim`); restrained weights. Consistency over variety.
+5. **The canvas is stable; chrome floats.** The work surface NEVER reflows or rescales on selection (lock px-per-unit). Panels float *over* it; the toolbar morphs smoothly; one icon language; a per-context accent. Infinite/dotted background beats a white card on a page.
+6. **Interaction feels alive before the click.** Cursor affordances (resize cursors on handles, grab/grabbing on pan), hover highlights, valid/invalid ghost tints, smooth transitions, unmistakable active states.
+7. **Light and dark are BOTH primary.** Design and verify in both; neither is an afterthought.
+8. **Optical, not metric, alignment.** Center to the eye (text trim, icon nudge); balance a frame so no element reads as an afterthought; never ship a clipped focus ring.
+
+## Gotchas That Quietly Break the Bar
+
+| Symptom | Cause / fix |
+|---|---|
+| Popover text clipped / see-through | A `backdrop-filter` ancestor traps even `position:fixed` children → **portal the popover to `<body>`**; opaque frame + inner scroll owns any fade-mask. |
+| Pill/toolbar drifts off-center | `left:50%` on an auto-width fixed element caps it to 50vw → wrap in a full-width flex container, center inside; recompute after layout settles. |
+| Dark mode looks washed/low-contrast | Light tokens reused on dark → add explicit dark ramps; re-run APCA. |
+| Two controls read "active" at once | Mode vs tool both filled with the accent → give the resting one a tinted/outline state. |
+| Glyph looks wrong only when rotated | Glyph drawn fixed while footprint swapped → re-orient the silhouette with the rotation. |
+
+## Encode the Bar (so it's enforceable)
+
+The bar only bites if it's written down where agents read it:
+- **Tokens** in one file (colors as the actual system, not ad-hoc hex), emitted to CSS vars.
+- **A design-system doc** (a SPEC section / memory) stating the domains, the variation axis per role, the type rules, the chrome model.
+- **Feed it to the design-critic**: "challenge the render against THIS bar in light + dark" — not "is it nice?". Vague critics pass everything.
+
+**REQUIRED COMPANION:** `orchestrating-elite-agent-qa` is how this bar gets enforced per slice (the browser-driving critic gate).
+
+## Worked Example (one system, fully specified)
+
+Burning-Man hub editor, build-free vanilla JS:
+- **Color = OKLCH, three domains, one axis each.** Structures (fills) = cool band blue→purple→pink, vary **hue**, lock L≈.88/C≈.07; neutral types near-grey. Power "draws" (need badges) = warm band green→orange, vary **hue**, NO red (it also colors the wires). Power infrastructure (generator · drops · distros · fire-lanes · hazard) = **red, reserved**; drops vary **lightness** only. Colors-off → one uniform grey for all structures; the semantic red/badges stay. APCA-gate every amp label + draw chip.
+- **Type:** Geist + Geist Mono; mono for ids/amps/metadata; `text-box-trim` centering.
+- **Chrome:** stable dotted infinite canvas (px-per-foot locked across select/deselect); floating inspector + center-bottom morphing toolbar pill (Lucide icons, per-mode accent); slide-up legend with plain text-on-surface tabs (not a boxy segmented box), content inset ~15%.
+- **Interaction:** orientation-aware resize cursors on edge/vertex handles; SimCity ghost preview (valid/invalid tint) before placement; soft red "needs-power" halos, not hard error tiles, for in-progress states.
+
+## Deploying This Skill (per writing-skills)
+
+A reference/taste skill — test by **retrieval + application**: give an agent a UI task with this skill loaded and check the output actually exhibits the principles (one-axis color, APCA, floating chrome, dark verified), not just that it read them. Tighten any principle an agent reads but doesn't apply.

--- a/test/init-with-design.test.js
+++ b/test/init-with-design.test.js
@@ -1,4 +1,4 @@
-// rc.16 — `clud-bug init --with-design` installs the design-critic kit (3
+// rc.16 — `clud-bug init --with-design` installs the design-critic kit (4
 // `kind: design` skills) and flips the off-by-default `design` block to
 // enabled, so the visual review lens runs (local recipe + hosted bot).
 
@@ -45,14 +45,14 @@ test('init --with-design installs the design kit + enables the design lens', asy
   // The design block is flipped on.
   assert.equal(manifest.design?.enabled, true, 'design.enabled should be true');
 
-  // The 3 design-kit skills are registered with kind: design.
+  // The 4 design-kit skills are registered with kind: design.
   const designEntries = (manifest.installed || []).filter((e) => e.kind === 'design');
-  assert.ok(designEntries.length >= 3, `expected >=3 design entries, got ${designEntries.length}`);
+  assert.ok(designEntries.length >= 4, `expected >=4 design entries, got ${designEntries.length}`);
   const slugs = designEntries.map((e) => e.slug).sort();
   assert.deepEqual(
     slugs,
-    ['design-system-consistency', 'frontend-a11y', 'visual-polish'],
-    'all three design-kit skills should be pinned',
+    ['design-system-consistency', 'designing-elite-ui', 'frontend-a11y', 'visual-polish'],
+    'all four design-kit skills should be pinned',
   );
   for (const e of designEntries) {
     assert.equal(e.source, 'clud-bug-design', `${e.slug} source should be clud-bug-design`);


### PR DESCRIPTION
## What

Adds `designing-elite-ui` to the CLI design-kit (`templates/skills/design/`) as a 4th bundled default `kind: design` skill, so the hosted design-critic measures rendered UIs against a **concrete elite bar** (one-axis color, APCA-gated contrast, floating/stable chrome, dark parity) instead of a vague "looks fine."

## Why this location / no loader change

- `loadDesignKit(DESIGN_DIR)` (`src/cli/skills.ts`) is **directory-driven** — it reads every `.md` in `templates/skills/design/`, stamps `kind: design` + `source: clud-bug-design`, and `writeSkills` pins them. Dropping a file in is all that's needed; the loader is untouched.
- The hosted pass (`clud-bug-app/lib/design-pass.ts` → `buildDesignPrompt`) concatenates every `kind: design` skill's **body verbatim** into the visual critic prompt. So the new skill flows straight into the critic once `init --with-design` has pinned it.
- Design defaults live **only** in the CLI design-kit (bundled-only, no agent-skills upstream — per `loadDesignKit`'s doc). Not a baseline skill (those are the no-manifest code-review fallback, `kind: baseline`, in the app).

## Contents

- **New:** `templates/skills/design/designing-elite-ui.md` — frontmatter matches the 3 sibling design-kit skills (`kind: design`, `review_mode: dedicated`, `applies_to`); **body is verbatim** from the authored `designing-elite-ui` skill (principles, gotchas table, worked example). Description adapted to the sibling "Visual review —" format (description feeds only the manifest/dashboard listing — `buildDesignPrompt` uses name + body only).
- **Sync:** `test/init-with-design.test.js` now pins the exact 4-slug set (`deepEqual`) and `>= 4` count. `src/cli/main.ts` help/comment strings bumped "3 `kind: design` skills" → "4".

## Verification

`vitest run test/init-with-design.test.js test/skills-frontmatter.test.js` → **41 passed**. The end-to-end `init --with-design` test confirms the new skill loads, is stamped `kind: design` / `source: clud-bug-design`, and pins as slug `designing-elite-ui` alongside the other three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)