### PR TITLE
chore: bump to 0.7.0-rc.24 (ships the Z4 CLI notary handshake)

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.23
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.24
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/decisions-branches/chore-bump-rc24.md
+++ b/docs/decisions-branches/chore-bump-rc24.md
@@ -1,0 +1,11 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-16 21:28 - chore: bump to 0.7.0-rc.24 (ships the Z4 CLI notary challenge/response handshake)
+
+**Reasoning:** Publishes the Phase Z4 CLI side (#233): post-check-run now fetches a single-use nonce from the notary's /notarize/challenge and echoes it in the bundle before submitting. Release discipline: propagated the version pin to the 3 workflow templates + strict-mode-gate action.yml. The handshake is opt-in (only active when CLUD_BUG_NOTARY_URL is set), so this ships inert until an install opts in.
+
+**Implications:**
+- Tag v0.7.0-rc.24 after merge triggers the OIDC npm-publish (npm@11, fixed in #231) -> dist-tag 'next'; the hosted notary server (#97) is already deployed
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (23 decisions)
+## 2026-07 (24 decisions)
 
-- **2026-07-16** — Phase Z4 (CLI): challenge/response nonce handshake before /notarize + pr-less skip *(feat-notary-z4-cli)* — [decisions-branches/feat-notary-z4-cli.md](decisions-branches/feat-notary-z4-cli.md)
-- *... 21 more decisions ...*
+- **2026-07-16** — chore: bump to 0.7.0-rc.24 (ships the Z4 CLI notary challenge/response handshake) *(chore-bump-rc24)* — [decisions-branches/chore-bump-rc24.md](decisions-branches/chore-bump-rc24.md)
+- *... 22 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.23",
+  "version": "0.7.0-rc.24",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.23
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.24
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -413,7 +413,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.23
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.24
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -717,7 +717,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.23
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.24
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow


### PR DESCRIPTION
Bumps clud-bug to **0.7.0-rc.24** to ship the Phase Z4 CLI challenge/response handshake (#233) to installs — `post-check-run` fetches a single-use nonce from the notary before submitting. Opt-in (inert unless `CLUD_BUG_NOTARY_URL` is set). Version pin propagated to the 3 workflow templates + `strict-mode-gate/action.yml`; 980/980 tests green. After merge I tag `v0.7.0-rc.24` → OIDC publish to `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)