### PR TITLE
Phase Z4 (CLI): challenge/response nonce handshake before /notarize

### DIFF
--- a/docs/decisions-branches/feat-notary-z4-cli.md
+++ b/docs/decisions-branches/feat-notary-z4-cli.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-16 16:59 - Phase Z4 (CLI): challenge/response nonce handshake before /notarize + pr-less skip
+
+**Reasoning:** The notary requires a single-use nonce (SPEC §10.3.3 ① replay-closure): post-check-run now POSTs {repo,pr,head_sha} to the notary's /notarize/challenge, echoes the returned nonce in the bundle, then submits. Applies the Z4 adversarial-review fixes: correct the challenge URL to /notarize/challenge (matches the server's app/api/notarize/challenge route — a sibling /challenge would 404); skip the notary entirely for a pr-less (commit-trigger) bundle since the notary certifies PR heads; a 402 (not entitled / App absent) yields a loud NOT-notarized warning + self-attested fallback (never blocks work).
+
+**Alternatives considered:** Treat /challenge as a sibling of the notary base (rejected — the real server route is app/api/notarize/challenge, a sub-path of /notarize)
+
+**Implications:**
+- Needs a clud-bug rc.24 bump+publish so the handshake ships to installs; the server side (POST /notarize + /notarize/challenge + entitlement gate + audit) is clud-bug-app branch feat-notary-z4 (separate PR)
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -79,6 +79,7 @@ clud-bug
 │   ├── init-with-skdd.test.js
 │   ├── inline-threads.test.js
 │   ├── notary-bundle.test.js
+│   ├── notary-submit.test.js
 │   ├── notary-validate.test.js
 │   ├── prompt-builder.test.js
 │   ├── prompts.eval.test.js

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (22 decisions)
+## 2026-07 (23 decisions)
 
-- **2026-07-11** — fix(ci): pin npm-publish to npm@11 so OIDC publish works on the Node 20 runner *(fix-npm-publish-node20)* — [decisions-branches/fix-npm-publish-node20.md](decisions-branches/fix-npm-publish-node20.md)
-- *... 20 more decisions ...*
+- **2026-07-16** — Phase Z4 (CLI): challenge/response nonce handshake before /notarize + pr-less skip *(feat-notary-z4-cli)* — [decisions-branches/feat-notary-z4-cli.md](decisions-branches/feat-notary-z4-cli.md)
+- *... 21 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/src/cli/post-check-run.ts
+++ b/src/cli/post-check-run.ts
@@ -81,20 +81,88 @@ interface NotaryResult {
   bundle: NotaryBundle | null;
 }
 
