### PR TITLE
fix(ci): pin npm-publish to npm@11 so OIDC publish works on the Node 20 runner

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -116,7 +116,13 @@ jobs:
         # it falls back to looking for NPM_TOKEN, finds none, and the
         # publish PUT gets rejected with a misleading 404. End-to-end
         # OIDC publish needs npm 11.5.1+.
-        run: npm install -g npm@latest
+        #
+        # Pin to npm@11 (not @latest): npm@latest is now npm 12, whose engine
+        # requires Node >=22.22 / 24.15 — it EBADENGINE-fails on this Node-20
+        # runner before publishing. npm@11 (latest 11.x) supports Node ^20.17
+        # and is OIDC-capable. (TODO: bump the runner to Node 22/24 — Node 20 is
+        # EOL — then @latest can return.)
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm install --no-audit --no-fund
@@ -153,7 +159,9 @@ jobs:
       - name: Upgrade npm to a Trusted-Publishing-capable version
         # Same reason as the publish job: dist-tag is one of the calls
         # that needs OIDC end-to-end (sign + auth), which is npm 11.5.1+.
-        run: npm install -g npm@latest
+        # Pinned to npm@11 (not @latest=12, which needs Node 22+) — see the
+        # publish job's note.
+        run: npm install -g npm@11
 
       - name: Validate inputs
         # Bail loudly if version is missing — promote-tag without a

--- a/docs/decisions-branches/fix-npm-publish-node20.md
+++ b/docs/decisions-branches/fix-npm-publish-node20.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-11 14:53 - fix(ci): pin npm-publish to npm@11 so OIDC publish works on the Node 20 runner
+
+**Reasoning:** npm@latest is now npm 12, whose engine requires Node >=22.22/24.15 — it EBADENGINE-fails on the workflow's Node-20 runner before the publish step, so v0.7.0-rc.23's publish failed. npm@11 (latest 11.x) is OIDC-capable AND supports Node ^20.17, unblocking the release with minimal risk.
+
+**Alternatives considered:** Bump the runner to Node 22/24 (Node 20 is EOL) — deferred to avoid re-testing prepublishOnly on a new Node in the same change; left as a TODO in the workflow
+
+**Implications:**
+- After merge, re-publish rc.23 via workflow_dispatch (mode=publish, tag=v0.7.0-rc.23) using main's fixed workflow — no re-tag needed
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (21 decisions)
+## 2026-07 (22 decisions)
 
-- **2026-07-11** — chore: bump to 0.7.0-rc.23 (ships Phase Z3 — the CLI notary side) *(chore-bump-rc23)* — [decisions-branches/chore-bump-rc23.md](decisions-branches/chore-bump-rc23.md)
-- *... 19 more decisions ...*
+- **2026-07-11** — fix(ci): pin npm-publish to npm@11 so OIDC publish works on the Node 20 runner *(fix-npm-publish-node20)* — [decisions-branches/fix-npm-publish-node20.md](decisions-branches/fix-npm-publish-node20.md)
+- *... 20 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)


### PR DESCRIPTION
**The v0.7.0-rc.23 publish failed** — not our code, a CI env drift. The workflow runs `npm install -g npm@latest`, but `npm@latest` is now **npm 12**, whose engine requires Node `>=22.22 / 24.15`. On the workflow's **Node 20** runner it `EBADENGINE`-fails *before* the publish step:

```
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

**Fix:** pin both jobs to `npm@11` (latest 11.x) — OIDC/Trusted-Publishing-capable *and* supports Node `^20.17`. Minimal + certain on the current runner. Left a TODO to bump the runner to Node 22/24 (Node 20 is EOL) as a separate, test-on-new-node change.

**After merge:** re-publish rc.23 via `workflow_dispatch` (mode=publish, tag=`v0.7.0-rc.23`) using main's fixed workflow — no re-tag needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)