### PR TITLE
Phase Z3: clud-bug CLI notary side — deterministic validators + attestation bundle + submit-bundle handshake

### DIFF
--- a/docs/decisions-branches/feat-notary-z3.md
+++ b/docs/decisions-branches/feat-notary-z3.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-11 14:22 - Phase Z3: clud-bug CLI notary side — deterministic ③④⑤ validators + attestation bundle + submit-bundle handshake
+
+**Reasoning:** The un-forgeable notary core (SPEC §10.3.3). Pure validators (coverage/grounding/consistency) reuse the inline-threads diff parser; the CLI is a deterministic program that refuses to certify an inconsistent/ungrounded review before assembling a bundle, then submits to the notary (Z4 stub) with a self-attested fallback. Adversarially reviewed (4 lenses -> per-finding verify); 6 confirmed findings fixed incl. two majors (server 4xx -> terminal reject not fallback; quote/tab-aware diff parser for non-ASCII + space filenames).
+
+**Alternatives considered:** Required grounding via a split CRITICAL_FINDING_ITEM schema variant (rejected: discriminated-union type-ripple through the App finding aggregator + couples the live hosted Zod pipeline, for no added safety since the notary re-check is the real gate), camelCase bundle finding fields (rejected: snake_case grounding_kind matches the review-output wire schema + the recipe)
+
+**Implications:**
+- Z4 consumes the exported NotaryBundle schema + notaryResponseIsRejection semantics; the CLI notary path stays opt-in behind CLUD_BUG_NOTARY_URL until the Z4 endpoint + Z6 integration_id pin land; hosted grounding-required elevation + POST /notarize deferred to Z4; grounding is OPTIONAL in the review-output schema but REQUIRED-and-validated in the notary bundle
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -78,6 +78,8 @@ clud-bug
 │   ├── init-with-design.test.js
 │   ├── init-with-skdd.test.js
 │   ├── inline-threads.test.js
+│   ├── notary-bundle.test.js
+│   ├── notary-validate.test.js
 │   ├── prompt-builder.test.js
 │   ├── prompts.eval.test.js
 │   ├── prompts.test.js

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (19 decisions)
+## 2026-07 (20 decisions)
 
-- **2026-07-04** — Add designing-elite-ui as a 4th bundled kind: design skill in the CLI design-kit *(feat-design-kit-elite-ui)* — [decisions-branches/feat-design-kit-elite-ui.md](decisions-branches/feat-design-kit-elite-ui.md)
-- *... 17 more decisions ...*
+- **2026-07-11** — Phase Z3: clud-bug CLI notary side — deterministic ③④⑤ validators + attestation bundle + submit-bundle handshake *(feat-notary-z3)* — [decisions-branches/feat-notary-z3.md](decisions-branches/feat-notary-z3.md)
+- *... 18 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/src/cli/hooks.ts
+++ b/src/cli/hooks.ts
@@ -57,7 +57,11 @@ export function buildCommitReviewCommand(pin: string = 'next'): string {
     `if [ -n "$ev" ]; then case "$ev" in *'git commit'*|*'logmind log'*) ;; *) exit 0 ;; esac; fi`,
     `sha=$(git rev-parse HEAD 2>/dev/null) || exit 0`,
     `gitdir=$(git rev-parse --git-dir 2>/dev/null) || exit 0`,
-    `marker="$gitdir/clud-bug-last-commit-review"`,
+    // Pure LOOP-GUARD, not an attestation (§10.3.3): records only that the recipe
+    // was already SURFACED for this SHA (avoids a re-review on an amend / double
+    // fire). It never means "reviewed" and never yields a green check — the only
+    // authoritative "reviewed" state is the notary-issued `clud-bug-review` check.
+    `marker="$gitdir/clud-bug-hook-fired"`,
     `[ "$(cat "$marker" 2>/dev/null)" = "$sha" ] && exit 0`,
     // H4 — one retry on a transient npx/network blip (a stale lock, a slow
     // registry) before giving up, so a hiccup doesn't silently skip the review.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -126,6 +126,8 @@ function parseArgs(argv) {
     else if (a === '--no-strict') args.strict = false;
     else if (a === '--owner') args.owner = argv[++i];
     else if (a === '--details-url') args.detailsUrl = argv[++i];
+    // Phase Z: notary attestation bundle (JSON path) for `post-check-run`.
+    else if (a === '--bundle') args.bundle = argv[++i];
     else args._.push(a);
   }
   return args;
@@ -229,6 +231,10 @@ Commands:
                         clean|critical|failed --sha <sha> [--critical-count N]
                         [--source local|ci] [--strict|--no-strict] [--dry-run].
                         clean→success, critical+strict→failure, else neutral.
+                        With CLUD_BUG_NOTARY_URL set + --bundle <file>, submits a
+                        notary attestation bundle instead (Phase Z); the notary
+                        issues the check. Falls back to the self-attested post if
+                        the endpoint is unreachable.
 
 Options:
   --offline             Skip skills.sh; pin only the bundled baseline specimens.

--- a/src/cli/post-check-run.ts
+++ b/src/cli/post-check-run.ts
@@ -14,8 +14,20 @@
 
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
 
