### PR TITLE
chore: bump to 0.7.0-rc.23 (ships Phase Z3 — the CLI notary side)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.22
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.23
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/decisions-branches/chore-bump-rc23.md
+++ b/docs/decisions-branches/chore-bump-rc23.md
@@ -1,0 +1,11 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-11 14:40 - chore: bump to 0.7.0-rc.23 (ships Phase Z3 — the CLI notary side)
+
+**Reasoning:** Publishes the Z3 notary contract (NotaryBundle, validateBundle/validateCoverage/validateGrounding/validateConsistency, parseBundle, notaryResponseIsRejection) so clud-bug-app can import it to build Z4 (the /notarize server). Release discipline: propagated the version pin to the 3 workflow templates + strict-mode-gate action.yml.
+
+**Implications:**
+- Tag v0.7.0-rc.23 after merge triggers the OIDC npm-publish workflow -> dist-tag 'next'; clud-bug-app then bumps its clud-bug dep to rc.23 for Z4
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (20 decisions)
+## 2026-07 (21 decisions)
 
-- **2026-07-11** — Phase Z3: clud-bug CLI notary side — deterministic ③④⑤ validators + attestation bundle + submit-bundle handshake *(feat-notary-z3)* — [decisions-branches/feat-notary-z3.md](decisions-branches/feat-notary-z3.md)
-- *... 18 more decisions ...*
+- **2026-07-11** — chore: bump to 0.7.0-rc.23 (ships Phase Z3 — the CLI notary side) *(chore-bump-rc23)* — [decisions-branches/chore-bump-rc23.md](decisions-branches/chore-bump-rc23.md)
+- *... 19 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.22",
+  "version": "0.7.0-rc.23",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.22
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.23
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.22
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.23
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -717,7 +717,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.22
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.23
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow


### PR DESCRIPTION
Bumps clud-bug to **0.7.0-rc.23** to publish the Phase Z3 notary contract so `clud-bug-app` can import it for Z4 (the `/notarize` server).

**Publishes:** `NotaryBundle` / `buildBundle` / `parseBundle` / `notaryResponseIsRejection` (notary-bundle) + `validateBundle` / `validateCoverage` / `validateGrounding` / `validateConsistency` / `splitUnifiedDiff` / `spanAppearsInDiff` (notary-validate), all from `clud-bug/core`.

**Release discipline:** propagated the version pin to the 3 workflow templates + `strict-mode-gate/action.yml` (enforced by `release-discipline.test.js` + `prompts.test.js`). 973/973 tests green.

**After merge:** I push the `v0.7.0-rc.23` tag → the OIDC `npm-publish` workflow ships it to dist-tag `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)