+/** Outcome of the `POST /challenge` round-trip that precedes `/notarize`. */
+type ChallengeResult = { nonce: string } | 'rejected' | 'fallback';
+
+/**
+ * Mint the single-use nonce (Z4 ① replay-closure) the notary requires before it
+ * will certify a bundle: `POST {repo, pr, head_sha}` to `/notarize/challenge`
+ * (a sub-path of `/notarize`, matching the server route), expect `{ nonce }`.
+ * Classified like `/notarize` — a 4xx is the server AUTHORITATIVELY
+ * declining (terminal), a 5xx/network error just means the endpoint is DOWN
+ * (fallback to the self-attested check) — EXCEPT 402 (not-entitled): that's not
+ * a decline of THIS bundle, it's "this install can't be notarized at all", so it
+ * gets a loud warning explaining why the check is unnotarized and falls back
+ * rather than blocking the review with a bare rejection.
+ */
+async function fetchChallenge(
+  notaryUrl: string,
+  bundle: NotaryBundle,
+  warn: (m: string) => void,
+): Promise<ChallengeResult> {
+  const url = notaryUrl.replace(/\/+$/, '') + '/notarize/challenge';
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ repo: bundle.repo, pr: bundle.pr, head_sha: bundle.head_sha }),
+    });
+  } catch (e) {
+    warn(`notary challenge endpoint unreachable (${e instanceof Error ? e.message : String(e)}); falling back to the self-attested check.`);
+    return 'fallback';
+  }
+
+  if (res.status === 402) {
+    warn(
+      [
+        'this review is NOT notarized — no independent check verified it; the',
+        'merge check is self-attested only.',
+        'Install the clud-bug App / upgrade to certify: https://cludbug.dev',
+      ].join('\n'),
+    );
+    return 'fallback';
+  }
+  if (notaryResponseIsRejection(res.status)) {
+    warn(`notary declined the challenge (HTTP ${res.status}); not certifying.`);
+    return 'rejected';
+  }
+  if (!res.ok) {
+    warn(`notary challenge endpoint unavailable (HTTP ${res.status}); falling back to the self-attested check.`);
+    return 'fallback';
+  }
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch (e) {
+    warn(`notary challenge response was not valid JSON (${e instanceof Error ? e.message : String(e)}); falling back to the self-attested check.`);
+    return 'fallback';
+  }
+  const nonce = body && typeof body === 'object' ? (body as Record<string, unknown>)['nonce'] : undefined;
+  if (typeof nonce !== 'string' || !nonce) {
+    warn('notary challenge response is missing a nonce; falling back to the self-attested check.');
+    return 'fallback';
+  }
+  return { nonce };
+}
+
 /**
  * The notary submit path (Phase Z). Reads + parses the bundle, LOCALLY
  * re-validates it (the handshake — a deterministic program refusing to certify
- * an inconsistent/ungrounded review), then POSTs to the notary. The server (Z4)
- * re-validates ①–⑤ against GitHub and — as SOLE issuer — posts the pinned check.
+ * an inconsistent/ungrounded review), mints a challenge nonce, then POSTs to the
+ * notary. The server (Z4) re-validates ①–⑤ against GitHub and — as SOLE issuer —
+ * posts the pinned check.
  *
  * Outcomes:
  *   'posted'   — the notary accepted; the SERVER owns the check, do not self-post.
  *   'rejected' — the certification is definitively refused (malformed / inconsistent /
- *                ungrounded bundle, OR a server 4xx AUTHORITATIVELY declining). Post
- *                NO check — never a false green off a bad artifact or over a server "no".
- *   'fallback' — the endpoint is DOWN (network error or 5xx), not a verdict; the caller
- *                may self-post the self-attested check (derived from THIS bundle) so local
- *                max mode keeps gating while Z4 is pending.
+ *                ungrounded bundle, OR a server 4xx AUTHORITATIVELY declining, on either
+ *                `/challenge` or `/notarize`). Post NO check — never a false green off a
+ *                bad artifact or over a server "no".
+ *   'fallback' — the endpoint is DOWN (network error or 5xx) or NOT ENTITLED (402), not a
+ *                verdict; the caller may self-post the self-attested check (derived from
+ *                THIS bundle) so local max mode keeps gating while Z4 is pending.
  */
 async function submitToNotary(
   notaryUrl: string,
@@ -133,8 +201,24 @@ async function submitToNotary(
     }
   }
 