-import { deriveCheck, normalizeVerdict, CLUD_BUG_CHECK_NAME } from '../core/index.js';
+import {
+  deriveCheck,
+  normalizeVerdict,
+  CLUD_BUG_CHECK_NAME,
+  parseBundle,
+  validateBundle,
+  validateConsistency,
+  splitUnifiedDiff,
+  notaryResponseIsRejection,
+  type NotaryBundle,
+  type DiffFile,
+} from '../core/index.js';
 import { readManifest } from './skills.js';
 
 interface PostCheckRunArgs {
@@ -27,6 +39,8 @@ interface PostCheckRunArgs {
   owner?: string;
   repo?: string;
   detailsUrl?: string;
+  /** Path to a notary attestation bundle (JSON). Activates the notary submit path. */
+  bundle?: string;
   dryRun?: boolean;
   cwd?: string;
   _?: string[];
@@ -35,6 +49,115 @@ interface PostCheckRunArgs {
 function sh(cmd: string, cmdArgs: string[], input?: string): { ok: boolean; out: string; err: string } {
   const r = spawnSync(cmd, cmdArgs, { encoding: 'utf8', ...(input !== undefined ? { input } : {}) });
   return { ok: r.status === 0, out: (r.stdout ?? '').trim(), err: (r.stderr ?? '').trim() };
+}
+
+/**
+ * Best-effort load of the diff a bundle attests to, as `DiffFile[]`, for the
+ * LOCAL pre-check. Prefers the PR diff (matches GitHub's view); falls back to
+ * the commit diff. Returns `[]` when neither is obtainable — the caller then
+ * skips the diff-dependent checks (③④) and lets the SERVER do the authoritative
+ * validation against GitHub's ground truth (Z4).
+ */
+function loadDiffFiles(bundle: NotaryBundle): DiffFile[] {
+  let raw = '';
+  if (bundle.pr !== undefined) {
+    const r = sh('gh', ['pr', 'diff', String(bundle.pr), '--color', 'never']);
+    if (r.ok) raw = r.out;
+  }
+  if (!raw && bundle.head_sha) {
+    // -c core.quotepath=false → git emits non-ASCII paths as literal UTF-8
+    // (no octal quoting), so the splitter sees real filenames.
+    const r = sh('git', ['-c', 'core.quotepath=false', 'show', '--no-color', '--format=', bundle.head_sha]);
+    if (r.ok) raw = r.out;
+  }
+  return raw ? splitUnifiedDiff(raw) : [];
+}
+
+type NotaryOutcome = 'posted' | 'rejected' | 'fallback';
+
+interface NotaryResult {
+  outcome: NotaryOutcome;
+  /** The parsed + locally-validated bundle, when we got that far (for a bundle-derived fallback). */
+  bundle: NotaryBundle | null;
+}
+
+/**
+ * The notary submit path (Phase Z). Reads + parses the bundle, LOCALLY
+ * re-validates it (the handshake — a deterministic program refusing to certify
+ * an inconsistent/ungrounded review), then POSTs to the notary. The server (Z4)
+ * re-validates ①–⑤ against GitHub and — as SOLE issuer — posts the pinned check.
+ *
+ * Outcomes:
+ *   'posted'   — the notary accepted; the SERVER owns the check, do not self-post.
+ *   'rejected' — the certification is definitively refused (malformed / inconsistent /
+ *                ungrounded bundle, OR a server 4xx AUTHORITATIVELY declining). Post
+ *                NO check — never a false green off a bad artifact or over a server "no".
+ *   'fallback' — the endpoint is DOWN (network error or 5xx), not a verdict; the caller
+ *                may self-post the self-attested check (derived from THIS bundle) so local
+ *                max mode keeps gating while Z4 is pending.
+ */
+async function submitToNotary(
+  notaryUrl: string,
+  bundlePath: string,
+  warn: (m: string) => void,
+): Promise<NotaryResult> {
+  let bundle: NotaryBundle | null;
+  try {
+    bundle = parseBundle(JSON.parse(await readFile(bundlePath, 'utf8')));
+  } catch (e) {
+    warn(`could not read the bundle at ${bundlePath} (${e instanceof Error ? e.message : String(e)}); not certifying.`);
+    return { outcome: 'rejected', bundle: null };
+  }
+  if (!bundle) {
+    warn(`the bundle at ${bundlePath} is malformed; not certifying (fix the review artifact).`);
+    return { outcome: 'rejected', bundle: null };
+  }
+
+  // Local pre-check: consistency is diff-free (always run); coverage + grounding
+  // need the diff (run only when one is obtainable — else defer to the server).
+  const diffFiles = loadDiffFiles(bundle);
+  const consistency = validateConsistency(bundle.verdict, bundle.findings);
+  if (!consistency.ok) {
+    warn(`bundle is internally inconsistent — ${consistency.reason}; not certifying.`);
+    return { outcome: 'rejected', bundle };
+  }
+  if (diffFiles.length > 0) {
+    const v = validateBundle(bundle, diffFiles);
+    if (!v.coverage.ok) {
+      warn(`bundle coverage is incomplete — unreviewed changed file(s): ${v.coverage.missingFiles.join(', ')}; not certifying.`);
+      return { outcome: 'rejected', bundle };
+    }
+    if (!v.grounding.ok) {
+      warn(`bundle has ungrounded critical finding(s): ${v.grounding.violations.map((x) => x.reason).join('; ')}; not certifying.`);
+      return { outcome: 'rejected', bundle };
+    }
+  }
+
+  // Submit. TODO(Z4): the server mints/consumes the nonce, re-fetches GitHub's
+  // ground-truth diff, re-runs ①–⑤, signs, and posts the pinned check.
+  const url = notaryUrl.replace(/\/+$/, '') + '/notarize';
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(bundle),
+    });
+    if (res.ok) {
+      process.stdout.write(`clud-bug: notarized ${bundle.repo}@${bundle.head_sha.slice(0, 12)} (verdict=${bundle.verdict}); the notary posts the check.\n`);
+      return { outcome: 'posted', bundle };
+    }
+    // A 4xx is the SOLE issuer authoritatively declining — terminal, no check.
+    // Only a 5xx (server down) is a fallback-able outage.
+    if (notaryResponseIsRejection(res.status)) {
+      warn(`notary declined the bundle (HTTP ${res.status}); not certifying.`);
+      return { outcome: 'rejected', bundle };
+    }
+    warn(`notary unavailable (HTTP ${res.status}); falling back to the self-attested check.`);
+    return { outcome: 'fallback', bundle };
+  } catch (e) {
+    warn(`notary endpoint unreachable (${e instanceof Error ? e.message : String(e)}); falling back to the self-attested check.`);
+    return { outcome: 'fallback', bundle };
+  }
 }
 
 export async function runPostCheckRun(args: PostCheckRunArgs): Promise<void> {
@@ -47,6 +170,21 @@ export async function runPostCheckRun(args: PostCheckRunArgs): Promise<void> {
     const r = sh('git', ['rev-parse', 'HEAD']);
     if (!r.ok) return void warn('no --sha and `git rev-parse HEAD` failed; skipping.');
     sha = r.out;
+  }
+
+  // --- Notary submit path (Phase Z) — the un-forgeable route -------------
+  // When CLUD_BUG_NOTARY_URL is set and a --bundle is supplied, submit an
+  // attestation bundle: the CLI locally re-checks it (the handshake) and the
+  // notary (Z4) issues the pinned check. Only 'fallback' (endpoint unreachable)
+  // continues to the self-attested self-post below; 'posted'/'rejected' are terminal.
+  let fallbackBundle: NotaryBundle | null = null;
+  const notaryUrl = process.env.CLUD_BUG_NOTARY_URL?.trim();
+  if (notaryUrl && typeof args.bundle === 'string' && args.bundle && !args.dryRun) {
+    const { outcome, bundle } = await submitToNotary(notaryUrl, args.bundle, warn);
+    if (outcome !== 'fallback') return;
+    // Endpoint down → self-post below, derived from the ALREADY-VALIDATED bundle
+    // (not the raw --verdict flags, which a bundle-only invocation never passes).
+    fallbackBundle = bundle;
   }
 
   // --- strictMode: explicit flag wins, else the repo manifest -----------
@@ -62,9 +200,15 @@ export async function runPostCheckRun(args: PostCheckRunArgs): Promise<void> {
     }
   }
 
-  const verdict = normalizeVerdict(typeof args.verdict === 'string' ? args.verdict : undefined);
-  const criticalCount = Number(args.criticalCount ?? 0) || 0;
-  const source = args.source === 'local' ? 'local' : 'ci';
+  // A bundle-fallback self-post reflects what was actually VALIDATED (bundle
+  // verdict + its critical count, local source); otherwise the raw flags.
+  const verdict = fallbackBundle
+    ? fallbackBundle.verdict
+    : normalizeVerdict(typeof args.verdict === 'string' ? args.verdict : undefined);
+  const criticalCount = fallbackBundle
+    ? fallbackBundle.findings.filter((f) => f.severity === 'critical').length
+    : Number(args.criticalCount ?? 0) || 0;
+  const source: 'local' | 'ci' = fallbackBundle ? 'local' : args.source === 'local' ? 'local' : 'ci';
   const { conclusion, title, summary } = deriveCheck({ verdict, strictMode, criticalCount, source });
 
   // --- resolve owner/repo (flags, else gh) ------------------------------

--- a/src/cli/review-prompt.ts
+++ b/src/cli/review-prompt.ts
@@ -199,8 +199,11 @@ export function renderReviewRecipe(input: {
       ' ' +
       SEVERITY_RULE +
       ' Record `file`, `line` (when a line applies), `severity` (`critical` | `minor` | ' +
-      '`preexisting`), the `skill`, how you grounded it (quote / repro / invariant), and a one-line ' +
-      '`summary`. Finding nothing is the normal, common outcome — be precise, not exhaustive.';
+      '`preexisting`), the `skill`, a one-line `summary`, and — for EVERY 🔴 critical — its ' +
+      '`grounding` (the VERBATIM changed line you quote, or the reproduction command+output, or the ' +
+      'named violated invariant) plus `grounding_kind` (`quote`/`reproduction`/`invariant`). The notary ' +
+      're-checks a `quote` grounding against the diff, so quote the line EXACTLY. Finding nothing is the ' +
+      'normal, common outcome — be precise, not exhaustive.';
   } else {
     const passLines = Array.from({ length: maxPasses }, (_, i) => {
       const role = roleForPass(plan.roles, i, 'Reviewer');
@@ -250,19 +253,31 @@ export function renderReviewRecipe(input: {
       : 'Surface the findings into the session, and — if an open PR exists — post or edit (in ' +
         'place, by integer comment id) the clud-bug summary comment on it.';
 
-  // H3 — the merge-gate step (PR only). After reporting, the agent posts a
-  // SELF-ATTESTED `clud-bug-review` check so branch protection can gate the merge
-  // on a local review too. Commit/push triggers skip it (no PR head to anchor a
-  // check to). The conclusion is derived by `post-check-run` from the verdict +
-  // the repo's strictMode.
+  // H3 + Phase Z — the merge-gate step (PR only). clud-bug is a NOTARY: a green
+  // `clud-bug-review` check is CERTIFIED against the diff, not merely self-asserted.
+  // When the repo is notary-enabled (`CLUD_BUG_NOTARY_URL` set), the agent submits
+  // an attestation BUNDLE — clud-bug locally re-checks it (coverage/grounding/
+  // consistency; the handshake) and the notary issues the check after re-validating
+  // against GitHub's ground truth. Absent a notary, it falls back to the self-attested
+  // post (a developer-local signal, never the authoritative gate for untrusted authors).
+  // Commit/push triggers skip this (no PR head to anchor a check to).
   const gateStep =
     trigger === 'pr'
-      ? `\n\n## 5. Post the merge-gate check
-After reporting, post the self-attested \`clud-bug-review\` check so branch protection can gate on it:
+      ? `\n\n## 5. Certify the review (merge-gate check)
+clud-bug is a **notary** — a green \`clud-bug-review\` is CERTIFIED, not self-asserted. Your review must be validatable: every 🔴 critical carries a \`grounding\` span that appears verbatim in the diff (or a reproduction / named invariant), and you list every changed file you covered.
+
+**If this repo is notary-enabled** (\`CLUD_BUG_NOTARY_URL\` is set), write your findings as an attestation bundle and submit it — clud-bug re-checks it locally and the notary validates it against GitHub before issuing the check:
+\`\`\`bash
+# bundle.json = { "repo": "<owner>/<repo>", "pr": <N>, "head_sha": "<sha>", "verdict": "clean|critical|unverified",
+#   "findings": [ { "severity": "critical", "file": "...", "line": N, "summary": "...", "grounding": "<verbatim diff line>", "grounding_kind": "quote" } ],
+#   "coverage": ["<every changed file you reviewed>"], "recipe_version": "local" }
+clud-bug post-check-run --sha "$(git rev-parse HEAD)" --bundle bundle.json
+\`\`\`
+**Otherwise** post the self-attested check (a local signal, not independent CI):
 \`\`\`bash
 clud-bug post-check-run --sha "$(git rev-parse HEAD)" --verdict <clean|critical|unverified> --critical-count <N> --source local
 \`\`\`
-\`clean\` → passes (merge unblocked); \`critical\` → fails when the repo is in strict mode; \`unverified\` → neutral (does not block, but is NOT a pass) — post it when the change touched a probe/invariant surface you could not verify here (no probe ran, or a MAJOR you could not safely reproduce under execution-safety), so it defers to the sandboxed CI probe. **Do NOT post \`clean\` on an invariant-touching change you did not actually verify.** This is a **self-attested** local review (this session), not independent CI — post it honestly from what you actually found. Skip silently if \`gh\` lacks \`checks: write\`.`
+\`clean\` → passes; \`critical\` → fails in strict mode; \`unverified\` → neutral (not a pass) — use it when a probe/invariant surface could not be verified here, so it defers to CI. **Never post \`clean\` on a change you did not actually verify.** Post honestly from what you found; skip silently if \`gh\` lacks \`checks: write\`.`
       : '';
 
   // 3b (rc.15) — the OPTIONAL design-critic visual pass. Rendered only when the

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -327,6 +327,34 @@ export {
   type DerivedCheck,
   type DeriveCheckInput,
 } from './check-verdict.js';
+// Phase Z3 — the NOTARY. `notary-bundle` owns the attestation-bundle shape (the
+// contract Z4's `/notarize` consumes) + a tolerant parser; `notary-validate` owns
+// the pure deterministic ③④⑤ checks (coverage / grounding / consistency) both the
+// local CLI and the server re-run. SPEC §10.3.3.
+export {
+  buildBundle,
+  parseBundle,
+  notaryResponseIsRejection,
+  NOTARY_BUNDLE_VERSION,
+  NOTARY_PROTOCOL_VERSION,
+  type NotaryBundle,
+  type NotaryFinding,
+  type NotarySeverity,
+  type GroundingKind,
+} from './notary-bundle.js';
+export {
+  validateBundle,
+  validateCoverage,
+  validateGrounding,
+  validateConsistency,
+  spanAppearsInDiff,
+  splitUnifiedDiff,
+  type BundleValidation,
+  type CoverageResult,
+  type GroundingResult,
+  type GroundingViolation,
+  type ConsistencyResult,
+} from './notary-validate.js';
 export {
   API_BASE,
   MAX_SKILLS,

--- a/src/core/notary-bundle.ts
+++ b/src/core/notary-bundle.ts
@@ -1,0 +1,196 @@
+// Phase Z3 — the notary ATTESTATION BUNDLE.
+//
+// clud-bug is a NOTARY: it VALIDATES + CERTIFIES that a review actually ran
+// before a green `clud-bug-review` check gates a merge (protocol SPEC §10.3.3).
+// The bundle is the wire artifact the local CLI assembles from a completed
+// review and submits to the notary (`POST /notarize`, built in Z4). The server
+// re-validates it against GitHub's ground-truth diff, then — as the SOLE issuer
+// — posts the pinned check. This module owns the bundle SHAPE (the contract Z4
+// consumes) + a tolerant parser; the pure ①–⑤ checks live in `./notary-validate`.
+//
+// Design note (grounding): `grounding` is REQUIRED-for-critical HERE (enforced
+// by `validateGrounding`), not in the shared review-output schema
+// (`./review-schema`). A schema-`required` field can be satisfied with junk; the
+// load-bearing guarantee is the notary re-checking the quoted span against the
+// diff. Keeping the review-output field optional avoids a discriminated-union
+// ripple through the App's finding aggregator and any coupling to the live
+// hosted Zod pipeline. See docs/decisions-branches/feat-notary-z3.md.
+
+import type { ReviewVerdict } from './check-verdict.js';
+
+/** Bundle wire-format version. Bump on a breaking shape change. */
+export const NOTARY_BUNDLE_VERSION = 1;
+
+/**
+ * The protocol contract the bundle attests to — tracks SPEC §10.3.3
+ * ("Attestation integrity"). Bump in lockstep with a §10.3.3 contract change
+ * (coordinate the SPEC edit with logmind — the SPEC is the shared SkDD contract).
+ */
+export const NOTARY_PROTOCOL_VERSION = '1.2.0';
+
+export type NotarySeverity = 'critical' | 'minor' | 'preexisting';
+
+/**
+ * How a finding is grounded (mirrors the Phase R grounding forms: quote /
+ * reproduction / invariant). The notary deterministically verifies `quote`
+ * (the span must appear in the ground-truth diff); `reproduction`/`invariant`
+ * carry no diff-checkable artifact and are deferred to the clean-case audit.
+ */
+export type GroundingKind = 'quote' | 'reproduction' | 'invariant';
+
+/** A single finding as carried in the attestation bundle. */
+export interface NotaryFinding {
+  severity: NotarySeverity;
+  /** File path (repo-root-relative). Absent for a genuinely cross-cutting finding. */
+  file?: string;
+  /** 1-indexed line in `file`. */
+  line?: number;
+  summary: string;
+  /**
+   * Evidence anchoring the finding. REQUIRED for `critical` (the notary rejects
+   * a bare critical): a verbatim span from a changed line (`quote`), a
+   * reproduction's command+output (`reproduction`), or the violated-invariant
+   * statement (`invariant`).
+   */
+  grounding?: string;
+  /** Which grounding form `grounding` uses (defaults to `quote` when absent). */
+  grounding_kind?: GroundingKind;
+}
+
+/**
+ * The attestation bundle — assembled locally from a completed review, submitted
+ * to the notary. Z4's `/notarize` consumes exactly this shape, re-validates ①–⑤
+ * against GitHub, then posts the pinned check.
+ */
+export interface NotaryBundle {
+  bundle_version: number;
+  /** `owner/repo`. */
+  repo: string;
+  /** PR number. Absent for a commit-trigger local pre-notarization (no PR yet). */
+  pr?: number;
+  head_sha: string;
+  verdict: ReviewVerdict;
+  findings: NotaryFinding[];
+  /**
+   * The changed-file paths the review covered. The notary set-diffs this against
+   * GitHub's ground-truth changed files (③ coverage) so a partial / stale-checkout
+   * review can't be certified as complete.
+   */
+  coverage: string[];
+  /** The review recipe / CLI version that produced this bundle (provenance). */
+  recipe_version: string;
+  /** The SPEC §10.3.3 contract version this bundle conforms to. */
+  protocol_version: string;
+  /**
+   * Single-use nonce bound to (repo, PR, head_sha), minted by the server
+   * (`POST /challenge`, Z4). Absent on a locally pre-built bundle; the server
+   * requires it before certifying (① replay-closure).
+   */
+  nonce?: string;
+}
+
+/** Assemble a bundle from a completed review, stamping the wire + protocol versions. */
+export function buildBundle(input: {
+  repo: string;
+  pr?: number;
+  headSha: string;
+  verdict: ReviewVerdict;
+  findings: NotaryFinding[];
+  coverage: string[];
+  recipeVersion: string;
+  nonce?: string;
+}): NotaryBundle {
+  return {
+    bundle_version: NOTARY_BUNDLE_VERSION,
+    repo: input.repo,
+    ...(input.pr !== undefined ? { pr: input.pr } : {}),
+    head_sha: input.headSha,
+    verdict: input.verdict,
+    findings: input.findings,
+    coverage: input.coverage,
+    recipe_version: input.recipeVersion,
+    protocol_version: NOTARY_PROTOCOL_VERSION,
+    ...(input.nonce !== undefined ? { nonce: input.nonce } : {}),
+  };
+}
+
+const SEVERITIES: ReadonlySet<string> = new Set(['critical', 'minor', 'preexisting']);
+const GROUNDING_KINDS: ReadonlySet<string> = new Set(['quote', 'reproduction', 'invariant']);
+const VERDICTS: ReadonlySet<string> = new Set(['clean', 'critical', 'failed', 'unverified']);
+
+/**
+ * Classify a notary `/notarize` HTTP response for the submit path. A definitive
+ * client error (4xx) is the server AUTHORITATIVELY refusing to certify this
+ * bundle → terminal (post NO check). A 5xx or a network error is the endpoint
+ * being DOWN, not a verdict → the caller may fall back to the self-attested
+ * check. Conflating the two would let a server "no" be overridden by a local green.
+ */
+export function notaryResponseIsRejection(status: number): boolean {
+  return status >= 400 && status < 500;
+}
+
+function parseFinding(raw: unknown): NotaryFinding | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r['severity'] !== 'string' || !SEVERITIES.has(r['severity'])) return null;
+  if (typeof r['summary'] !== 'string' || !r['summary']) return null;
+  const finding: NotaryFinding = {
+    severity: r['severity'] as NotarySeverity,
+    summary: r['summary'],
+  };
+  if (typeof r['file'] === 'string' && r['file']) finding.file = r['file'];
+  if (typeof r['line'] === 'number' && Number.isInteger(r['line']) && r['line'] >= 1) {
+    finding.line = r['line'];
+  }
+  if (typeof r['grounding'] === 'string' && r['grounding']) finding.grounding = r['grounding'];
+  if (typeof r['grounding_kind'] === 'string' && GROUNDING_KINDS.has(r['grounding_kind'])) {
+    finding.grounding_kind = r['grounding_kind'] as GroundingKind;
+  }
+  return finding;
+}
+
+/**
+ * Tolerant parser for a bundle read from disk / the wire. Returns null on a
+ * missing or malformed required field (never throws) — the CLI treats a null as
+ * "no submittable bundle" and falls back to the self-attested path. A malformed
+ * finding is DROPPED, not tolerated silently into a green: if any finding is
+ * unparseable the whole bundle is rejected (null), so a truncated payload can't
+ * be certified as if it were complete.
+ */
+export function parseBundle(raw: unknown): NotaryBundle | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r['repo'] !== 'string' || !r['repo'].includes('/')) return null;
+  if (typeof r['head_sha'] !== 'string' || !r['head_sha']) return null;
+  // `verdict` is enum-typed — whitelist it like every other enum field, so a
+  // garbage verdict is a malformed bundle (null), never blind-cast through the
+  // trust boundary into validateConsistency / a derived check.
+  if (typeof r['verdict'] !== 'string' || !VERDICTS.has(r['verdict'])) return null;
+  if (!Array.isArray(r['findings'])) return null;
+  if (!Array.isArray(r['coverage'])) return null;
+
+  const findings: NotaryFinding[] = [];
+  for (const f of r['findings']) {
+    const parsed = parseFinding(f);
+    if (!parsed) return null; // reject the whole bundle rather than silently drop a finding
+    findings.push(parsed);
+  }
+  const coverage = r['coverage'].filter((c): c is string => typeof c === 'string');
+  if (coverage.length !== r['coverage'].length) return null;
+
+  const bundle: NotaryBundle = {
+    bundle_version:
+      typeof r['bundle_version'] === 'number' ? r['bundle_version'] : NOTARY_BUNDLE_VERSION,
+    repo: r['repo'],
+    head_sha: r['head_sha'],
+    verdict: r['verdict'] as ReviewVerdict,
+    findings,
+    coverage,
+    recipe_version: typeof r['recipe_version'] === 'string' ? r['recipe_version'] : '',
+    protocol_version:
+      typeof r['protocol_version'] === 'string' ? r['protocol_version'] : NOTARY_PROTOCOL_VERSION,
+  };
+  if (typeof r['pr'] === 'number' && Number.isInteger(r['pr'])) bundle.pr = r['pr'];
+  if (typeof r['nonce'] === 'string' && r['nonce']) bundle.nonce = r['nonce'];
+  return bundle;
+}

--- a/src/core/notary-validate.ts
+++ b/src/core/notary-validate.ts
@@ -1,0 +1,343 @@
+// Phase Z3 — the notary's DETERMINISTIC validators (③ coverage · ④ grounding ·
+// ⑤ consistency). Pure, no LLM, ~free (protocol SPEC §10.3.3).
+//
+// These run in TWO places: LOCALLY during a `clud-bug` run (fast context for the
+// max-mode agent + a pre-checked bundle) and AUTHORITATIVELY on the server
+// (Z4's `/notarize`, re-run against GitHub's ground-truth diff — local is
+// patchable, so it's never authoritative alone). Both call the SAME functions
+// here; only the diff source differs.
+//
+// What is (and isn't) provable deterministically:
+//   ⑤ consistency — verdict ⟺ findings. Fully decidable.
+//   ④ grounding   — a `quote`-form critical's span MUST appear in the diff; a
+//                   critical with NO evidence is rejected. `reproduction`/
+//                   `invariant` criticals carry no diff-checkable artifact →
+//                   accepted-but-flagged for the clean-case audit (accepting a
+//                   critical is the SAFE direction — it blocks).
+//   ③ coverage    — every changed file is present in the review's coverage claim
+//                   (no silently-skipped file). Note: whether the review truly
+//                   *looked* at a clean hunk is NOT attestable — that's the
+//                   theorem, handled by the audit, not here.
+
+import { parseHeadLines, type DiffFile } from './inline-threads.js';
+import type { ReviewVerdict } from './check-verdict.js';
+import type { NotaryBundle, NotaryFinding } from './notary-bundle.js';
+
+// ---------------------------------------------------------------------------
+// ⑤ consistency — verdict ⟺ findings
+// ---------------------------------------------------------------------------
+
+export interface ConsistencyResult {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * A `clean` verdict with a critical finding, or a `critical` verdict with none,
+ * is internally contradictory — the review can't be trusted, so it can't gate.
+ * `unverified` and `failed` are self-consistent regardless of the finding set
+ * (they never claim "clean"), so they always pass ⑤.
+ */
+export function validateConsistency(
+  verdict: ReviewVerdict,
+  findings: readonly NotaryFinding[],
+): ConsistencyResult {
+  const criticalCount = findings.filter((f) => f.severity === 'critical').length;
+  if (verdict === 'clean' && criticalCount > 0) {
+    return { ok: false, reason: `verdict 'clean' but ${criticalCount} critical finding(s) present` };
+  }
+  if (verdict === 'critical' && criticalCount === 0) {
+    return { ok: false, reason: `verdict 'critical' but no critical findings` };
+  }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// ③ coverage — every changed file addressed
+// ---------------------------------------------------------------------------
+
+export interface CoverageResult {
+  ok: boolean;
+  /** Changed files present in the ground-truth diff but absent from the coverage claim. */
+  missingFiles: string[];
+}
+
+/**
+ * The review's coverage claim MUST include every file the ground-truth diff
+ * changed. A missing file = a silently-skipped surface → the review can't be
+ * certified as complete. Extra claimed files (not in the diff) are harmless and
+ * ignored. Empty diff → trivially covered.
+ */
+export function validateCoverage(
+  coverage: readonly string[],
+  diffFiles: readonly DiffFile[],
+): CoverageResult {
+  const claimed = new Set(coverage.map((f) => f.trim()).filter(Boolean));
+  const missingFiles = diffFiles
+    .map((f) => f.filename)
+    .filter((name) => !claimed.has(name));
+  return { ok: missingFiles.length === 0, missingFiles };
+}
+
+// ---------------------------------------------------------------------------
+// ④ grounding — every 🔴 critical anchored to real evidence
+// ---------------------------------------------------------------------------
+
+export interface GroundingViolation {
+  index: number;
+  file?: string | undefined;
+  line?: number | undefined;
+  reason: string;
+}
+
+export interface GroundingResult {
+  ok: boolean;
+  /** Hard failures: a critical with no evidence, or a `quote` span not in the diff. */
+  violations: GroundingViolation[];
+  /**
+   * Criticals whose grounding the deterministic notary CANNOT confirm
+   * (`reproduction`/`invariant` form — no diff-checkable artifact). Not a
+   * failure: accepting a critical blocks the merge, the safe direction. Surfaced
+   * so the server can seed the clean-case audit / a human can scrutinize them.
+   */
+  unverifiable: GroundingViolation[];
+}
+
+/**
+ * For every CRITICAL finding:
+ *   - no `grounding` at all              → hard violation (no bare critical).
+ *   - `quote` (or unspecified) grounding → the span MUST appear verbatim
+ *     (whitespace-normalized) in an added/context line of its file's diff, else
+ *     hard violation (a claimed quote that isn't in the diff is fabricated).
+ *   - `reproduction`/`invariant`         → recorded as `unverifiable` (audit).
+ * Minor/preexisting findings are not grounding-gated here.
+ */
+export function validateGrounding(
+  findings: readonly NotaryFinding[],
+  diffFiles: readonly DiffFile[],
+): GroundingResult {
+  const violations: GroundingViolation[] = [];
+  const unverifiable: GroundingViolation[] = [];
+
+  findings.forEach((f, index) => {
+    if (f.severity !== 'critical') return;
+    const span = (f.grounding ?? '').trim();
+    if (!span) {
+      violations.push({ index, file: f.file, line: f.line, reason: 'critical finding has no grounding' });
+      return;
+    }
+    const kind = f.grounding_kind ?? 'quote';
+    if (kind !== 'quote') {
+      // No diff-checkable artifact — defer to the audit rather than reject.
+      unverifiable.push({ index, file: f.file, line: f.line, reason: `grounded by ${kind} (not deterministically verifiable)` });
+      return;
+    }
+    if (!f.file) {
+      violations.push({ index, line: f.line, reason: 'quote-grounded critical has no file to anchor against' });
+      return;
+    }
+    const file = diffFiles.find((d) => d.filename === f.file);
+    if (!file || !file.patch) {
+      violations.push({ index, file: f.file, line: f.line, reason: 'quote-grounded critical references a file not in the diff' });
+      return;
+    }
+    if (!spanAppearsInDiff(span, file.patch)) {
+      violations.push({ index, file: f.file, line: f.line, reason: 'grounding span not found in the diff' });
+    }
+  });
+
+  return { ok: violations.length === 0, violations, unverifiable };
+}
+
+// ---------------------------------------------------------------------------
+// whole-bundle validation
+// ---------------------------------------------------------------------------
+
+export interface BundleValidation {
+  ok: boolean;
+  coverage: CoverageResult;
+  grounding: GroundingResult;
+  consistency: ConsistencyResult;
+}
+
+/**
+ * Run ③④⑤ over a bundle against a diff. `ok` is the AND of all three hard
+ * checks (grounding's `unverifiable` list does not fail the bundle). The server
+ * layers ① nonce + ② ground-truth-diff-fetch + the clean-case audit ON TOP of
+ * this (Z4); this function is the shared deterministic core both sides call.
+ */
+export function validateBundle(
+  bundle: NotaryBundle,
+  diffFiles: readonly DiffFile[],
+): BundleValidation {
+  const coverage = validateCoverage(bundle.coverage, diffFiles);
+  const grounding = validateGrounding(bundle.findings, diffFiles);
+  const consistency = validateConsistency(bundle.verdict, bundle.findings);
+  return {
+    ok: coverage.ok && grounding.ok && consistency.ok,
+    coverage,
+    grounding,
+    consistency,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// diff helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Whitespace-normalized substring match of a quoted span against the HEAD-side
+ * (added + context) content of a unified-diff patch. Normalizing runs of
+ * whitespace to a single space tolerates indentation/wrapping differences
+ * between the agent's quote and the exact diff bytes, while still requiring the
+ * actual tokens to be present (an attacker can't ground a span that isn't there).
+ */
+export function spanAppearsInDiff(span: string, patch: string): boolean {
+  const needle = normalizeWhitespace(span);
+  if (!needle) return false;
+  return normalizeWhitespace(collectHeadSide(patch)).includes(needle);
+}
+
+function normalizeWhitespace(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * The HEAD-side content of a patch: added (`+`) and context lines, prefix
+ * stripped, joined by newlines. Mirrors `parseHeadLines`' notion of "on the new
+ * side of the diff" but yields the CONTENT rather than the line numbers.
+ */
+function collectHeadSide(patch: string): string {
+  const out: string[] = [];
+  const hunkHeaderRe = /^@@\s+-\d+(?:,\d+)?\s+\+\d+(?:,\d+)?\s+@@/;
+  let inHunk = false;
+  for (const raw of patch.split('\n')) {
+    if (hunkHeaderRe.test(raw)) {
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue;
+    if (raw.startsWith('+') && !raw.startsWith('+++')) {
+      out.push(raw.slice(1));
+    } else if (raw.startsWith('-') && !raw.startsWith('---')) {
+      // LEFT-side only — not on the head side.
+    } else if (raw.startsWith('\\')) {
+      // "\ No newline at end of file" — not content.
+    } else {
+      // Context line — appears on the head side.
+      out.push(raw.startsWith(' ') ? raw.slice(1) : raw);
+    }
+  }
+  return out.join('\n');
+}
+
+/**
+ * Decode a path token from a diff header to its real string. Handles the two
+ * ways git mangles a path: (a) a git-appended TRAILING TAB on an unquoted path
+ * containing a space (`b/my file.ts\t`), and (b) a fully C-QUOTED path when it
+ * has non-ASCII / control bytes (`"b/caf\303\251.ts"`, octal-escaped UTF-8).
+ * Without this, such files silently vanish from the parsed diff — a
+ * false-accept for coverage and a false-reject for a legitimately-grounded
+ * critical. (Our own `git` calls also pass `-c core.quotepath=false`, but
+ * `gh pr diff` and other sources can still quote, so the parser must be robust.)
+ */
+function unquoteGitPath(raw: string): string {
+  // A git-appended trailing tab separates an unquoted path from following text.
+  const s0 = raw.replace(/\t.*$/, '');
+  if (!s0.startsWith('"')) return s0;
+  const inner = s0.slice(1, s0.endsWith('"') ? -1 : s0.length);
+  const bytes: number[] = [];
+  for (let i = 0; i < inner.length; i++) {
+    const c = inner[i]!;
+    if (c !== '\\') {
+      for (const b of Buffer.from(c, 'utf8')) bytes.push(b);
+      continue;
+    }
+    const next = inner[i + 1] ?? '';
+    if (next >= '0' && next <= '7') {
+      let oct = '';
+      let j = i + 1;
+      while (j < inner.length && oct.length < 3 && inner[j]! >= '0' && inner[j]! <= '7') {
+        oct += inner[j];
+        j++;
+      }
+      bytes.push(parseInt(oct, 8) & 0xff);
+      i = j - 1;
+    } else {
+      const map: Record<string, number> = { n: 10, t: 9, r: 13, '"': 34, '\\': 92, a: 7, b: 8, f: 12, v: 11 };
+      bytes.push(map[next] ?? next.charCodeAt(0));
+      i += 1;
+    }
+  }
+  return Buffer.from(bytes).toString('utf8');
+}
+
+/** The destination (`b/…`) path from a `diff --git <src> <dst>` line, quote-aware. */
+function dstPathFromDiffGit(rest: string): string | undefined {
+  if (rest.endsWith('"')) {
+    // The dst is the trailing "…" token (may itself contain spaces/escapes).
+    const m = rest.match(/"((?:[^"\\]|\\.)*)"$/);
+    if (!m) return undefined;
+    const unq = unquoteGitPath(`"${m[1]}"`);
+    return unq.startsWith('b/') ? unq.slice(2) : unq;
+  }
+  const m = rest.match(/ b\/(.+)$/);
+  return m ? m[1] : undefined;
+}
+
+/**
+ * Split raw unified-diff text (`git diff` / `gh pr diff` output) into per-file
+ * `{ filename, patch }` entries — the same shape `gh api .../pulls/{n}/files`
+ * returns, so downstream validators are source-agnostic. Each `patch` is the
+ * hunk region (from the first `@@` onward). Files with no hunk (pure
+ * rename/mode/binary) yield `{ filename }` with no patch. Quote/tab-aware
+ * (see `unquoteGitPath`) so non-ASCII and space-containing paths survive.
+ */
+export function splitUnifiedDiff(raw: string): DiffFile[] {
+  const files: DiffFile[] = [];
+  if (!raw) return files;
+
+  let filename: string | undefined;
+  let body: string[] = [];
+  let inHunk = false;
+
+  const flush = () => {
+    if (filename !== undefined) {
+      files.push(body.length ? { filename, patch: body.join('\n') } : { filename });
+    }
+    filename = undefined;
+    body = [];
+    inHunk = false;
+  };
+
+  for (const line of raw.split('\n')) {
+    if (line.startsWith('diff --git ')) {
+      flush();
+      filename = dstPathFromDiffGit(line.slice('diff --git '.length));
+      continue;
+    }
+    if (filename === undefined) continue;
+    // The `+++ ` header is the most reliable filename (handles renames); skip
+    // `/dev/null` (a deletion — keep the `diff --git` name).
+    if (line.startsWith('+++ ')) {
+      const p = line.slice('+++ '.length);
+      if (p !== '/dev/null') {
+        const unq = unquoteGitPath(p);
+        filename = unq.startsWith('b/') ? unq.slice(2) : unq;
+      }
+      continue;
+    }
+    if (line.startsWith('@@')) {
+      inHunk = true;
+      body.push(line);
+      continue;
+    }
+    if (inHunk) body.push(line);
+  }
+  flush();
+
+  return files;
+}
+
+// Re-export the reused primitive so notary consumers have one import surface.
+export { parseHeadLines };

--- a/src/core/review-schema-zod.ts
+++ b/src/core/review-schema-zod.ts
@@ -58,6 +58,11 @@ export const findingItemSchema = z.object({
   line: z.number().int().min(1).optional(),
   summary: z.string().min(1),
   reasoning: z.string().optional(),
+  // Notary grounding (§10.3.3). Optional on the WIRE (a schema-required field can
+  // be satisfied with junk); the notary bundle + `validateGrounding` enforce it
+  // as required-for-critical, checking the span against the ground-truth diff.
+  grounding: z.string().optional(),
+  grounding_kind: z.enum(['quote', 'reproduction', 'invariant']).optional(),
 });
 export type FindingItem = z.infer<typeof findingItemSchema>;
 

--- a/src/core/review-schema.ts
+++ b/src/core/review-schema.ts
@@ -62,6 +62,15 @@ const FINDING_ITEM: JSONSchemaObject = {
       type: 'string',
       description: 'Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings.',
     },
+    grounding: {
+      type: 'string',
+      description: 'Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣.',
+    },
+    grounding_kind: {
+      type: 'string',
+      enum: ['quote', 'reproduction', 'invariant'],
+      description: 'Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted.',
+    },
   },
   required: ['skill', 'summary'],
 };
@@ -185,6 +194,9 @@ export interface ReviewFinding {
   file?: string;
   line?: number;
   reasoning?: string;
+  /** Verbatim evidence for the notary (§10.3.3). Expected on critical findings. */
+  grounding?: string;
+  grounding_kind?: 'quote' | 'reproduction' | 'invariant';
 }
 
 export interface PerSkillScanItem {

--- a/test/notary-bundle.test.js
+++ b/test/notary-bundle.test.js
@@ -1,0 +1,118 @@
+// Phase Z3 — the notary attestation bundle: assembly + the tolerant wire parser.
+// The parser is a trust boundary (it reads an artifact the local agent produced),
+// so the rejection cases matter: a malformed or truncated bundle must be `null`,
+// never a partially-accepted "green".
+
+import { test } from 'vitest';
+import { strict as assert } from 'node:assert';
+
+import {
+  buildBundle,
+  parseBundle,
+  notaryResponseIsRejection,
+  NOTARY_BUNDLE_VERSION,
+  NOTARY_PROTOCOL_VERSION,
+} from '../src/core/notary-bundle.js';
+
+const SHA = 'a'.repeat(40);
+
+test('buildBundle: stamps wire + protocol versions and omits absent optionals', () => {
+  const b = buildBundle({
+    repo: 'o/r', headSha: SHA, verdict: 'clean', findings: [], coverage: [], recipeVersion: 'local',
+  });
+  assert.equal(b.bundle_version, NOTARY_BUNDLE_VERSION);
+  assert.equal(b.protocol_version, NOTARY_PROTOCOL_VERSION);
+  assert.equal(b.repo, 'o/r');
+  assert.equal('pr' in b, false);
+  assert.equal('nonce' in b, false);
+});
+
+test('buildBundle: carries pr and nonce when provided', () => {
+  const b = buildBundle({
+    repo: 'o/r', pr: 7, headSha: SHA, verdict: 'clean', findings: [], coverage: ['a.ts'],
+    recipeVersion: 'local', nonce: 'abc123',
+  });
+  assert.equal(b.pr, 7);
+  assert.equal(b.nonce, 'abc123');
+});
+
+test('parseBundle: round-trips a built bundle', () => {
+  const b = buildBundle({
+    repo: 'o/r', pr: 7, headSha: SHA, verdict: 'critical',
+    findings: [{ severity: 'critical', file: 'a.ts', line: 2, summary: 'x', grounding: 'y', grounding_kind: 'quote' }],
+    coverage: ['a.ts'], recipeVersion: 'local',
+  });
+  const parsed = parseBundle(JSON.parse(JSON.stringify(b)));
+  assert.deepEqual(parsed, b);
+});
+
+test('parseBundle: rejects a non-object', () => {
+  assert.equal(parseBundle(null), null);
+  assert.equal(parseBundle('nope'), null);
+});
+
+test('parseBundle: rejects a missing/!owner-repo `repo`', () => {
+  assert.equal(parseBundle({ repo: 'noslash', head_sha: SHA, verdict: 'clean', findings: [], coverage: [] }), null);
+});
+
+test('parseBundle: rejects an unknown verdict (trust-boundary whitelist)', () => {
+  assert.equal(parseBundle({ repo: 'o/r', head_sha: SHA, verdict: 'CLEAN', findings: [], coverage: [] }), null);
+  assert.equal(parseBundle({ repo: 'o/r', head_sha: SHA, verdict: 'banana', findings: [], coverage: [] }), null);
+  assert.equal(parseBundle({ repo: 'o/r', head_sha: SHA, verdict: 'clean ', findings: [], coverage: [] }), null);
+});
+
+test('parseBundle: accepts every legitimate verdict', () => {
+  for (const v of ['clean', 'critical', 'failed', 'unverified']) {
+    const b = parseBundle({ repo: 'o/r', head_sha: SHA, verdict: v, findings: [], coverage: [] });
+    assert.ok(b, `verdict ${v} should parse`);
+    assert.equal(b.verdict, v);
+  }
+});
+
+test('notaryResponseIsRejection: 4xx is a terminal decline; 5xx/2xx are not', () => {
+  for (const s of [400, 403, 409, 422, 499]) assert.equal(notaryResponseIsRejection(s), true, String(s));
+  for (const s of [200, 500, 502, 503]) assert.equal(notaryResponseIsRejection(s), false, String(s));
+});
+
+test('parseBundle: rejects a missing head_sha / findings / coverage', () => {
+  assert.equal(parseBundle({ repo: 'o/r', verdict: 'clean', findings: [], coverage: [] }), null);
+  assert.equal(parseBundle({ repo: 'o/r', head_sha: SHA, verdict: 'clean', coverage: [] }), null);
+  assert.equal(parseBundle({ repo: 'o/r', head_sha: SHA, verdict: 'clean', findings: [] }), null);
+});
+
+test('parseBundle: rejects the WHOLE bundle when any finding is malformed', () => {
+  const raw = {
+    repo: 'o/r', head_sha: SHA, verdict: 'critical', coverage: ['a.ts'],
+    findings: [
+      { severity: 'critical', file: 'a.ts', line: 2, summary: 'ok', grounding: 'y' },
+      { severity: 'not-a-severity', summary: 'bad' }, // malformed
+    ],
+  };
+  assert.equal(parseBundle(raw), null);
+});
+
+test('parseBundle: rejects non-string coverage entries', () => {
+  const raw = { repo: 'o/r', head_sha: SHA, verdict: 'clean', findings: [], coverage: ['a.ts', 42] };
+  assert.equal(parseBundle(raw), null);
+});
+
+test('parseBundle: drops an out-of-range line but keeps the finding', () => {
+  const raw = {
+    repo: 'o/r', head_sha: SHA, verdict: 'clean', coverage: [],
+    findings: [{ severity: 'minor', file: 'a.ts', line: 0, summary: 'x' }],
+  };
+  const parsed = parseBundle(raw);
+  assert.ok(parsed);
+  assert.equal(parsed.findings.length, 1);
+  assert.equal('line' in parsed.findings[0], false);
+});
+
+test('parseBundle: ignores an unknown grounding_kind (leaves it unset → defaults to quote)', () => {
+  const raw = {
+    repo: 'o/r', head_sha: SHA, verdict: 'critical', coverage: ['a.ts'],
+    findings: [{ severity: 'critical', file: 'a.ts', line: 2, summary: 'x', grounding: 'y', grounding_kind: 'telepathy' }],
+  };
+  const parsed = parseBundle(raw);
+  assert.ok(parsed);
+  assert.equal('grounding_kind' in parsed.findings[0], false);
+});

--- a/test/notary-validate.test.js
+++ b/test/notary-validate.test.js
@@ -1,0 +1,334 @@
+// Phase Z3 — the notary's deterministic validators (③ coverage · ④ grounding ·
+// ⑤ consistency) + the diff splitter. These gate the un-forgeable merge check,
+// so the adversarial cases (fabricated critical, dropped real critical, verdict
+// lie, removed-line grounding) are the point — not an afterthought.
+
+import { test } from 'vitest';
+import { strict as assert } from 'node:assert';
+
+import {
+  validateConsistency,
+  validateCoverage,
+  validateGrounding,
+  validateBundle,
+  spanAppearsInDiff,
+  splitUnifiedDiff,
+} from '../src/core/notary-validate.js';
+import { buildBundle } from '../src/core/notary-bundle.js';
+
+// A realistic single-file patch: one removed line, two added lines, context.
+const APP_PATCH = [
+  '@@ -1,3 +1,4 @@',
+  ' const a = 1;',
+  '-const b = 2;',
+  '+const b = 3;',
+  '+const password = "hunter2";',
+  ' export { a };',
+].join('\n');
+
+const DIFF = [{ filename: 'src/app.ts', patch: APP_PATCH }];
+
+// ---------------------------------------------------------------------------
+// ⑤ consistency
+// ---------------------------------------------------------------------------
+
+test('consistency: clean with a critical finding is rejected', () => {
+  const r = validateConsistency('clean', [{ severity: 'critical', summary: 'x' }]);
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /clean/);
+});
+
+test('consistency: critical verdict with no critical findings is rejected', () => {
+  const r = validateConsistency('critical', [{ severity: 'minor', summary: 'x' }]);
+  assert.equal(r.ok, false);
+});
+
+test('consistency: clean with no criticals passes', () => {
+  assert.equal(validateConsistency('clean', [{ severity: 'minor', summary: 'x' }]).ok, true);
+  assert.equal(validateConsistency('clean', []).ok, true);
+});
+
+test('consistency: critical with a critical finding passes', () => {
+  assert.equal(validateConsistency('critical', [{ severity: 'critical', summary: 'x', grounding: 'y' }]).ok, true);
+});
+
+test('consistency: unverified/failed are self-consistent regardless of findings', () => {
+  assert.equal(validateConsistency('unverified', [{ severity: 'critical', summary: 'x' }]).ok, true);
+  assert.equal(validateConsistency('failed', []).ok, true);
+});
+
+// ---------------------------------------------------------------------------
+// ③ coverage
+// ---------------------------------------------------------------------------
+
+test('coverage: a changed file absent from the claim fails (silent skip)', () => {
+  const r = validateCoverage([], DIFF);
+  assert.equal(r.ok, false);
+  assert.deepEqual(r.missingFiles, ['src/app.ts']);
+});
+
+test('coverage: every changed file claimed passes', () => {
+  assert.equal(validateCoverage(['src/app.ts'], DIFF).ok, true);
+});
+
+test('coverage: extra claimed files (not in the diff) are harmless', () => {
+  assert.equal(validateCoverage(['src/app.ts', 'src/other.ts'], DIFF).ok, true);
+});
+
+test('coverage: empty diff is trivially covered', () => {
+  assert.equal(validateCoverage([], []).ok, true);
+});
+
+// ---------------------------------------------------------------------------
+// ④ grounding — the core anti-forgery check
+// ---------------------------------------------------------------------------
+
+test('grounding: a critical quoting a real added line passes', () => {
+  const r = validateGrounding(
+    [{ severity: 'critical', file: 'src/app.ts', line: 3, summary: 'hardcoded secret', grounding: 'const password = "hunter2";', grounding_kind: 'quote' }],
+    DIFF,
+  );
+  assert.equal(r.ok, true);
+  assert.equal(r.violations.length, 0);
+});
+
+test('grounding: a FABRICATED critical (span not in the diff) is rejected', () => {
+  const r = validateGrounding(
+    [{ severity: 'critical', file: 'src/app.ts', line: 9, summary: 'made up', grounding: 'const nope = neverHappened();', grounding_kind: 'quote' }],
+    DIFF,
+  );
+  assert.equal(r.ok, false);
+  assert.match(r.violations[0].reason, /not found in the diff/);
+});
+
+test('grounding: a critical grounded on a REMOVED line is rejected (left-side only)', () => {
+  const r = validateGrounding(
+    [{ severity: 'critical', file: 'src/app.ts', line: 2, summary: 'x', grounding: 'const b = 2;', grounding_kind: 'quote' }],
+    DIFF,
+  );
+  assert.equal(r.ok, false);
+});
+
+test('grounding: a bare critical (no grounding at all) is rejected', () => {
+  const r = validateGrounding([{ severity: 'critical', file: 'src/app.ts', line: 3, summary: 'x' }], DIFF);
+  assert.equal(r.ok, false);
+  assert.match(r.violations[0].reason, /no grounding/);
+});
+
+test('grounding: reproduction/invariant criticals are unverifiable, not rejected', () => {
+  const r = validateGrounding(
+    [{ severity: 'critical', file: 'src/app.ts', line: 3, summary: 'race', grounding: 'ran the repro; observed a deadlock', grounding_kind: 'reproduction' }],
+    DIFF,
+  );
+  assert.equal(r.ok, true);
+  assert.equal(r.violations.length, 0);
+  assert.equal(r.unverifiable.length, 1);
+});
+
+test('grounding: quote-grounded critical on a file not in the diff is rejected', () => {
+  const r = validateGrounding(
+    [{ severity: 'critical', file: 'src/ghost.ts', line: 1, summary: 'x', grounding: 'anything', grounding_kind: 'quote' }],
+    DIFF,
+  );
+  assert.equal(r.ok, false);
+  assert.match(r.violations[0].reason, /not in the diff/);
+});
+
+test('grounding: minor/preexisting findings are not grounding-gated', () => {
+  const r = validateGrounding(
+    [
+      { severity: 'minor', file: 'src/app.ts', line: 3, summary: 'nit' },
+      { severity: 'preexisting', summary: 'old' },
+    ],
+    DIFF,
+  );
+  assert.equal(r.ok, true);
+});
+
+test('grounding: whitespace/indentation differences still match', () => {
+  // agent quotes with different leading indentation than the diff bytes.
+  const r = validateGrounding(
+    [{ severity: 'critical', file: 'src/app.ts', line: 3, summary: 'x', grounding: '   const   password = "hunter2";   ', grounding_kind: 'quote' }],
+    DIFF,
+  );
+  assert.equal(r.ok, true);
+});
+
+// ---------------------------------------------------------------------------
+// spanAppearsInDiff (unit)
+// ---------------------------------------------------------------------------
+
+test('spanAppearsInDiff: matches an added line, not a removed one', () => {
+  assert.equal(spanAppearsInDiff('const b = 3;', APP_PATCH), true);
+  assert.equal(spanAppearsInDiff('const b = 2;', APP_PATCH), false);
+});
+
+test('spanAppearsInDiff: matches a context line (head-side)', () => {
+  assert.equal(spanAppearsInDiff('export { a };', APP_PATCH), true);
+});
+
+test('spanAppearsInDiff: empty span never matches', () => {
+  assert.equal(spanAppearsInDiff('   ', APP_PATCH), false);
+});
+
+// ---------------------------------------------------------------------------
+// validateBundle — the two adversarial end-to-end cases from the plan
+// ---------------------------------------------------------------------------
+
+test('validateBundle: a well-formed grounded review passes', () => {
+  const bundle = buildBundle({
+    repo: 'o/r', pr: 1, headSha: 'a'.repeat(40), verdict: 'critical',
+    findings: [{ severity: 'critical', file: 'src/app.ts', line: 3, summary: 'secret', grounding: 'const password = "hunter2";', grounding_kind: 'quote' }],
+    coverage: ['src/app.ts'], recipeVersion: 'test',
+  });
+  assert.equal(validateBundle(bundle, DIFF).ok, true);
+});
+
+test('validateBundle: FABRICATED critical fails on grounding', () => {
+  const bundle = buildBundle({
+    repo: 'o/r', headSha: 'a'.repeat(40), verdict: 'critical',
+    findings: [{ severity: 'critical', file: 'src/app.ts', line: 3, summary: 'fake', grounding: 'not in diff at all', grounding_kind: 'quote' }],
+    coverage: ['src/app.ts'], recipeVersion: 'test',
+  });
+  const v = validateBundle(bundle, DIFF);
+  assert.equal(v.ok, false);
+  assert.equal(v.grounding.ok, false);
+});
+
+test('validateBundle: DROPPED real critical (unreviewed changed file) fails on coverage', () => {
+  // The review claims clean but never covered the file the diff changed.
+  const bundle = buildBundle({
+    repo: 'o/r', headSha: 'a'.repeat(40), verdict: 'clean',
+    findings: [], coverage: [], recipeVersion: 'test',
+  });
+  const v = validateBundle(bundle, DIFF);
+  assert.equal(v.ok, false);
+  assert.equal(v.coverage.ok, false);
+});
+
+test('validateBundle: verdict lie (clean + critical) fails on consistency', () => {
+  const bundle = buildBundle({
+    repo: 'o/r', headSha: 'a'.repeat(40), verdict: 'clean',
+    findings: [{ severity: 'critical', file: 'src/app.ts', line: 3, summary: 'x', grounding: 'const password = "hunter2";', grounding_kind: 'quote' }],
+    coverage: ['src/app.ts'], recipeVersion: 'test',
+  });
+  const v = validateBundle(bundle, DIFF);
+  assert.equal(v.ok, false);
+  assert.equal(v.consistency.ok, false);
+});
+
+// ---------------------------------------------------------------------------
+// splitUnifiedDiff
+// ---------------------------------------------------------------------------
+
+test('splitUnifiedDiff: splits a multi-file diff into per-file patches', () => {
+  const raw = [
+    'diff --git a/src/app.ts b/src/app.ts',
+    'index abc..def 100644',
+    '--- a/src/app.ts',
+    '+++ b/src/app.ts',
+    '@@ -1,2 +1,3 @@',
+    ' const a = 1;',
+    '+const b = 2;',
+    ' export { a };',
+    'diff --git a/README.md b/README.md',
+    'index 111..222 100644',
+    '--- a/README.md',
+    '+++ b/README.md',
+    '@@ -1 +1 @@',
+    '-old',
+    '+new',
+  ].join('\n');
+  const files = splitUnifiedDiff(raw);
+  assert.equal(files.length, 2);
+  assert.equal(files[0].filename, 'src/app.ts');
+  assert.ok(files[0].patch.startsWith('@@ -1,2 +1,3 @@'));
+  assert.ok(files[0].patch.includes('+const b = 2;'));
+  assert.equal(files[1].filename, 'README.md');
+  assert.ok(files[1].patch.includes('+new'));
+});
+
+test('splitUnifiedDiff: a pure rename (no hunk) yields a file with no patch', () => {
+  const raw = [
+    'diff --git a/old.txt b/new.txt',
+    'similarity index 100%',
+    'rename from old.txt',
+    'rename to new.txt',
+  ].join('\n');
+  const files = splitUnifiedDiff(raw);
+  assert.equal(files.length, 1);
+  assert.equal(files[0].filename, 'new.txt');
+  assert.equal(files[0].patch, undefined);
+});
+
+test('splitUnifiedDiff: empty input yields no files', () => {
+  assert.deepEqual(splitUnifiedDiff(''), []);
+});
+
+test('splitUnifiedDiff: decodes a git-quoted non-ASCII filename (café.ts)', () => {
+  // Real git (core.quotepath default) octal-escapes é as \303\251 and quotes the path.
+  const raw = [
+    'diff --git "a/caf\\303\\251.ts" "b/caf\\303\\251.ts"',
+    'index abc..def 100644',
+    '--- "a/caf\\303\\251.ts"',
+    '+++ "b/caf\\303\\251.ts"',
+    '@@ -1 +1 @@',
+    '-const x = 1;',
+    '+const x = 2;',
+  ].join('\n');
+  const files = splitUnifiedDiff(raw);
+  assert.equal(files.length, 1);
+  assert.equal(files[0].filename, 'café.ts');
+  assert.ok(files[0].patch.includes('+const x = 2;'));
+});
+
+test('splitUnifiedDiff: strips the git-appended trailing tab on a space-containing path', () => {
+  const raw = [
+    'diff --git a/my file.ts b/my file.ts',
+    'index abc..def 100644',
+    '--- a/my file.ts\t',
+    '+++ b/my file.ts\t',
+    '@@ -1 +1 @@',
+    '-a',
+    '+b',
+  ].join('\n');
+  const files = splitUnifiedDiff(raw);
+  assert.equal(files.length, 1);
+  assert.equal(files[0].filename, 'my file.ts');
+});
+
+test('splitUnifiedDiff: a quoted non-ASCII file still grounds a critical (no false-reject)', () => {
+  const raw = [
+    'diff --git "a/caf\\303\\251.ts" "b/caf\\303\\251.ts"',
+    '--- "a/caf\\303\\251.ts"',
+    '+++ "b/caf\\303\\251.ts"',
+    '@@ -1,2 +1,2 @@',
+    ' const a = 1;',
+    '+const secret = "leak";',
+  ].join('\n');
+  const r = validateGrounding(
+    [{ severity: 'critical', file: 'café.ts', line: 2, summary: 'secret', grounding: 'const secret = "leak";', grounding_kind: 'quote' }],
+    splitUnifiedDiff(raw),
+  );
+  assert.equal(r.ok, true);
+});
+
+test('splitUnifiedDiff output round-trips through the validators', () => {
+  const raw = [
+    'diff --git a/src/app.ts b/src/app.ts',
+    '--- a/src/app.ts',
+    '+++ b/src/app.ts',
+    '@@ -1,3 +1,4 @@',
+    ' const a = 1;',
+    '-const b = 2;',
+    '+const b = 3;',
+    '+const password = "hunter2";',
+    ' export { a };',
+  ].join('\n');
+  const files = splitUnifiedDiff(raw);
+  const r = validateGrounding(
+    [{ severity: 'critical', file: 'src/app.ts', line: 3, summary: 'x', grounding: 'const password = "hunter2";', grounding_kind: 'quote' }],
+    files,
+  );
+  assert.equal(r.ok, true);
+});


### PR DESCRIPTION
## Phase Z3 — the clud-bug CLI notary side

Builds the CLI half of the **un-forgeable review notary** (protocol SPEC §10.3.3). clud-bug becomes a NOTARY that VALIDATES + CERTIFIES a review before a green `clud-bug-review` check can gate a merge — the neutral "reviewed-by ✅" trust authority. This PR is the local/CLI producer; the authoritative server (`POST /notarize`, sole-issuer) is Z4.

### What's here
- **`src/core/notary-validate.ts`** — pure, deterministic, LLM-free validators (~free):
  - ⑤ `validateConsistency` — verdict ⟺ findings.
  - ③ `validateCoverage` — every changed file present in the review's coverage claim (no silent skip).
  - ④ `validateGrounding` — every 🔴 critical carries a `grounding` span; a `quote`-form span MUST appear verbatim in the diff (reuses the `inline-threads.ts` diff parser); `reproduction`/`invariant` forms are recorded as audit-relevant, not rejected (accepting a critical blocks = the safe direction).
  - `splitUnifiedDiff` (quote/tab-aware) + `spanAppearsInDiff`.
- **`src/core/notary-bundle.ts`** — the attestation **bundle** type + `buildBundle` + a tolerant, trust-boundary `parseBundle` (the contract Z4 consumes).
- **`post-check-run.ts`** — a notary submit path behind `CLUD_BUG_NOTARY_URL` + `--bundle`: the CLI is a deterministic program that LOCALLY re-checks the bundle (the handshake — refuses to certify an inconsistent/ungrounded review) then POSTs to the notary. **Default path (no env) is unchanged.**
- **`hooks.ts`** — renamed the loop-guard marker → `clud-bug-hook-fired` (kills the "review happened" semantic confusion; the marker is NOT an attestation).
- **`review-prompt.ts`** — recipe §5 reframed as notary certification + instructs emitting a grounding span per critical.
- **schema** — additive optional `grounding` / `grounding_kind` on the shared finding item (JSON + Zod).
- Tests: `test/notary-validate.test.js`, `test/notary-bundle.test.js` (adversarial cases: fabricated critical, dropped real critical, verdict lie, removed-line grounding, quoted/space filenames, verdict whitelist).

### Design deviation to review
The plan called for a **required** grounding field via a split `CRITICAL_FINDING_ITEM` schema variant. That forces a discriminated-union type ripple through the App's finding aggregator and couples the live hosted Zod pipeline — **real risk, no added safety**, because a schema-`required` field can be satisfied with junk while the load-bearing guarantee is the notary re-checking the span against the ground-truth diff. So: `grounding` is **optional in the review-output schema**, **required-and-validated in the notary bundle/validators**. Same guarantee, lower blast radius.

### Adversarially reviewed before commit
A 4-lens Workflow (security-bypass · diff-parsing · integration · design-faithfulness, opus on the crux) with per-finding opus verification → **6 confirmed findings fixed** (10 refuted):
1. **[major]** server 4xx (authoritative "invalid") was downgraded to `fallback` → self-attest green could override the notary's NO. Now a 4xx is terminal `rejected`; only network/5xx → fallback.
2. **[major]** `splitUnifiedDiff` dropped git-quoted non-ASCII filenames (`"b/café.ts"`) entirely → now quote-aware + `core.quotepath=false` on local git calls.
3. **[minor]** `parseBundle` didn't whitelist `verdict` at the trust boundary → now rejects unknown verdicts.
4. **[minor]** `splitUnifiedDiff` kept git's trailing tab on space-containing paths → stripped.
5. **[minor]** fallback re-derived from `args.verdict` (absent in a bundle-only call) → now derives the self-post from the validated bundle.

### Notes
- The repo's own `.claude/settings.json` hook still references the old marker string (a frozen generated artifact, independent loop-guard file) — regenerates on the next `clud-bug update`; benign.
- Related (separate): #228 — dogfood feedback that local *self*-review is low-catch; that's a catch-rate concern distinct from this un-forgeability work.

**Not for merge yet** — CEO gate. Z4 (`/notarize` + sole-issuer check + nonce) consumes `NotaryBundle` + `notaryResponseIsRejection`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