-  // Submit. TODO(Z4): the server mints/consumes the nonce, re-fetches GitHub's
-  // ground-truth diff, re-runs ①–⑤, signs, and posts the pinned check.
+  // The notary certifies a PR head (it re-fetches GitHub's PR diff), so a
+  // pr-less bundle (a commit-trigger local pre-notarization, no PR yet) can't be
+  // notarized — don't waste a challenge on a guaranteed 422; self-attest instead.
+  if (bundle.pr == null) {
+    warn('bundle has no PR — the notary certifies PR heads; using the self-attested check.');
+    return { outcome: 'fallback', bundle };
+  }
+
+  // Mint the single-use nonce (① replay-closure) before certifying. A terminal
+  // decline here (bad request / not-entitled) never reaches `/notarize`; only a
+  // minted nonce does.
+  const challenge = await fetchChallenge(notaryUrl, bundle, warn);
+  if (challenge === 'rejected') return { outcome: 'rejected', bundle };
+  if (challenge === 'fallback') return { outcome: 'fallback', bundle };
+  bundle.nonce = challenge.nonce;
+
+  // Submit. The server re-fetches GitHub's ground-truth diff, re-runs ①–⑤,
+  // checks + consumes the nonce, signs, and posts the pinned check.
   const url = notaryUrl.replace(/\/+$/, '') + '/notarize';
   try {
     const res = await fetch(url, {

--- a/test/notary-submit.test.js
+++ b/test/notary-submit.test.js
@@ -1,0 +1,307 @@
+// Phase Z4 (CLI side) — the challenge/response nonce handshake that precedes
+// `/notarize`. `submitToNotary` now mints a single-use nonce via `POST
+// /challenge` before submitting, per SPEC §10.3.3 ① replay-closure. These
+// tests drive the REAL compiled CLI (subprocess) against a throwaway local
+// HTTP server standing in for the notary — matching check-verdict.test.js's
+// `post-check-run` idiom and cli.test.js's "can't monkey-patch fetch in a
+// child process" note (see its `CLUD_BUG_SKILLS_SH_BASE` override).
+
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+
+const CLI = join(dirname(dirname(fileURLToPath(import.meta.url))), 'bin', 'clud-bug.js');
+
+// NB: `spawn`, not `spawnSync` — the mock notary server below lives in THIS
+// same test process. `spawnSync` blocks the whole JS thread until the child
+// exits, which would starve that server's event loop and deadlock any test
+// that both spawns the CLI and expects it to reach a same-process server.
+function run(cwd, args, env = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      cwd,
+      // A broken PATH means any `git`/`gh` the CLI shells out to (owner/repo
+      // resolution, the diff load for coverage/grounding, the final check-run
+      // POST) fails closed with ENOENT rather than making a real network call —
+      // keeps these tests hermetic regardless of local `gh` auth. The bundle
+      // uses a made-up `head_sha`, so the diff load was always going to come up
+      // empty; this just makes that deterministic too.
+      env: { ...process.env, PATH: '/dev/null/does-not-exist', ...env },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => (stdout += d));
+    child.stderr.on('data', (d) => (stderr += d));
+    child.on('error', reject);
+    // Safety net: a stray open socket must never hang the test suite — fail
+    // loudly (non-null `.signal`) instead of hanging until vitest's own
+    // per-test timeout.
+    const timer = setTimeout(() => child.kill('SIGKILL'), 15000);
+    child.on('close', (status, signal) => {
+      clearTimeout(timer);
+      resolve({ status, signal, stdout, stderr });
+    });
+  });
+}
+
+async function withServer(handler, fn) {
+  const requests = [];
+  const server = createServer((req, res) => {
+    let raw = '';
+    req.on('data', (c) => (raw += c));
+    req.on('end', () => {
+      let body;
+      try {
+        body = raw ? JSON.parse(raw) : undefined;
+      } catch {
+        body = undefined;
+      }
+      requests.push({ method: req.method, url: req.url, body });
+      // Force the socket closed once the response is flushed — otherwise the
+      // CLI's fetch keeps the HTTP/1.1 keep-alive connection open and
+      // `server.close()` below hangs waiting for a connection nobody is
+      // going to close from either end.
+      res.on('finish', () => req.socket.destroy());
+      handler(req, res, body);
+    });
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  try {
+    const { port } = server.address();
+    return await fn(`http://127.0.0.1:${port}`, requests);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+async function makeBundle(dir, overrides = {}) {
+  const bundle = {
+    bundle_version: 1,
+    repo: 'o/r',
+    pr: 7,
+    head_sha: 'deadbeefcafefeed0000',
+    verdict: 'clean',
+    findings: [],
+    coverage: [],
+    recipe_version: 'test',
+    protocol_version: '1.2.0',
+    ...overrides,
+  };
+  const path = join(dir, 'bundle.json');
+  await writeFile(path, JSON.stringify(bundle));
+  return path;
+}
+
+describe('post-check-run notary submit: /challenge handshake', () => {
+  it('200 challenge → nonce attached to the bundle POSTed to /notarize; outcome posted', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cb-notary-'));
+    try {
+      const bundlePath = await makeBundle(dir);
+      await withServer(
+        (req, res) => {
+          if (req.method === 'POST' && req.url === '/notarize/challenge') {
+            res.writeHead(200, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ nonce: 'nonce-123' }));
+          } else if (req.method === 'POST' && req.url === '/notarize') {
+            res.writeHead(200, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ ok: true }));
+          } else {
+            res.writeHead(404);
+            res.end();
+          }
+        },
+        async (url, requests) => {
+          const r = await run(dir, ['post-check-run', '--sha', 'deadbeefcafefeed0000', '--bundle', bundlePath], {
+            CLUD_BUG_NOTARY_URL: url,
+          });
+          expect(r.status).toBe(0);
+          expect(r.stdout).toMatch(/notarized o\/r@deadbeefcafe\b/);
+
+          const challengeReq = requests.find((x) => x.url === '/notarize/challenge');
+          expect(challengeReq).toBeTruthy();
+          expect(challengeReq.body).toMatchObject({ repo: 'o/r', head_sha: 'deadbeefcafefeed0000' });
+
+          const notarizeReq = requests.find((x) => x.url === '/notarize');
+          expect(notarizeReq).toBeTruthy();
+          expect(notarizeReq.body.nonce).toBe('nonce-123');
+        },
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('402 (not entitled) on /challenge → loud NOT-notarized warning, falls back, never calls /notarize', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cb-notary-'));
+    try {
+      const bundlePath = await makeBundle(dir);
+      await withServer(
+        (req, res) => {
+          if (req.method === 'POST' && req.url === '/notarize/challenge') {
+            res.writeHead(402, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ error: 'not entitled' }));
+          } else {
+            res.writeHead(404);
+            res.end();
+          }
+        },
+        async (url, requests) => {
+          const r = await run(dir, ['post-check-run', '--sha', 'deadbeefcafefeed0000', '--bundle', bundlePath], {
+            CLUD_BUG_NOTARY_URL: url,
+          });
+          // Best-effort verb — never fatal even though the final self-attested
+          // check-run POST also fails closed (no `gh` on PATH).
+          expect(r.status).toBe(0);
+          expect(r.stderr).toMatch(/NOT notarized/);
+          expect(r.stderr).toMatch(/self-attested/);
+          expect(r.stderr).toMatch(/cludbug\.dev/);
+          expect(requests.some((x) => x.url === '/notarize')).toBe(false);
+        },
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('non-402 4xx on /challenge → terminal rejected (not a fallback), never calls /notarize', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cb-notary-'));
+    try {
+      const bundlePath = await makeBundle(dir);
+      await withServer(
+        (req, res) => {
+          if (req.method === 'POST' && req.url === '/notarize/challenge') {
+            res.writeHead(400, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ error: 'bad request' }));
+          } else {
+            res.writeHead(404);
+            res.end();
+          }
+        },
+        async (url, requests) => {
+          const r = await run(dir, ['post-check-run', '--sha', 'deadbeefcafefeed0000', '--bundle', bundlePath], {
+            CLUD_BUG_NOTARY_URL: url,
+          });
+          expect(r.status).toBe(0);
+          expect(r.stderr).toMatch(/notary declined the challenge/);
+          expect(r.stderr).not.toMatch(/NOT notarized/);
+          expect(r.stdout).not.toMatch(/notarized/);
+          expect(requests.some((x) => x.url === '/notarize')).toBe(false);
+        },
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('5xx on /challenge → fallback (endpoint down), never calls /notarize', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cb-notary-'));
+    try {
+      const bundlePath = await makeBundle(dir);
+      await withServer(
+        (req, res) => {
+          if (req.method === 'POST' && req.url === '/notarize/challenge') {
+            res.writeHead(503, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ error: 'down for maintenance' }));
+          } else {
+            res.writeHead(404);
+            res.end();
+          }
+        },
+        async (url, requests) => {
+          const r = await run(dir, ['post-check-run', '--sha', 'deadbeefcafefeed0000', '--bundle', bundlePath], {
+            CLUD_BUG_NOTARY_URL: url,
+          });
+          expect(r.status).toBe(0);
+          expect(r.stderr).toMatch(/notary challenge endpoint unavailable/);
+          expect(r.stderr).toMatch(/falling back to the self-attested check/);
+          expect(r.stderr).not.toMatch(/NOT notarized/);
+          expect(requests.some((x) => x.url === '/notarize')).toBe(false);
+        },
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('network error reaching /challenge (endpoint down) → fallback', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cb-notary-'));
+    try {
+      const bundlePath = await makeBundle(dir);
+      const r = await run(dir, ['post-check-run', '--sha', 'deadbeefcafefeed0000', '--bundle', bundlePath], {
+        // Port 1 is (almost certainly) not listening → ECONNREFUSED, same
+        // unreachable-host idiom cli.test.js uses for skills.sh.
+        CLUD_BUG_NOTARY_URL: 'http://127.0.0.1:1',
+      });
+      expect(r.status).toBe(0);
+      expect(r.stderr).toMatch(/notary challenge endpoint unreachable/);
+      expect(r.stderr).toMatch(/falling back to the self-attested check/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('successful challenge but /notarize itself 4xx → still terminal rejected (unchanged semantics)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cb-notary-'));
+    try {
+      const bundlePath = await makeBundle(dir);
+      await withServer(
+        (req, res) => {
+          if (req.method === 'POST' && req.url === '/notarize/challenge') {
+            res.writeHead(200, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ nonce: 'nonce-456' }));
+          } else if (req.method === 'POST' && req.url === '/notarize') {
+            res.writeHead(422, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ error: 'ungrounded critical' }));
+          } else {
+            res.writeHead(404);
+            res.end();
+          }
+        },
+        async (url, requests) => {
+          const r = await run(dir, ['post-check-run', '--sha', 'deadbeefcafefeed0000', '--bundle', bundlePath], {
+            CLUD_BUG_NOTARY_URL: url,
+          });
+          expect(r.status).toBe(0);
+          expect(r.stderr).toMatch(/notary declined the bundle/);
+          expect(r.stdout).not.toMatch(/notarized/);
+          const notarizeReq = requests.find((x) => x.url === '/notarize');
+          expect(notarizeReq).toBeTruthy();
+          expect(notarizeReq.body.nonce).toBe('nonce-456');
+        },
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('pr-less bundle → self-attest fallback; never contacts the notary at all', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cb-notary-'));
+    try {
+      // JSON.stringify drops `pr: undefined`, so the bundle has no PR — a
+      // commit-trigger local pre-notarization the notary can't certify.
+      const bundlePath = await makeBundle(dir, { pr: undefined });
+      await withServer(
+        (req, res) => {
+          res.writeHead(500);
+          res.end();
+        },
+        async (url, requests) => {
+          const r = await run(dir, ['post-check-run', '--sha', 'deadbeefcafefeed0000', '--bundle', bundlePath], {
+            CLUD_BUG_NOTARY_URL: url,
+          });
+          expect(r.status).toBe(0);
+          expect(r.stderr).toMatch(/no PR/);
+          expect(r.stdout).not.toMatch(/notarized/);
+          // Neither the challenge nor the notarize endpoint was ever hit.
+          expect(requests.length).toBe(0);
+        },
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
The CLI half of the Z4 notary handshake. `post-check-run`'s `submitToNotary` now mints a single-use nonce (SPEC §10.3.3 ① replay-closure) before submitting: `POST {repo, pr, head_sha}` → `/notarize/challenge` → echo `{nonce}` in the bundle → `POST /notarize`.

**Adversarial-review fixes folded in** (from the Z4 build Workflow's verify pass):
- **Challenge URL** → `/notarize/challenge` (the server route is `app/api/notarize/challenge`; a sibling `/challenge` would 404).
- **pr-less bundles skip the notary** (it certifies PR heads) → self-attested check, no wasted 422.
- **402 (not eligible / App absent)** → loud `NOT notarized` warning + self-attested fallback; never blocks work.

980/980 tests green (incl. the new pr-less→fallback case). **Not for merge yet** — CEO gate. After merge: a clud-bug **rc.24** bump+publish ships the handshake. The server side is `clud-bug-app#` (branch `feat-notary-z4`, separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)