### PR TITLE
ZP3: self-hosted Action → notary (build-bundle + base-ref-guarded CI notarize step + init installs both)

### DIFF
--- a/.ci-rendered/workflow-py.yml
+++ b/.ci-rendered/workflow-py.yml
@@ -689,12 +689,17 @@ jobs:
         run: |
           set -uo pipefail
 
-          # strictMode from the BASE ref's manifest — a PR can't opt itself out
-          # (or disable the notary) by editing its own HEAD .clud-bug.json.
+          # strictMode + notary enablement from the BASE ref's manifest — a PR
+          # can't opt itself out of strict mode OR disable the notary by editing
+          # its own HEAD .clud-bug.json. Unreadable base → --no-strict + --notary.
           STRICT_FLAG=--no-strict
+          NOTARY_FLAG=--notary
           if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
             if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
               STRICT_FLAG=--strict
+            fi
+            if jq -e '.notary == false' /tmp/base-manifest.json > /dev/null 2>&1; then
+              NOTARY_FLAG=--no-notary
             fi
           fi
 
@@ -705,7 +710,7 @@ jobs:
             > bundle.json
 
           npx --yes clud-bug@0.7.0-rc.24 post-check-run \
-            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG"
+            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG" "$NOTARY_FLAG"
 
       # Wave 5a (D.2.X) — see workflow.yml.tmpl for design notes.
       - name: Post inline review threads

--- a/.ci-rendered/workflow-py.yml
+++ b/.ci-rendered/workflow-py.yml
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v12
+# clud-bug-template-version: v14
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -213,6 +213,19 @@ jobs:
           echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
           exit 1
 
+      # ── Design-critic (optional, opt-in) ─────────────────────────────────
+      # clud-bug can also review the *rendered* UI of your PR's preview deploy.
+      # The hosted clud-bug[bot] does this for you on Team installs (Browserless).
+      # To run it here on the Action reviewer instead — Claude drives a real
+      # browser on this runner, no paid render service — enable it in 3 steps:
+      #   1. clud-bug init --with-design   (installs the design kit + flips the
+      #      `design` block in .claude/skills/.clud-bug.json to enabled: true)
+      #   2. add a browser MCP to claude_args below, e.g.:
+      #        --mcp-config '{"mcpServers":{"playwright":{"command":"npx","args":["-y","@playwright/mcp@latest"]}}}'
+      #   3. append the browser tools to --allowedTools, e.g.:
+      #        ,mcp__playwright__browser_navigate,mcp__playwright__browser_take_screenshot
+      # Off by default. See the §3b design step in `clud-bug review-prompt`.
+      # ──────────────────────────────────────────────────────────────────────
       - uses: anthropics/claude-code-action@v1.0.133
         if: steps.guard.outputs.skip != 'true'
         env:
@@ -222,7 +235,7 @@ jobs:
           # HEAD_SHA (v0.6.10+) — see workflow.yml.tmpl for design notes.
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           # Per-section byte budgets — see workflow.yml.tmpl for design notes.
-          MAX_DIFF_BYTES: '80000'
+          MAX_DIFF_BYTES: '5000000'
           MAX_COMMENT_BYTES: '20000'
           MAX_SKILL_BYTES: '4000'
           # Thinking-budget cap (v0.6.8) — see workflow.yml.tmpl for design notes.
@@ -389,6 +402,36 @@ jobs:
                 every file's verdict so a maintainer can verify nothing was
                 skipped.
 
+            Mid-review self-check-in (v0.6.27 / §5.5 Layer 3):
+            After every 5 tool_uses, write a single-line budget heartbeat as a
+            free-text "thinking" message (not a tool call — these don't cost a
+            turn) of the form:
+
+              [budget] files_reviewed=X/N, turns_used=Y/M, pace=ok|behind
+
+            Where:
+              - X / N is the count of files you've meaningfully looked at so far
+                over the total in this PR's diff.
+              - Y / M is your current turn count over max_turns.
+              - pace = "ok" when X / N >= Y / (M - 5). The denominator subtracts the
+                5-turn emit reservation: over the (M - 5) turns available for file
+                review, your file-coverage rate must match where you actually are
+                in the budget. (Don't subtract from Y — that would be saying "I've
+                used Y minus 5 turns" which double-counts the reservation.)
+                pace = "behind" otherwise.
+
+            When pace = "behind", immediately pivot strategy:
+              1. Stop deep-dive analysis on the current file.
+              2. Switch to one-sentence verdicts for every remaining file.
+              3. Keep going through the whole diff — silent skipping is
+                 non-negotiable. Cover everything, even if some files only get
+                 "no issues found in this file" as their verdict.
+
+            The heartbeat serves two purposes: (a) forces internal pacing — you
+            can't drift past budget without noticing; (b) lands in the action's
+            streaming output for post-hoc calibration of the per-line cost
+            coefficients used by paths-check's Layer 1 estimator.
+
             Incremental-diff handshake (v0.6.10+) — emit the SHA marker:
             At the very end of the summary (after the Skills-referenced footer,
             on its own line), append:
@@ -413,6 +456,27 @@ jobs:
             If strictMode is unset or absent, set `status_header: "bare"` —
             the renderer emits the bare `## 🐛 Clud Bug review` (no suffix),
             matching the v0.6.21- visible behaviour for non-strict-mode repos.
+
+            Grounding (REQUIRED on every 🔴 critical — notary attestation §10.3.3):
+            This review's structured output is assembled into a NOTARY ATTESTATION
+            BUNDLE for independent certification. The notary REJECTS an ungrounded
+            critical, refusing the WHOLE bundle (no green check). So populate the
+            `grounding` + `grounding_kind` schema fields on EVERY critical, one of:
+              - `quote` — the offending line copied VERBATIM from the diff (with a
+                matching `line`). The notary re-verifies this span is a byte-exact
+                substring of a changed line; PREFER it (the only form checked
+                deterministically) whenever a single changed line carries the bug.
+              - `reproduction` — a command you ran + its observed output (only under
+                the execution-safety rule; never run an untrusted contributor/fork
+                diff). Stronger evidence than a quote, not weaker.
+              - `invariant` — a one-sentence named property the change breaks + the
+                input that breaks it. For a bug on no single changed line (emergent,
+                combinatorial, or cross-cutting), reproduce it or name the invariant
+                instead of staying silent.
+            Default `grounding_kind` to `quote`; `reproduction`/`invariant` are
+            audit-verified. A repro you ran, or a named invariant, SATISFIES any
+            skill that says "quote the exact line or drop". Drop only what NONE of
+            the three grounds. `grounding` is optional on 🟡 minor / 🟣 pre-existing.
 
             Tone: conversational, concise field-naturalist voice (you are Clud
             Bug examining specimens of code) — never at the cost of clarity,
@@ -567,7 +631,7 @@ jobs:
             --model ${{ needs.paths-check.outputs.model }}
             --max-turns ${{ needs.paths-check.outputs.max_turns }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
-            --json-schema '{"type":"object","additionalProperties":false,"properties":{"status_header":{"type":"string","enum":["critical findings","clean","bare"],"description":"Strict-mode opt-in repos: `critical findings` when ANY 🔴 finding exists, otherwise `clean`. Non-strict-mode repos (the default): emit `bare` — the renderer produces a `## 🐛 Clud Bug review` H2 with no suffix, matching the v0.6.21- behaviour. Check .claude/skills/.clud-bug.json for `strictMode: true` to pick critical/clean vs bare."},"summary_counts":{"type":"object","additionalProperties":false,"properties":{"critical":{"type":"integer","minimum":0},"minor":{"type":"integer","minimum":0},"preexisting":{"type":"integer","minimum":0},"resolved_from_prior":{"type":"integer","minimum":0},"still_open":{"type":"integer","minimum":0}},"required":["critical","minor","preexisting","resolved_from_prior","still_open"]},"per_skill_scan":{"type":"array","description":"One entry per LOADED skill — even silent ones. Empty when no skills are installed.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string"},"outcome":{"type":"string","description":"One sentence describing what the skill found. Max ~15 words. Examples: \"scanned all paths. 2 critical findings below.\", \"0 findings.\", \"not applicable to this diff.\""}},"required":["skill","outcome"]}},"critical_findings":{"type":"array","description":"NEW 🔴 findings (bugs, security, perf, missing test coverage). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"minor_findings":{"type":"array","description":"NEW 🟡 findings (nits, style, observations). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"preexisting_findings":{"type":"array","description":"NEW 🟣 findings (issues that pre-date this PR). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"dedicated_sections":{"type":"array","description":"Per-dedicated-mode-skill section blocks. Each item carries the section header text and its findings.","items":{"type":"object","additionalProperties":false,"properties":{"section_name":{"type":"string","description":"Human-readable section title, e.g. \"Brand voice\"."},"skill":{"type":"string","description":"The dedicated skill name."},"findings":{"type":"array","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}}},"required":["section_name","skill","findings"]}},"diagnostics":{"type":"array","description":"0.0.T tee-hint diagnostics. One line per `head -c` cap that fired during fetch. Empty when no truncation occurred.","items":{"type":"string"}},"skills_referenced":{"type":"array","description":"Names of every skill cited in any finding. Empty list (or [\"(none)\"]) when no skill applied.","items":{"type":"string"}},"last_reviewed_sha":{"type":"string","description":"The HEAD SHA at review time, used by the incremental-diff handshake. Set to the literal value of the workflow env var $HEAD_SHA."}},"required":["status_header","summary_counts","per_skill_scan","critical_findings","minor_findings","preexisting_findings","skills_referenced","last_reviewed_sha"]}'
+            --json-schema '{"type":"object","additionalProperties":false,"properties":{"status_header":{"type":"string","enum":["critical findings","clean","bare"],"description":"Strict-mode opt-in repos: `critical findings` when ANY 🔴 finding exists, otherwise `clean`. Non-strict-mode repos (the default): emit `bare` — the renderer produces a `## 🐛 Clud Bug review` H2 with no suffix, matching the v0.6.21- behaviour. Check .claude/skills/.clud-bug.json for `strictMode: true` to pick critical/clean vs bare."},"summary_counts":{"type":"object","additionalProperties":false,"properties":{"critical":{"type":"integer","minimum":0},"minor":{"type":"integer","minimum":0},"preexisting":{"type":"integer","minimum":0},"resolved_from_prior":{"type":"integer","minimum":0},"still_open":{"type":"integer","minimum":0}},"required":["critical","minor","preexisting","resolved_from_prior","still_open"]},"per_skill_scan":{"type":"array","description":"One entry per LOADED skill — even silent ones. Empty when no skills are installed.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string"},"outcome":{"type":"string","description":"One sentence describing what the skill found. Max ~15 words. Examples: \"scanned all paths. 2 critical findings below.\", \"0 findings.\", \"not applicable to this diff.\""}},"required":["skill","outcome"]}},"critical_findings":{"type":"array","description":"NEW 🔴 findings (bugs, security, perf, missing test coverage). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}},"minor_findings":{"type":"array","description":"NEW 🟡 findings (nits, style, observations). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}},"preexisting_findings":{"type":"array","description":"NEW 🟣 findings (issues that pre-date this PR). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}},"dedicated_sections":{"type":"array","description":"Per-dedicated-mode-skill section blocks. Each item carries the section header text and its findings.","items":{"type":"object","additionalProperties":false,"properties":{"section_name":{"type":"string","description":"Human-readable section title, e.g. \"Brand voice\"."},"skill":{"type":"string","description":"The dedicated skill name."},"findings":{"type":"array","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}}},"required":["section_name","skill","findings"]}},"diagnostics":{"type":"array","description":"0.0.T tee-hint diagnostics. One line per `head -c` cap that fired during fetch. Empty when no truncation occurred.","items":{"type":"string"}},"skills_referenced":{"type":"array","description":"Names of every skill cited in any finding. Empty list (or [\"(none)\"]) when no skill applied.","items":{"type":"string"}},"last_reviewed_sha":{"type":"string","description":"The HEAD SHA at review time, used by the incremental-diff handshake. Set to the literal value of the workflow env var $HEAD_SHA."}},"required":["status_header","summary_counts","per_skill_scan","critical_findings","minor_findings","preexisting_findings","skills_referenced","last_reviewed_sha"]}'
           prompt: |
             Review this pull request following the discipline in your
             system prompt — every rule about skill routing, comment
@@ -603,11 +667,106 @@ jobs:
           THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.26 render --stdin)
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 render --stdin)
           CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
           gh pr comment "$PR_NUMBER" --body "$BODY
 
           $CALIBRATION"
+
+      # Phase ZP3 — route this Action's review through the NOTARY.
+      # See workflow.yml.tmpl for full design notes (base-ref trust guard;
+      # continue-on-error coexists with the strict-mode-gate backstop).
+      - name: Notarize review
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -uo pipefail
+
+          # strictMode from the BASE ref's manifest — a PR can't opt itself out
+          # (or disable the notary) by editing its own HEAD .clud-bug.json.
+          STRICT_FLAG=--no-strict
+          if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
+            if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
+              STRICT_FLAG=--strict
+            fi
+          fi
+
+          printf '%s\n' "$STRUCTURED" \
+            | npx --yes clud-bug@0.7.0-rc.24 build-bundle \
+                --repo "$REPO" --pr "$PR_NUMBER" --sha "$HEAD_SHA" \
+                --recipe-version "ci-0.7.0-rc.24" \
+            > bundle.json
+
+          npx --yes clud-bug@0.7.0-rc.24 post-check-run \
+            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG"
+
+      # Wave 5a (D.2.X) — see workflow.yml.tmpl for design notes.
+      - name: Post inline review threads
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 post-inline-threads --stdin)
+          echo "::notice title=inline-threads::$RESULT"
+
+      # Wave 5b (D.2.6) — see workflow.yml.tmpl for design notes.
+      - name: Auto-resolve fixed threads
+        if: success() && github.event.action == 'synchronize'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Optional fine-grained PAT (Pull requests: write). Present → the
+          # workflow resolves fixed threads like the hosted App. Absent (the
+          # default; an unset secret renders empty) → graceful "verified fixed"
+          # reply only, since the Actions GITHUB_TOKEN can't resolve threads.
+          CLUD_BUG_RESOLVE_PAT: ${{ secrets.CLUD_BUG_RESOLVE_PAT }}
+        run: |
+          set -euo pipefail
+          RESULT=$(npx --yes clud-bug@0.7.0-rc.24 resolve-threads)
+          echo "::notice title=auto-resolve::$RESULT"
+
+      # v0.6.29 / Component 4 — see workflow.yml.tmpl for design notes.
+      - name: Update skill-usage tracking
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          mkdir -p .claude/skills
+          if [ ! -f .claude/skills/.clud-bug.json ]; then
+            echo '{"version": 1}' > .claude/skills/.clud-bug.json
+          fi
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 update-skill-usage --stdin
+          echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
+
+      - name: Upload skill-usage artifact
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}
+          path: .claude/skills/.clud-bug.json
+          # v0.6.31 hotfix: upload-artifact@v4 excludes hidden files
+          # by default. See workflow.yml.tmpl for full context.
+          include-hidden-files: true
+          retention-days: 90
 
       # v0.6.26 / §5.5 Layer 6 fallback render-from-inlines — see workflow.yml.tmpl for design notes.
       - name: Fallback summary (structured_output empty)
@@ -665,9 +824,52 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.26
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.24
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].
           # See workflow.yml.tmpl for design notes.
           bot-login: 'github-actions[bot]'
+
+      # v0.7.0-rc.3 — SPEC §7.2.1 formal-review event poster.
+      # See workflow.yml.tmpl for full design rationale; this step
+      # bridges the canonical-ruleset `required_approving_review_count: 1`
+      # floor on the npm workflow path. Best-effort: never fails the
+      # workflow (continue-on-error). Drive-by exploit guard: external
+      # contributors NEVER get APPROVE.
+      - name: Formal review — APPROVE / REQUEST_CHANGES / COMMENT
+        if: always() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -uo pipefail
+          STRICT_MODE=false
+          if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
+            if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
+              STRICT_MODE=true
+            fi
+          fi
+          export STRICT_MODE
+          VERDICT=$(printf '%s\n' "$STRUCTURED" \
+            | npx --yes clud-bug@0.7.0-rc.24 select-review-event --stdin \
+            | tail -n1)
+          VERDICT="${VERDICT:-skip}"
+          echo "::notice title=Clud Bug 🐛::Formal review verdict: $VERDICT (strictMode=$STRICT_MODE, author_assoc=$PR_AUTHOR_ASSOCIATION)"
+          if [ "$VERDICT" = "skip" ]; then
+            exit 0
+          fi
+          BODY=$(printf 'Automated formal review by clud-bug — see the summary comment for the substantive findings.\n\nVerdict: **%s**\n\n<!-- clud-bug-formal-review: workflow-path v0.7.0-rc.3 -->' "$VERDICT")
+          gh api -X POST "/repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            -f event="$VERDICT" \
+            -f commit_id="$HEAD_SHA" \
+            -f body="$BODY" \
+            > /dev/null \
+            || echo "::warning title=Clud Bug 🐛::Formal review POST failed (likely 422 self-PR or missing perms); degrading to comment-only."

--- a/.ci-rendered/workflow-ts.yml
+++ b/.ci-rendered/workflow-ts.yml
@@ -690,12 +690,17 @@ jobs:
         run: |
           set -uo pipefail
 
-          # strictMode from the BASE ref's manifest — a PR can't opt itself out
-          # (or disable the notary) by editing its own HEAD .clud-bug.json.
+          # strictMode + notary enablement from the BASE ref's manifest — a PR
+          # can't opt itself out of strict mode OR disable the notary by editing
+          # its own HEAD .clud-bug.json. Unreadable base → --no-strict + --notary.
           STRICT_FLAG=--no-strict
+          NOTARY_FLAG=--notary
           if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
             if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
               STRICT_FLAG=--strict
+            fi
+            if jq -e '.notary == false' /tmp/base-manifest.json > /dev/null 2>&1; then
+              NOTARY_FLAG=--no-notary
             fi
           fi
 
@@ -706,7 +711,7 @@ jobs:
             > bundle.json
 
           npx --yes clud-bug@0.7.0-rc.24 post-check-run \
-            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG"
+            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG" "$NOTARY_FLAG"
 
       # Wave 5a (D.2.X) — see workflow.yml.tmpl for design notes.
       - name: Post inline review threads

--- a/.ci-rendered/workflow-ts.yml
+++ b/.ci-rendered/workflow-ts.yml
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v12
+# clud-bug-template-version: v14
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -213,6 +213,19 @@ jobs:
           echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
           exit 1
 
+      # ── Design-critic (optional, opt-in) ─────────────────────────────────
+      # clud-bug can also review the *rendered* UI of your PR's preview deploy.
+      # The hosted clud-bug[bot] does this for you on Team installs (Browserless).
+      # To run it here on the Action reviewer instead — Claude drives a real
+      # browser on this runner, no paid render service — enable it in 3 steps:
+      #   1. clud-bug init --with-design   (installs the design kit + flips the
+      #      `design` block in .claude/skills/.clud-bug.json to enabled: true)
+      #   2. add a browser MCP to claude_args below, e.g.:
+      #        --mcp-config '{"mcpServers":{"playwright":{"command":"npx","args":["-y","@playwright/mcp@latest"]}}}'
+      #   3. append the browser tools to --allowedTools, e.g.:
+      #        ,mcp__playwright__browser_navigate,mcp__playwright__browser_take_screenshot
+      # Off by default. See the §3b design step in `clud-bug review-prompt`.
+      # ──────────────────────────────────────────────────────────────────────
       - uses: anthropics/claude-code-action@v1.0.133
         if: steps.guard.outputs.skip != 'true'
         env:
@@ -222,7 +235,7 @@ jobs:
           # HEAD_SHA (v0.6.10+) — see workflow.yml.tmpl for design notes.
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           # Per-section byte budgets — see workflow.yml.tmpl for design notes.
-          MAX_DIFF_BYTES: '80000'
+          MAX_DIFF_BYTES: '5000000'
           MAX_COMMENT_BYTES: '20000'
           MAX_SKILL_BYTES: '4000'
           # Thinking-budget cap (v0.6.8) — see workflow.yml.tmpl for design notes.
@@ -390,6 +403,36 @@ jobs:
                 every file's verdict so a maintainer can verify nothing was
                 skipped.
 
+            Mid-review self-check-in (v0.6.27 / §5.5 Layer 3):
+            After every 5 tool_uses, write a single-line budget heartbeat as a
+            free-text "thinking" message (not a tool call — these don't cost a
+            turn) of the form:
+
+              [budget] files_reviewed=X/N, turns_used=Y/M, pace=ok|behind
+
+            Where:
+              - X / N is the count of files you've meaningfully looked at so far
+                over the total in this PR's diff.
+              - Y / M is your current turn count over max_turns.
+              - pace = "ok" when X / N >= Y / (M - 5). The denominator subtracts the
+                5-turn emit reservation: over the (M - 5) turns available for file
+                review, your file-coverage rate must match where you actually are
+                in the budget. (Don't subtract from Y — that would be saying "I've
+                used Y minus 5 turns" which double-counts the reservation.)
+                pace = "behind" otherwise.
+
+            When pace = "behind", immediately pivot strategy:
+              1. Stop deep-dive analysis on the current file.
+              2. Switch to one-sentence verdicts for every remaining file.
+              3. Keep going through the whole diff — silent skipping is
+                 non-negotiable. Cover everything, even if some files only get
+                 "no issues found in this file" as their verdict.
+
+            The heartbeat serves two purposes: (a) forces internal pacing — you
+            can't drift past budget without noticing; (b) lands in the action's
+            streaming output for post-hoc calibration of the per-line cost
+            coefficients used by paths-check's Layer 1 estimator.
+
             Incremental-diff handshake (v0.6.10+) — emit the SHA marker:
             At the very end of the summary (after the Skills-referenced footer,
             on its own line), append:
@@ -414,6 +457,27 @@ jobs:
             If strictMode is unset or absent, set `status_header: "bare"` —
             the renderer emits the bare `## 🐛 Clud Bug review` (no suffix),
             matching the v0.6.21- visible behaviour for non-strict-mode repos.
+
+            Grounding (REQUIRED on every 🔴 critical — notary attestation §10.3.3):
+            This review's structured output is assembled into a NOTARY ATTESTATION
+            BUNDLE for independent certification. The notary REJECTS an ungrounded
+            critical, refusing the WHOLE bundle (no green check). So populate the
+            `grounding` + `grounding_kind` schema fields on EVERY critical, one of:
+              - `quote` — the offending line copied VERBATIM from the diff (with a
+                matching `line`). The notary re-verifies this span is a byte-exact
+                substring of a changed line; PREFER it (the only form checked
+                deterministically) whenever a single changed line carries the bug.
+              - `reproduction` — a command you ran + its observed output (only under
+                the execution-safety rule; never run an untrusted contributor/fork
+                diff). Stronger evidence than a quote, not weaker.
+              - `invariant` — a one-sentence named property the change breaks + the
+                input that breaks it. For a bug on no single changed line (emergent,
+                combinatorial, or cross-cutting), reproduce it or name the invariant
+                instead of staying silent.
+            Default `grounding_kind` to `quote`; `reproduction`/`invariant` are
+            audit-verified. A repro you ran, or a named invariant, SATISFIES any
+            skill that says "quote the exact line or drop". Drop only what NONE of
+            the three grounds. `grounding` is optional on 🟡 minor / 🟣 pre-existing.
 
             Tone: conversational, concise field-naturalist voice (you are Clud
             Bug examining specimens of code) — never at the cost of clarity,
@@ -568,7 +632,7 @@ jobs:
             --model ${{ needs.paths-check.outputs.model }}
             --max-turns ${{ needs.paths-check.outputs.max_turns }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
-            --json-schema '{"type":"object","additionalProperties":false,"properties":{"status_header":{"type":"string","enum":["critical findings","clean","bare"],"description":"Strict-mode opt-in repos: `critical findings` when ANY 🔴 finding exists, otherwise `clean`. Non-strict-mode repos (the default): emit `bare` — the renderer produces a `## 🐛 Clud Bug review` H2 with no suffix, matching the v0.6.21- behaviour. Check .claude/skills/.clud-bug.json for `strictMode: true` to pick critical/clean vs bare."},"summary_counts":{"type":"object","additionalProperties":false,"properties":{"critical":{"type":"integer","minimum":0},"minor":{"type":"integer","minimum":0},"preexisting":{"type":"integer","minimum":0},"resolved_from_prior":{"type":"integer","minimum":0},"still_open":{"type":"integer","minimum":0}},"required":["critical","minor","preexisting","resolved_from_prior","still_open"]},"per_skill_scan":{"type":"array","description":"One entry per LOADED skill — even silent ones. Empty when no skills are installed.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string"},"outcome":{"type":"string","description":"One sentence describing what the skill found. Max ~15 words. Examples: \"scanned all paths. 2 critical findings below.\", \"0 findings.\", \"not applicable to this diff.\""}},"required":["skill","outcome"]}},"critical_findings":{"type":"array","description":"NEW 🔴 findings (bugs, security, perf, missing test coverage). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"minor_findings":{"type":"array","description":"NEW 🟡 findings (nits, style, observations). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"preexisting_findings":{"type":"array","description":"NEW 🟣 findings (issues that pre-date this PR). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"dedicated_sections":{"type":"array","description":"Per-dedicated-mode-skill section blocks. Each item carries the section header text and its findings.","items":{"type":"object","additionalProperties":false,"properties":{"section_name":{"type":"string","description":"Human-readable section title, e.g. \"Brand voice\"."},"skill":{"type":"string","description":"The dedicated skill name."},"findings":{"type":"array","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}}},"required":["section_name","skill","findings"]}},"diagnostics":{"type":"array","description":"0.0.T tee-hint diagnostics. One line per `head -c` cap that fired during fetch. Empty when no truncation occurred.","items":{"type":"string"}},"skills_referenced":{"type":"array","description":"Names of every skill cited in any finding. Empty list (or [\"(none)\"]) when no skill applied.","items":{"type":"string"}},"last_reviewed_sha":{"type":"string","description":"The HEAD SHA at review time, used by the incremental-diff handshake. Set to the literal value of the workflow env var $HEAD_SHA."}},"required":["status_header","summary_counts","per_skill_scan","critical_findings","minor_findings","preexisting_findings","skills_referenced","last_reviewed_sha"]}'
+            --json-schema '{"type":"object","additionalProperties":false,"properties":{"status_header":{"type":"string","enum":["critical findings","clean","bare"],"description":"Strict-mode opt-in repos: `critical findings` when ANY 🔴 finding exists, otherwise `clean`. Non-strict-mode repos (the default): emit `bare` — the renderer produces a `## 🐛 Clud Bug review` H2 with no suffix, matching the v0.6.21- behaviour. Check .claude/skills/.clud-bug.json for `strictMode: true` to pick critical/clean vs bare."},"summary_counts":{"type":"object","additionalProperties":false,"properties":{"critical":{"type":"integer","minimum":0},"minor":{"type":"integer","minimum":0},"preexisting":{"type":"integer","minimum":0},"resolved_from_prior":{"type":"integer","minimum":0},"still_open":{"type":"integer","minimum":0}},"required":["critical","minor","preexisting","resolved_from_prior","still_open"]},"per_skill_scan":{"type":"array","description":"One entry per LOADED skill — even silent ones. Empty when no skills are installed.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string"},"outcome":{"type":"string","description":"One sentence describing what the skill found. Max ~15 words. Examples: \"scanned all paths. 2 critical findings below.\", \"0 findings.\", \"not applicable to this diff.\""}},"required":["skill","outcome"]}},"critical_findings":{"type":"array","description":"NEW 🔴 findings (bugs, security, perf, missing test coverage). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}},"minor_findings":{"type":"array","description":"NEW 🟡 findings (nits, style, observations). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}},"preexisting_findings":{"type":"array","description":"NEW 🟣 findings (issues that pre-date this PR). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}},"dedicated_sections":{"type":"array","description":"Per-dedicated-mode-skill section blocks. Each item carries the section header text and its findings.","items":{"type":"object","additionalProperties":false,"properties":{"section_name":{"type":"string","description":"Human-readable section title, e.g. \"Brand voice\"."},"skill":{"type":"string","description":"The dedicated skill name."},"findings":{"type":"array","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}}},"required":["section_name","skill","findings"]}},"diagnostics":{"type":"array","description":"0.0.T tee-hint diagnostics. One line per `head -c` cap that fired during fetch. Empty when no truncation occurred.","items":{"type":"string"}},"skills_referenced":{"type":"array","description":"Names of every skill cited in any finding. Empty list (or [\"(none)\"]) when no skill applied.","items":{"type":"string"}},"last_reviewed_sha":{"type":"string","description":"The HEAD SHA at review time, used by the incremental-diff handshake. Set to the literal value of the workflow env var $HEAD_SHA."}},"required":["status_header","summary_counts","per_skill_scan","critical_findings","minor_findings","preexisting_findings","skills_referenced","last_reviewed_sha"]}'
           prompt: |
             Review this pull request following the discipline in your
             system prompt — every rule about skill routing, comment
@@ -604,11 +668,106 @@ jobs:
           THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.26 render --stdin)
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 render --stdin)
           CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
           gh pr comment "$PR_NUMBER" --body "$BODY
 
           $CALIBRATION"
+
+      # Phase ZP3 — route this Action's review through the NOTARY.
+      # See workflow.yml.tmpl for full design notes (base-ref trust guard;
+      # continue-on-error coexists with the strict-mode-gate backstop).
+      - name: Notarize review
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -uo pipefail
+
+          # strictMode from the BASE ref's manifest — a PR can't opt itself out
+          # (or disable the notary) by editing its own HEAD .clud-bug.json.
+          STRICT_FLAG=--no-strict
+          if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
+            if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
+              STRICT_FLAG=--strict
+            fi
+          fi
+
+          printf '%s\n' "$STRUCTURED" \
+            | npx --yes clud-bug@0.7.0-rc.24 build-bundle \
+                --repo "$REPO" --pr "$PR_NUMBER" --sha "$HEAD_SHA" \
+                --recipe-version "ci-0.7.0-rc.24" \
+            > bundle.json
+
+          npx --yes clud-bug@0.7.0-rc.24 post-check-run \
+            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG"
+
+      # Wave 5a (D.2.X) — see workflow.yml.tmpl for design notes.
+      - name: Post inline review threads
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 post-inline-threads --stdin)
+          echo "::notice title=inline-threads::$RESULT"
+
+      # Wave 5b (D.2.6) — see workflow.yml.tmpl for design notes.
+      - name: Auto-resolve fixed threads
+        if: success() && github.event.action == 'synchronize'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Optional fine-grained PAT (Pull requests: write). Present → the
+          # workflow resolves fixed threads like the hosted App. Absent (the
+          # default; an unset secret renders empty) → graceful "verified fixed"
+          # reply only, since the Actions GITHUB_TOKEN can't resolve threads.
+          CLUD_BUG_RESOLVE_PAT: ${{ secrets.CLUD_BUG_RESOLVE_PAT }}
+        run: |
+          set -euo pipefail
+          RESULT=$(npx --yes clud-bug@0.7.0-rc.24 resolve-threads)
+          echo "::notice title=auto-resolve::$RESULT"
+
+      # v0.6.29 / Component 4 — see workflow.yml.tmpl for design notes.
+      - name: Update skill-usage tracking
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          mkdir -p .claude/skills
+          if [ ! -f .claude/skills/.clud-bug.json ]; then
+            echo '{"version": 1}' > .claude/skills/.clud-bug.json
+          fi
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 update-skill-usage --stdin
+          echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
+
+      - name: Upload skill-usage artifact
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}
+          path: .claude/skills/.clud-bug.json
+          # v0.6.31 hotfix: upload-artifact@v4 excludes hidden files
+          # by default. See workflow.yml.tmpl for full context.
+          include-hidden-files: true
+          retention-days: 90
 
       # v0.6.26 / §5.5 Layer 6 fallback render-from-inlines — see workflow.yml.tmpl for design notes.
       - name: Fallback summary (structured_output empty)
@@ -666,9 +825,52 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.26
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.24
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].
           # See workflow.yml.tmpl for design notes.
           bot-login: 'github-actions[bot]'
+
+      # v0.7.0-rc.3 — SPEC §7.2.1 formal-review event poster.
+      # See workflow.yml.tmpl for full design rationale; this step
+      # bridges the canonical-ruleset `required_approving_review_count: 1`
+      # floor on the npm workflow path. Best-effort: never fails the
+      # workflow (continue-on-error). Drive-by exploit guard: external
+      # contributors NEVER get APPROVE.
+      - name: Formal review — APPROVE / REQUEST_CHANGES / COMMENT
+        if: always() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -uo pipefail
+          STRICT_MODE=false
+          if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
+            if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
+              STRICT_MODE=true
+            fi
+          fi
+          export STRICT_MODE
+          VERDICT=$(printf '%s\n' "$STRUCTURED" \
+            | npx --yes clud-bug@0.7.0-rc.24 select-review-event --stdin \
+            | tail -n1)
+          VERDICT="${VERDICT:-skip}"
+          echo "::notice title=Clud Bug 🐛::Formal review verdict: $VERDICT (strictMode=$STRICT_MODE, author_assoc=$PR_AUTHOR_ASSOCIATION)"
+          if [ "$VERDICT" = "skip" ]; then
+            exit 0
+          fi
+          BODY=$(printf 'Automated formal review by clud-bug — see the summary comment for the substantive findings.\n\nVerdict: **%s**\n\n<!-- clud-bug-formal-review: workflow-path v0.7.0-rc.3 -->' "$VERDICT")
+          gh api -X POST "/repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            -f event="$VERDICT" \
+            -f commit_id="$HEAD_SHA" \
+            -f body="$BODY" \
+            > /dev/null \
+            || echo "::warning title=Clud Bug 🐛::Formal review POST failed (likely 422 self-PR or missing perms); degrading to comment-only."

--- a/.ci-rendered/workflow.yml
+++ b/.ci-rendered/workflow.yml
@@ -924,13 +924,19 @@ jobs:
         run: |
           set -uo pipefail
 
-          # Resolve strictMode from the BASE ref's manifest — a PR cannot opt
-          # itself out of strict mode (or the notary) by editing its own HEAD
-          # .clud-bug.json. Best-effort: any error falls through to --no-strict.
+          # Resolve strictMode AND notary enablement from the BASE ref's
+          # manifest — a PR cannot opt itself out of strict mode OR disable the
+          # notary by editing its own HEAD .clud-bug.json. Best-effort: an
+          # unreadable base manifest falls through to --no-strict + --notary
+          # (fail SAFE toward independent certification).
           STRICT_FLAG=--no-strict
+          NOTARY_FLAG=--notary
           if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
             if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
               STRICT_FLAG=--strict
+            fi
+            if jq -e '.notary == false' /tmp/base-manifest.json > /dev/null 2>&1; then
+              NOTARY_FLAG=--no-notary
             fi
           fi
 
@@ -941,7 +947,7 @@ jobs:
             > bundle.json
 
           npx --yes clud-bug@0.7.0-rc.24 post-check-run \
-            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG"
+            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG" "$NOTARY_FLAG"
 
       # v0.7.0-rc.7 / Wave 5a (D.2.X): post per-finding inline review
       # threads alongside the summary comment. Each thread is anchored

--- a/.ci-rendered/workflow.yml
+++ b/.ci-rendered/workflow.yml
@@ -1,4 +1,4 @@
-# clud-bug-template-version: v12
+# clud-bug-template-version: v14
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
@@ -383,6 +383,19 @@ jobs:
           echo "::error::Without it, Clud Bug review is a silent no-op."
           exit 1
 
+      # ── Design-critic (optional, opt-in) ─────────────────────────────────
+      # clud-bug can also review the *rendered* UI of your PR's preview deploy.
+      # The hosted clud-bug[bot] does this for you on Team installs (Browserless).
+      # To run it here on the Action reviewer instead — Claude drives a real
+      # browser on this runner, no paid render service — enable it in 3 steps:
+      #   1. clud-bug init --with-design   (installs the design kit + flips the
+      #      `design` block in .claude/skills/.clud-bug.json to enabled: true)
+      #   2. add a browser MCP to claude_args below, e.g.:
+      #        --mcp-config '{"mcpServers":{"playwright":{"command":"npx","args":["-y","@playwright/mcp@latest"]}}}'
+      #   3. append the browser tools to --allowedTools, e.g.:
+      #        ,mcp__playwright__browser_navigate,mcp__playwright__browser_take_screenshot
+      # Off by default. See the §3b design step in `clud-bug review-prompt`.
+      # ──────────────────────────────────────────────────────────────────────
       - uses: anthropics/claude-code-action@v1.0.133
         # Skip the action when guard already posted the bot/fork advisory.
         if: steps.guard.outputs.skip != 'true'
@@ -396,12 +409,21 @@ jobs:
           # <prior_sha>..HEAD` (delta) when the SHA is still in HEAD's
           # ancestry. Fix-push reviews ingest only the new bytes.
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          # Per-section byte budgets (v0.6.4). The system-prompt instructs
-          # Claude to cap each per-PR input fetch with `head -c`. Caching
-          # covers the stable system prefix; capping covers the variable
-          # suffix (diff, comments, skills). Override per-repo by setting
-          # these env vars in the consuming workflow if defaults don't fit.
-          MAX_DIFF_BYTES: '80000'
+          # Per-section byte budgets (v0.6.4, MAX_DIFF_BYTES bumped 2026-06-08).
+          # The system-prompt instructs Claude to cap each per-PR input fetch
+          # with `head -c`. Caching covers the stable system prefix; capping
+          # covers the variable suffix (diff, comments, skills). Override
+          # per-repo by setting these env vars in the consuming workflow if
+          # defaults don't fit.
+          #
+          # 2026-06-08 CEO directive (v0.6.35): MAX_DIFF_BYTES bumped from
+          # 80000 (80KB) → 5000000 (5MB). The old default silently truncated
+          # any PR diff > 80KB, leading to half-reviews on real-world PRs.
+          # CEO: "a large diff should NEVER be a blocker or guard." 5MB is
+          # far above realistic single-PR diff sizes but bounded enough that
+          # the runner doesn't OOM. Repos that want stricter discipline can
+          # still set lower values per-repo.
+          MAX_DIFF_BYTES: '5000000'
           MAX_COMMENT_BYTES: '20000'
           MAX_SKILL_BYTES: '4000'
           # MAX_THINKING_TOKENS caps Claude Code's extended-thinking budget per
@@ -576,6 +598,36 @@ jobs:
                 every file's verdict so a maintainer can verify nothing was
                 skipped.
 
+            Mid-review self-check-in (v0.6.27 / §5.5 Layer 3):
+            After every 5 tool_uses, write a single-line budget heartbeat as a
+            free-text "thinking" message (not a tool call — these don't cost a
+            turn) of the form:
+
+              [budget] files_reviewed=X/N, turns_used=Y/M, pace=ok|behind
+
+            Where:
+              - X / N is the count of files you've meaningfully looked at so far
+                over the total in this PR's diff.
+              - Y / M is your current turn count over max_turns.
+              - pace = "ok" when X / N >= Y / (M - 5). The denominator subtracts the
+                5-turn emit reservation: over the (M - 5) turns available for file
+                review, your file-coverage rate must match where you actually are
+                in the budget. (Don't subtract from Y — that would be saying "I've
+                used Y minus 5 turns" which double-counts the reservation.)
+                pace = "behind" otherwise.
+
+            When pace = "behind", immediately pivot strategy:
+              1. Stop deep-dive analysis on the current file.
+              2. Switch to one-sentence verdicts for every remaining file.
+              3. Keep going through the whole diff — silent skipping is
+                 non-negotiable. Cover everything, even if some files only get
+                 "no issues found in this file" as their verdict.
+
+            The heartbeat serves two purposes: (a) forces internal pacing — you
+            can't drift past budget without noticing; (b) lands in the action's
+            streaming output for post-hoc calibration of the per-line cost
+            coefficients used by paths-check's Layer 1 estimator.
+
             Incremental-diff handshake (v0.6.10+) — emit the SHA marker:
             At the very end of the summary (after the Skills-referenced footer,
             on its own line), append:
@@ -600,6 +652,27 @@ jobs:
             If strictMode is unset or absent, set `status_header: "bare"` —
             the renderer emits the bare `## 🐛 Clud Bug review` (no suffix),
             matching the v0.6.21- visible behaviour for non-strict-mode repos.
+
+            Grounding (REQUIRED on every 🔴 critical — notary attestation §10.3.3):
+            This review's structured output is assembled into a NOTARY ATTESTATION
+            BUNDLE for independent certification. The notary REJECTS an ungrounded
+            critical, refusing the WHOLE bundle (no green check). So populate the
+            `grounding` + `grounding_kind` schema fields on EVERY critical, one of:
+              - `quote` — the offending line copied VERBATIM from the diff (with a
+                matching `line`). The notary re-verifies this span is a byte-exact
+                substring of a changed line; PREFER it (the only form checked
+                deterministically) whenever a single changed line carries the bug.
+              - `reproduction` — a command you ran + its observed output (only under
+                the execution-safety rule; never run an untrusted contributor/fork
+                diff). Stronger evidence than a quote, not weaker.
+              - `invariant` — a one-sentence named property the change breaks + the
+                input that breaks it. For a bug on no single changed line (emergent,
+                combinatorial, or cross-cutting), reproduce it or name the invariant
+                instead of staying silent.
+            Default `grounding_kind` to `quote`; `reproduction`/`invariant` are
+            audit-verified. A repro you ran, or a named invariant, SATISFIES any
+            skill that says "quote the exact line or drop". Drop only what NONE of
+            the three grounds. `grounding` is optional on 🟡 minor / 🟣 pre-existing.
 
             Tone: conversational, concise field-naturalist voice (you are Clud
             Bug examining specimens of code) — never at the cost of clarity,
@@ -759,12 +832,12 @@ jobs:
           # structured output (action exposes outputs.structured_output).
           # The model emits findings as schema fields; a post-step
           # renders to markdown and posts. The schema is rendered into
-          # this template at `clud-bug init` time via {"type":"object","additionalProperties":false,"properties":{"status_header":{"type":"string","enum":["critical findings","clean","bare"],"description":"Strict-mode opt-in repos: `critical findings` when ANY 🔴 finding exists, otherwise `clean`. Non-strict-mode repos (the default): emit `bare` — the renderer produces a `## 🐛 Clud Bug review` H2 with no suffix, matching the v0.6.21- behaviour. Check .claude/skills/.clud-bug.json for `strictMode: true` to pick critical/clean vs bare."},"summary_counts":{"type":"object","additionalProperties":false,"properties":{"critical":{"type":"integer","minimum":0},"minor":{"type":"integer","minimum":0},"preexisting":{"type":"integer","minimum":0},"resolved_from_prior":{"type":"integer","minimum":0},"still_open":{"type":"integer","minimum":0}},"required":["critical","minor","preexisting","resolved_from_prior","still_open"]},"per_skill_scan":{"type":"array","description":"One entry per LOADED skill — even silent ones. Empty when no skills are installed.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string"},"outcome":{"type":"string","description":"One sentence describing what the skill found. Max ~15 words. Examples: \"scanned all paths. 2 critical findings below.\", \"0 findings.\", \"not applicable to this diff.\""}},"required":["skill","outcome"]}},"critical_findings":{"type":"array","description":"NEW 🔴 findings (bugs, security, perf, missing test coverage). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"minor_findings":{"type":"array","description":"NEW 🟡 findings (nits, style, observations). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"preexisting_findings":{"type":"array","description":"NEW 🟣 findings (issues that pre-date this PR). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"dedicated_sections":{"type":"array","description":"Per-dedicated-mode-skill section blocks. Each item carries the section header text and its findings.","items":{"type":"object","additionalProperties":false,"properties":{"section_name":{"type":"string","description":"Human-readable section title, e.g. \"Brand voice\"."},"skill":{"type":"string","description":"The dedicated skill name."},"findings":{"type":"array","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}}},"required":["section_name","skill","findings"]}},"diagnostics":{"type":"array","description":"0.0.T tee-hint diagnostics. One line per `head -c` cap that fired during fetch. Empty when no truncation occurred.","items":{"type":"string"}},"skills_referenced":{"type":"array","description":"Names of every skill cited in any finding. Empty list (or [\"(none)\"]) when no skill applied.","items":{"type":"string"}},"last_reviewed_sha":{"type":"string","description":"The HEAD SHA at review time, used by the incremental-diff handshake. Set to the literal value of the workflow env var $HEAD_SHA."}},"required":["status_header","summary_counts","per_skill_scan","critical_findings","minor_findings","preexisting_findings","skills_referenced","last_reviewed_sha"]}.
+          # this template at `clud-bug init` time via {"type":"object","additionalProperties":false,"properties":{"status_header":{"type":"string","enum":["critical findings","clean","bare"],"description":"Strict-mode opt-in repos: `critical findings` when ANY 🔴 finding exists, otherwise `clean`. Non-strict-mode repos (the default): emit `bare` — the renderer produces a `## 🐛 Clud Bug review` H2 with no suffix, matching the v0.6.21- behaviour. Check .claude/skills/.clud-bug.json for `strictMode: true` to pick critical/clean vs bare."},"summary_counts":{"type":"object","additionalProperties":false,"properties":{"critical":{"type":"integer","minimum":0},"minor":{"type":"integer","minimum":0},"preexisting":{"type":"integer","minimum":0},"resolved_from_prior":{"type":"integer","minimum":0},"still_open":{"type":"integer","minimum":0}},"required":["critical","minor","preexisting","resolved_from_prior","still_open"]},"per_skill_scan":{"type":"array","description":"One entry per LOADED skill — even silent ones. Empty when no skills are installed.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string"},"outcome":{"type":"string","description":"One sentence describing what the skill found. Max ~15 words. Examples: \"scanned all paths. 2 critical findings below.\", \"0 findings.\", \"not applicable to this diff.\""}},"required":["skill","outcome"]}},"critical_findings":{"type":"array","description":"NEW 🔴 findings (bugs, security, perf, missing test coverage). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}},"minor_findings":{"type":"array","description":"NEW 🟡 findings (nits, style, observations). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}},"preexisting_findings":{"type":"array","description":"NEW 🟣 findings (issues that pre-date this PR). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}},"dedicated_sections":{"type":"array","description":"Per-dedicated-mode-skill section blocks. Each item carries the section header text and its findings.","items":{"type":"object","additionalProperties":false,"properties":{"section_name":{"type":"string","description":"Human-readable section title, e.g. \"Brand voice\"."},"skill":{"type":"string","description":"The dedicated skill name."},"findings":{"type":"array","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}}},"required":["section_name","skill","findings"]}},"diagnostics":{"type":"array","description":"0.0.T tee-hint diagnostics. One line per `head -c` cap that fired during fetch. Empty when no truncation occurred.","items":{"type":"string"}},"skills_referenced":{"type":"array","description":"Names of every skill cited in any finding. Empty list (or [\"(none)\"]) when no skill applied.","items":{"type":"string"}},"last_reviewed_sha":{"type":"string","description":"The HEAD SHA at review time, used by the incremental-diff handshake. Set to the literal value of the workflow env var $HEAD_SHA."}},"required":["status_header","summary_counts","per_skill_scan","critical_findings","minor_findings","preexisting_findings","skills_referenced","last_reviewed_sha"]}.
           claude_args: |
             --model ${{ needs.paths-check.outputs.model }}
             --max-turns ${{ needs.paths-check.outputs.max_turns }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
-            --json-schema '{"type":"object","additionalProperties":false,"properties":{"status_header":{"type":"string","enum":["critical findings","clean","bare"],"description":"Strict-mode opt-in repos: `critical findings` when ANY 🔴 finding exists, otherwise `clean`. Non-strict-mode repos (the default): emit `bare` — the renderer produces a `## 🐛 Clud Bug review` H2 with no suffix, matching the v0.6.21- behaviour. Check .claude/skills/.clud-bug.json for `strictMode: true` to pick critical/clean vs bare."},"summary_counts":{"type":"object","additionalProperties":false,"properties":{"critical":{"type":"integer","minimum":0},"minor":{"type":"integer","minimum":0},"preexisting":{"type":"integer","minimum":0},"resolved_from_prior":{"type":"integer","minimum":0},"still_open":{"type":"integer","minimum":0}},"required":["critical","minor","preexisting","resolved_from_prior","still_open"]},"per_skill_scan":{"type":"array","description":"One entry per LOADED skill — even silent ones. Empty when no skills are installed.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string"},"outcome":{"type":"string","description":"One sentence describing what the skill found. Max ~15 words. Examples: \"scanned all paths. 2 critical findings below.\", \"0 findings.\", \"not applicable to this diff.\""}},"required":["skill","outcome"]}},"critical_findings":{"type":"array","description":"NEW 🔴 findings (bugs, security, perf, missing test coverage). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"minor_findings":{"type":"array","description":"NEW 🟡 findings (nits, style, observations). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"preexisting_findings":{"type":"array","description":"NEW 🟣 findings (issues that pre-date this PR). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"dedicated_sections":{"type":"array","description":"Per-dedicated-mode-skill section blocks. Each item carries the section header text and its findings.","items":{"type":"object","additionalProperties":false,"properties":{"section_name":{"type":"string","description":"Human-readable section title, e.g. \"Brand voice\"."},"skill":{"type":"string","description":"The dedicated skill name."},"findings":{"type":"array","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}}},"required":["section_name","skill","findings"]}},"diagnostics":{"type":"array","description":"0.0.T tee-hint diagnostics. One line per `head -c` cap that fired during fetch. Empty when no truncation occurred.","items":{"type":"string"}},"skills_referenced":{"type":"array","description":"Names of every skill cited in any finding. Empty list (or [\"(none)\"]) when no skill applied.","items":{"type":"string"}},"last_reviewed_sha":{"type":"string","description":"The HEAD SHA at review time, used by the incremental-diff handshake. Set to the literal value of the workflow env var $HEAD_SHA."}},"required":["status_header","summary_counts","per_skill_scan","critical_findings","minor_findings","preexisting_findings","skills_referenced","last_reviewed_sha"]}'
+            --json-schema '{"type":"object","additionalProperties":false,"properties":{"status_header":{"type":"string","enum":["critical findings","clean","bare"],"description":"Strict-mode opt-in repos: `critical findings` when ANY 🔴 finding exists, otherwise `clean`. Non-strict-mode repos (the default): emit `bare` — the renderer produces a `## 🐛 Clud Bug review` H2 with no suffix, matching the v0.6.21- behaviour. Check .claude/skills/.clud-bug.json for `strictMode: true` to pick critical/clean vs bare."},"summary_counts":{"type":"object","additionalProperties":false,"properties":{"critical":{"type":"integer","minimum":0},"minor":{"type":"integer","minimum":0},"preexisting":{"type":"integer","minimum":0},"resolved_from_prior":{"type":"integer","minimum":0},"still_open":{"type":"integer","minimum":0}},"required":["critical","minor","preexisting","resolved_from_prior","still_open"]},"per_skill_scan":{"type":"array","description":"One entry per LOADED skill — even silent ones. Empty when no skills are installed.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string"},"outcome":{"type":"string","description":"One sentence describing what the skill found. Max ~15 words. Examples: \"scanned all paths. 2 critical findings below.\", \"0 findings.\", \"not applicable to this diff.\""}},"required":["skill","outcome"]}},"critical_findings":{"type":"array","description":"NEW 🔴 findings (bugs, security, perf, missing test coverage). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}},"minor_findings":{"type":"array","description":"NEW 🟡 findings (nits, style, observations). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}},"preexisting_findings":{"type":"array","description":"NEW 🟣 findings (issues that pre-date this PR). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}},"dedicated_sections":{"type":"array","description":"Per-dedicated-mode-skill section blocks. Each item carries the section header text and its findings.","items":{"type":"object","additionalProperties":false,"properties":{"section_name":{"type":"string","description":"Human-readable section title, e.g. \"Brand voice\"."},"skill":{"type":"string","description":"The dedicated skill name."},"findings":{"type":"array","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."},"grounding":{"type":"string","description":"Verbatim evidence anchoring the finding. STRONGLY EXPECTED on a 🔴 critical (the notary attestation rejects an ungrounded critical): the exact changed line quoted from the diff, OR a reproduction command + observed output, OR the one-sentence violated invariant. Optional on 🟡/🟣."},"grounding_kind":{"type":"string","enum":["quote","reproduction","invariant"],"description":"Which form `grounding` takes. `quote` is verified deterministically by the notary (the span must appear in the diff); `reproduction`/`invariant` are audit-verified. Defaults to `quote` when omitted."}},"required":["skill","summary"]}}},"required":["section_name","skill","findings"]}},"diagnostics":{"type":"array","description":"0.0.T tee-hint diagnostics. One line per `head -c` cap that fired during fetch. Empty when no truncation occurred.","items":{"type":"string"}},"skills_referenced":{"type":"array","description":"Names of every skill cited in any finding. Empty list (or [\"(none)\"]) when no skill applied.","items":{"type":"string"}},"last_reviewed_sha":{"type":"string","description":"The HEAD SHA at review time, used by the incremental-diff handshake. Set to the literal value of the workflow env var $HEAD_SHA."}},"required":["status_header","summary_counts","per_skill_scan","critical_findings","minor_findings","preexisting_findings","skills_referenced","last_reviewed_sha"]}'
           prompt: |
             Review this pull request following the discipline in your
             system prompt — every rule about skill routing, comment
@@ -811,11 +884,170 @@ jobs:
           THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.26 render --stdin)
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 render --stdin)
           CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
           gh pr comment "$PR_NUMBER" --body "$BODY
 
           $CALIBRATION"
+
+      # Phase ZP3 — route this self-hosted Action's review through the NOTARY.
+      #
+      # Transform the SAME structured_output the render step consumed into a
+      # notary attestation bundle (`build-bundle`: flattens the finding buckets,
+      # derives the verdict from the critical count, derives coverage from a
+      # fresh `gh pr diff --name-only`), then submit it via `post-check-run
+      # --bundle`. With CLUD_BUG_NOTARY_URL resolved (default-on since ZP2), the
+      # CLI POSTs the bundle to the notary, which re-validates it against
+      # GitHub's ground-truth diff and — as the SOLE issuer — posts the pinned
+      # `clud-bug-review` check. If the endpoint is unreachable, post-check-run
+      # falls back to a self-attested check tagged `--source ci`.
+      #
+      # SECURITY — base-ref trust guard: strictMode is resolved from the BASE
+      # ref's `.clud-bug.json` (same discipline as the strict-mode-gate + Formal
+      # review steps), NOT the PR's HEAD, so a PR cannot set `strictMode: false`
+      # (or `notary: false`) in its own head to defang the merge gate.
+      #
+      # `continue-on-error: true` — notarization must NEVER be the source of job
+      # failure. The Strict-mode gate step below remains the AUTHORITATIVE merge
+      # backstop; this step deliberately does NOT double-gate it (a notary
+      # outage or fallback can't turn a clean review red on its own).
+      - name: Notarize review
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -uo pipefail
+
+          # Resolve strictMode from the BASE ref's manifest — a PR cannot opt
+          # itself out of strict mode (or the notary) by editing its own HEAD
+          # .clud-bug.json. Best-effort: any error falls through to --no-strict.
+          STRICT_FLAG=--no-strict
+          if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
+            if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
+              STRICT_FLAG=--strict
+            fi
+          fi
+
+          printf '%s\n' "$STRUCTURED" \
+            | npx --yes clud-bug@0.7.0-rc.24 build-bundle \
+                --repo "$REPO" --pr "$PR_NUMBER" --sha "$HEAD_SHA" \
+                --recipe-version "ci-0.7.0-rc.24" \
+            > bundle.json
+
+          npx --yes clud-bug@0.7.0-rc.24 post-check-run \
+            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG"
+
+      # v0.7.0-rc.7 / Wave 5a (D.2.X): post per-finding inline review
+      # threads alongside the summary comment. Each thread is anchored
+      # to a file + line in the diff and is a first-class GitHub review
+      # thread users can reply to. Each thread body carries a hidden
+      # `<!-- finding-id: <hash> -->` marker so Wave 5b (rc.8) auto-
+      # resolve can re-match findings on subsequent fix-pushes without
+      # any persistent state.
+      #
+      # Posted IN ADDITION TO the summary comment above — they serve
+      # different UX needs: the summary is the at-a-glance digest; the
+      # inline threads are where conversation + resolution happens.
+      #
+      # `continue-on-error` so a partial GraphQL/REST failure doesn't
+      # fail the whole review; the verb itself swallows errors into its
+      # stdout JSON and exits 0.
+      - name: Post inline review threads
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 post-inline-threads --stdin)
+          echo "::notice title=inline-threads::$RESULT"
+
+      # v0.7.0-rc.8 / Wave 5b (D.2.6): on fix-push events
+      # (pull_request.synchronize), ask the Anthropic Messages API per
+      # bot-authored unresolved inline thread whether the new commit
+      # addressed the original finding. ADDRESSED → resolve the thread
+      # + post a marker reply; UNCERTAIN / NOT_ADDRESSED → leave open.
+      # Fail-closed: verifier errors route to UNCERTAIN (never silently
+      # dismiss).
+      #
+      # Gated on `synchronize` because:
+      # - `opened` events have no prior threads to resolve.
+      # - Re-running on every event would waste verifier $ on unchanged
+      #   state.
+      #
+      # The verb re-derives prior-finding context from the
+      # `<!-- finding-id: ... -->` markers Wave 5a embeds in each
+      # comment body, so no persistent state is needed across pushes.
+      - name: Auto-resolve fixed threads
+        if: success() && github.event.action == 'synchronize'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Optional fine-grained PAT (Pull requests: write). Present → the
+          # workflow resolves fixed threads like the hosted App. Absent (the
+          # default; an unset secret renders empty) → graceful "verified fixed"
+          # reply only, since the Actions GITHUB_TOKEN can't resolve threads.
+          CLUD_BUG_RESOLVE_PAT: ${{ secrets.CLUD_BUG_RESOLVE_PAT }}
+        run: |
+          set -euo pipefail
+          RESULT=$(npx --yes clud-bug@0.7.0-rc.24 resolve-threads)
+          echo "::notice title=auto-resolve::$RESULT"
+
+      # v0.6.29 / Component 4: pipe structured_output through
+      # `clud-bug update-skill-usage` to compute the per-skill loads +
+      # citations delta from this one review. Writes to the ephemeral
+      # workspace .clud-bug.json AND uploads as a workflow artifact
+      # (90-day retention). v0.6.30 will add aggregation logic so
+      # `clud-bug usage --health` reads + merges artifacts across runs.
+      #
+      # Why artifact instead of committing back to main: committing
+      # would require `contents: write` permission (private-repo
+      # trigger-firing regression risk per v0.6.23 hotfix) + race
+      # handling. Artifacts are GitHub-native persistence with zero
+      # permission expansion + zero commit noise.
+      - name: Update skill-usage tracking
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true  # don't fail the whole review if usage update flakes
+        env:
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          mkdir -p .claude/skills
+          # If a .clud-bug.json already exists in the workspace (PR's
+          # snapshot), keep it. Otherwise initialize an empty shell so
+          # update-skill-usage has something to merge into.
+          if [ ! -f .claude/skills/.clud-bug.json ]; then
+            echo '{"version": 1}' > .claude/skills/.clud-bug.json
+          fi
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 update-skill-usage --stdin
+          echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
+
+      - name: Upload skill-usage artifact
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}
+          path: .claude/skills/.clud-bug.json
+          # v0.6.31 hotfix: actions/upload-artifact@v4 excludes hidden
+          # files by default. .clud-bug.json + .claude/ are both
+          # dot-prefixed, so v0.6.29-v0.6.30 silently uploaded zero
+          # artifacts org-wide. Must opt in explicitly.
+          include-hidden-files: true
+          retention-days: 90
 
       # Fallback comment when the model couldn't produce schema-valid
       # output after max retries (structured_output is empty). Keeps a
@@ -912,7 +1144,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.26
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.24
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow
@@ -922,3 +1154,98 @@ jobs:
           # never matches the new summary author → strict mode falls
           # open advisory for every install that opted in.
           bot-login: 'github-actions[bot]'
+
+      # v0.7.0-rc.3 — SPEC §7.2.1 formal-review event poster.
+      #
+      # Why this step exists: the canonical ruleset (SPEC §7.2) pins
+      # `required_approving_review_count: 1`. Before this step, the
+      # workflow path posted only a summary issue comment + a
+      # `clud-bug-review` check-run — neither of which counts as an
+      # approving review. So every PR on the workflow path required a
+      # human to click Approve, even when the bot's verdict was clean.
+      #
+      # This step bridges that gap: it pipes the same structured_output
+      # the render step consumed through `clud-bug select-review-event`
+      # (SPEC §7.2.1 rule table) and, on org-trusted authors, posts a
+      # formal `pulls.createReview` with `event=APPROVE` so the
+      # `required_approving_review_count: 1` floor flips automatically.
+      #
+      # Drive-by exploit guard: external contributors NEVER get APPROVE.
+      # The select-review-event verdict for any author in
+      # {NONE, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, MANNEQUIN} is forced
+      # to COMMENT — a human reviewer must explicitly Approve. See
+      # SPEC §7.2.1 precondition #3.
+      #
+      # Best-effort contract: this step MUST NEVER fail the workflow.
+      # `continue-on-error: true` ensures a malformed payload, network
+      # blip, or rate-limit on the formal-review API can't undo the
+      # already-posted summary comment. Worst case: no formal review is
+      # posted, falling back to today's comment-only behavior (= the
+      # pre-rc.3 status quo).
+      #
+      # Self-PR guard: when the PR author is `clud-bug[bot]` (D.7
+      # migration fan-out path that clud-bug-app authors), the verdict
+      # is "skip" — GitHub returns 422 on self-review, so we short-
+      # circuit before the network call.
+      - name: Formal review — APPROVE / REQUEST_CHANGES / COMMENT
+        if: always() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+          # SPEC §7.2.1 fields. The select-review-event command reads
+          # these from env (NOT stdin) so the workflow doesn't have to
+          # construct a nested JSON shape.
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -uo pipefail
+
+          # Resolve strictMode from the BASE ref's manifest — same
+          # discipline as strict-mode-gate (a PR can't opt itself out
+          # of strict mode by editing its own .clud-bug.json). Best-
+          # effort: any error here falls through to STRICT_MODE=false.
+          STRICT_MODE=false
+          if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
+            if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
+              STRICT_MODE=true
+            fi
+          fi
+          export STRICT_MODE
+
+          # Compute the verdict (one of: APPROVE / REQUEST_CHANGES /
+          # COMMENT / skip). The command degrades to "skip" on any
+          # caller-side error (malformed JSON, missing env), so we never
+          # need a fallback in shell.
+          VERDICT=$(printf '%s\n' "$STRUCTURED" \
+            | npx --yes clud-bug@0.7.0-rc.24 select-review-event --stdin \
+            | tail -n1)
+          VERDICT="${VERDICT:-skip}"
+
+          echo "::notice title=Clud Bug 🐛::Formal review verdict: $VERDICT (strictMode=$STRICT_MODE, author_assoc=$PR_AUTHOR_ASSOCIATION)"
+
+          if [ "$VERDICT" = "skip" ]; then
+            # Self-PR or caller-error case. No formal review posted;
+            # the summary comment + check-run remain the visible review
+            # surface. This is the pre-rc.3 status quo.
+            exit 0
+          fi
+
+          # Body is short + machine-pingable: human reviewers see the
+          # summary issue comment for the substantive review surface;
+          # the formal-review body is a cross-link.
+          BODY=$(printf 'Automated formal review by clud-bug — see the summary comment for the substantive findings.\n\nVerdict: **%s**\n\n<!-- clud-bug-formal-review: workflow-path v0.7.0-rc.3 -->' "$VERDICT")
+
+          # gh api fires `pulls.createReview` with the verdict event.
+          # commit_id pins the review to the exact SHA we reviewed so a
+          # later push doesn't auto-extend the approval scope.
+          gh api -X POST "/repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            -f event="$VERDICT" \
+            -f commit_id="$HEAD_SHA" \
+            -f body="$BODY" \
+            > /dev/null \
+            || echo "::warning title=Clud Bug 🐛::Formal review POST failed (likely 422 self-PR or missing perms); degrading to comment-only."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+### Added
+
+- **ZP3 — self-hosted Action → notary.** The self-hosted GitHub Action now routes its
+  review through the notary, at parity with local max mode.
+  - **`clud-bug build-bundle`** (`src/cli/build-bundle.ts`) — transforms a review's
+    `structured_output` (`ReviewData`, piped via `--stdin`) into a notary attestation
+    bundle. Flattens `critical`/`minor`/`preexisting` finding buckets 1:1, DERIVES the
+    verdict from the critical count (never the model's self-reported `summary_counts` —
+    matches `validateConsistency`), and derives `coverage` from a fresh
+    `gh pr diff <pr> --name-only` (GitHub ground-truth, not the incremental scan set).
+    Flags: `--repo --pr --sha --recipe-version`. Emits bundle JSON to stdout.
+  - **Workflow "Notarize review" step** (all 3 templates) — after render+post, pipes
+    `structured_output → build-bundle → post-check-run --bundle --source ci`. Gated on a
+    non-empty payload with `continue-on-error: true` so it can NEVER be the source of job
+    failure — the strict-mode gate stays the authoritative merge backstop (no double-gate).
+    `strictMode` is resolved from the **base ref** (`git show origin/<base>:…/.clud-bug.json`)
+    so a PR cannot set `notary:false` / `strictMode:false` in its own head to defang the check.
+  - **Grounding on CI criticals** — `reviewPrompt()` now instructs the CI review to populate
+    `grounding` + `grounding_kind` on every 🔴 critical. Load-bearing: `validateGrounding`
+    rejects an ungrounded critical, which would notary-reject the whole bundle. Prompt
+    byte/line caps bumped (17500→18700 bytes, 365→385 lines) for the ~1.5 KB block.
+  - **`clud-bug init` installs both surfaces by default** — `--with-hooks` is now ON by
+    default (added `--no-hooks` to opt out), so `init` scaffolds BOTH the max-mode commit
+    hook AND the GitHub Action enforcer. `--local-only` keeps its meaning (max mode, no Action).
+  - **`post-check-run`** now honors an explicit `--source ci` on the bundle-fallback path
+    (was hard-coded `local`), so a CI-originated self-attested fallback tags itself correctly.
+
 ## [0.7.0-rc.15] — 2026-06-29
 
 Design-critic lens (B1) — the skill-driven review thesis pointed at pixels. OPTIONAL and

--- a/docs/decisions-branches/feat-zp3-action-notary.md
+++ b/docs/decisions-branches/feat-zp3-action-notary.md
@@ -11,3 +11,16 @@
 
 ---
 
+## 2026-07-17 09:22 - ZP3 fix (critical): base-ref-guard the notary toggle — a PR could self-disable independent certification from its own HEAD
+
+**Reasoning:** Adversarial review (opus, triangulated with an orchestrator spot-check) confirmed: the CI Notarize step base-ref-guarded strictMode but NOT the notary toggle — post-check-run resolved 'notary' from readManifest(cwd) (the PR HEAD working tree), so a PR setting notary:false in its own .clud-bug.json skipped /notarize entirely and self-attested a non-blocking neutral check, defeating the notary layer ZP3 adds. Fix mirrors --strict/--no-strict exactly: an explicit --notary/--no-notary flag OVERRIDES the manifest (readNotaryConfig(manifest, override)); the workflow derives NOTARY_FLAG from the BASE ref alongside STRICT_FLAG. Also guards build-bundle against a null/non-object finding entry (adversarial review reproduced a crash), and the workflow comment's '(or disable the notary)' claim is now actually TRUE.
+
+**Alternatives considered:** Change readNotaryConfig precedence so env overrides the manifest opt-out (rejected: breaks the intended LOCAL hard-opt-out semantics; the explicit flag is cleaner and mirrors --strict)
+
+**Implications:**
+- Local (non-CI) behavior UNCHANGED — the manifest notary opt-out is only overridden by the explicit flag CI passes from the base ref
+- +4 tests (override precedence x3 + build-bundle null-guard); 1009 pass, fixtures 5/5, actionlint clean
+- Pulls the notary half of ZP4 (base-ref parity) into ZP3 where it belongs
+
+---
+

--- a/docs/decisions-branches/feat-zp3-action-notary.md
+++ b/docs/decisions-branches/feat-zp3-action-notary.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-17 08:52 - ZP3: route the self-hosted GitHub Action through the notary (build-bundle + base-ref-guarded CI notarize step + init installs both surfaces)
+
+**Reasoning:** Local max mode already notarizes (ZP2); the self-hosted Action posted only a self-attested check, so the un-forgeable notary gate never covered the Action path. build-bundle transforms the review's structured_output into a NotaryBundle (verdict derived from critical count to satisfy validateConsistency; coverage from GitHub's ground-truth gh pr diff --name-only) and post-check-run --bundle --source ci submits it. Grounding is now mandated on CI criticals because validateGrounding rejects a bare critical and would notary-reject the whole bundle. init installs both surfaces (hook + Action) by default so a fresh repo gets max-mode review AND the CI enforcer.
+
+**Alternatives considered:** Leave the Action self-attested (rejected: leaves the Action path outside the notary trust boundary ZP2 established for local mode). Derive strictMode from the PR head (rejected: a PR could set strictMode:false/notary:false in its own head to defang the gate — must read from the base ref like strict-mode-gate). Make the notarize step gate the job (rejected: strict-mode-gate is the authoritative backstop; continue-on-error avoids double-gating so a notary outage can't turn a clean review red).
+
+**Implications:**
+- Prompt byte/line caps bumped (17500->18700, 365->385) for the ~1.5KB grounding block. init default flip is a behavior change (added --no-hooks opt-out; updated tests). CODEOWNERS + the ::warning:: annotation on notary rejection are deferred to a follow-up.
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -66,6 +66,7 @@ clud-bug
 │   ├── agents-md.test.js
 │   ├── audit.test.js
 │   ├── branch-protection.test.js
+│   ├── build-bundle.test.js
 │   ├── check-verdict.test.js
 │   ├── cli.test.js
 │   ├── configure-github.test.js

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (26 decisions)
+## 2026-07 (27 decisions)
 
-- **2026-07-17** — ZP2 fix: a degenerate all-slash CLUD_BUG_NOTARY_URL no longer silently disables the notary *(feat-notary-default-on)* — [decisions-branches/feat-notary-default-on.md](decisions-branches/feat-notary-default-on.md)
-- *... 24 more decisions ...*
+- **2026-07-17** — ZP3: route the self-hosted GitHub Action through the notary (build-bundle + base-ref-guarded CI notarize step + init installs both surfaces) *(feat-zp3-action-notary)* — [decisions-branches/feat-zp3-action-notary.md](decisions-branches/feat-zp3-action-notary.md)
+- *... 25 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (27 decisions)
+## 2026-07 (28 decisions)
 
-- **2026-07-17** — ZP3: route the self-hosted GitHub Action through the notary (build-bundle + base-ref-guarded CI notarize step + init installs both surfaces) *(feat-zp3-action-notary)* — [decisions-branches/feat-zp3-action-notary.md](decisions-branches/feat-zp3-action-notary.md)
-- *... 25 more decisions ...*
+- **2026-07-17** — ZP3 fix (critical): base-ref-guard the notary toggle — a PR could self-disable independent certification from its own HEAD *(feat-zp3-action-notary)* — [decisions-branches/feat-zp3-action-notary.md](decisions-branches/feat-zp3-action-notary.md)
+- *... 26 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/src/cli/build-bundle.ts
+++ b/src/cli/build-bundle.ts
@@ -44,7 +44,10 @@ interface BuildBundleArgs {
 
 /** Map one review finding (schema shape) to a bundle finding (wire shape). */
 function toNotaryFinding(f: ReviewFinding, severity: NotarySeverity): NotaryFinding {
-  const finding: NotaryFinding = { severity, summary: f.summary };
+  const finding: NotaryFinding = {
+    severity,
+    summary: typeof f.summary === 'string' ? f.summary : '',
+  };
   if (typeof f.file === 'string' && f.file) finding.file = f.file;
   if (typeof f.line === 'number' && Number.isInteger(f.line) && f.line >= 1) finding.line = f.line;
   if (typeof f.grounding === 'string' && f.grounding) finding.grounding = f.grounding;
@@ -62,9 +65,13 @@ export function reviewDataToBundle(
   data: Partial<ReviewData>,
   meta: { repo: string; pr?: number; headSha: string; recipeVersion: string; coverage: string[] },
 ): NotaryBundle {
-  const critical = Array.isArray(data.critical_findings) ? data.critical_findings : [];
-  const minor = Array.isArray(data.minor_findings) ? data.minor_findings : [];
-  const preexisting = Array.isArray(data.preexisting_findings) ? data.preexisting_findings : [];
+  // Guard against a malformed bucket: a null/non-object entry (a lying or
+  // truncated structured_output) must be SKIPPED, not crash the transform.
+  const isFinding = (f: unknown): f is ReviewFinding => !!f && typeof f === 'object';
+  const bucket = (v: unknown): ReviewFinding[] => (Array.isArray(v) ? v.filter(isFinding) : []);
+  const critical = bucket(data.critical_findings);
+  const minor = bucket(data.minor_findings);
+  const preexisting = bucket(data.preexisting_findings);
 
   const findings: NotaryFinding[] = [
     ...critical.map((f) => toNotaryFinding(f, 'critical')),

--- a/src/cli/build-bundle.ts
+++ b/src/cli/build-bundle.ts
@@ -1,0 +1,140 @@
+// `clud-bug build-bundle` (Phase ZP3) — transform a completed review's
+// structured-output `ReviewData` JSON into a NOTARY ATTESTATION BUNDLE
+// (`NotaryBundle`), ready to hand to `post-check-run --bundle`.
+//
+// This is the missing seam that routes the self-hosted GitHub Action through
+// the notary: the Action already emits `outputs.structured_output` (the review
+// `ReviewData`); this verb reads it via --stdin, flattens the finding buckets,
+// derives the verdict + coverage the notary re-checks, and prints the bundle
+// JSON to stdout. The workflow then pipes that into `post-check-run --bundle`.
+//
+// Usage:
+//   <structured_output JSON> | clud-bug build-bundle \
+//     --repo owner/name --pr N --sha <sha> --recipe-version <v>  > bundle.json
+//
+// Design notes:
+//   - VERDICT is derived from `critical_findings.length > 0`, NOT the model's
+//     self-reported `summary_counts`. This is the SAME rule `validateConsistency`
+//     enforces on the notary side, so a bundle we build never trips its own
+//     consistency check on a miscounted `summary_counts`.
+//   - COVERAGE is a fresh `gh pr diff <pr> --name-only` (GitHub's ground-truth
+//     changed-file set), NOT the incremental `$CHANGED` the review may have
+//     scanned — the notary set-diffs coverage against GitHub's full changed
+//     files (③), so a partial/incremental view would be certified as complete.
+
+import { spawnSync } from 'node:child_process';
+
+import {
+  buildBundle,
+  type NotaryBundle,
+  type NotaryFinding,
+  type NotarySeverity,
+  type ReviewData,
+  type ReviewFinding,
+} from '../core/index.js';
+
+interface BuildBundleArgs {
+  repo?: string;
+  pr?: number;
+  sha?: string;
+  recipeVersion?: string;
+  stdin?: boolean;
+  _?: string[];
+}
+
+/** Map one review finding (schema shape) to a bundle finding (wire shape). */
+function toNotaryFinding(f: ReviewFinding, severity: NotarySeverity): NotaryFinding {
+  const finding: NotaryFinding = { severity, summary: f.summary };
+  if (typeof f.file === 'string' && f.file) finding.file = f.file;
+  if (typeof f.line === 'number' && Number.isInteger(f.line) && f.line >= 1) finding.line = f.line;
+  if (typeof f.grounding === 'string' && f.grounding) finding.grounding = f.grounding;
+  if (f.grounding_kind) finding.grounding_kind = f.grounding_kind;
+  return finding;
+}
+
+/**
+ * Pure transform: `ReviewData` (+ provenance/coverage) → `NotaryBundle`.
+ * Exported for unit testing. Severity buckets map 1:1 to notary severities;
+ * verdict is DERIVED from the critical bucket's length (not `summary_counts`),
+ * matching `validateConsistency`.
+ */
+export function reviewDataToBundle(
+  data: Partial<ReviewData>,
+  meta: { repo: string; pr?: number; headSha: string; recipeVersion: string; coverage: string[] },
+): NotaryBundle {
+  const critical = Array.isArray(data.critical_findings) ? data.critical_findings : [];
+  const minor = Array.isArray(data.minor_findings) ? data.minor_findings : [];
+  const preexisting = Array.isArray(data.preexisting_findings) ? data.preexisting_findings : [];
+
+  const findings: NotaryFinding[] = [
+    ...critical.map((f) => toNotaryFinding(f, 'critical')),
+    ...minor.map((f) => toNotaryFinding(f, 'minor')),
+    ...preexisting.map((f) => toNotaryFinding(f, 'preexisting')),
+  ];
+
+  // Verdict from the ACTUAL critical count — never the model's self-reported
+  // summary_counts (which validateConsistency would reject if it disagreed).
+  const verdict = findings.some((f) => f.severity === 'critical') ? 'critical' : 'clean';
+
+  return buildBundle({
+    repo: meta.repo,
+    ...(meta.pr !== undefined ? { pr: meta.pr } : {}),
+    headSha: meta.headSha,
+    verdict,
+    findings,
+    coverage: meta.coverage,
+    recipeVersion: meta.recipeVersion,
+  });
+}
+
+/** Fresh ground-truth changed-file set for the PR (the notary re-checks ③ coverage). */
+function loadCoverage(pr: number): string[] {
+  const r = spawnSync('gh', ['pr', 'diff', String(pr), '--name-only'], { encoding: 'utf8' });
+  if (r.status !== 0) return [];
+  return (r.stdout ?? '')
+    .split('\n')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export async function runBuildBundle(args: BuildBundleArgs): Promise<void> {
+  const fail = (m: string): never => {
+    process.stderr.write(`clud-bug build-bundle: ${m}\n`);
+    process.exit(2);
+  };
+
+  const repo = typeof args.repo === 'string' ? args.repo.trim() : '';
+  if (!repo || !repo.includes('/')) fail('--repo owner/name is required.');
+  const sha = typeof args.sha === 'string' ? args.sha.trim() : '';
+  if (!sha) fail('--sha <sha> is required.');
+  const recipeVersion = typeof args.recipeVersion === 'string' ? args.recipeVersion.trim() : '';
+  if (!recipeVersion) fail('--recipe-version <v> is required.');
+  const pr = typeof args.pr === 'number' && Number.isInteger(args.pr) && args.pr > 0 ? args.pr : undefined;
+  if (pr === undefined) fail('--pr <N> is required (the notary certifies PR heads).');
+
+  // Read the review ReviewData JSON from stdin (like `render`).
+  let raw = '';
+  for await (const chunk of process.stdin) raw += chunk;
+  raw = raw.trim();
+  if (!raw) fail('stdin was empty — pipe the review structured_output JSON.');
+
+  let data: Partial<ReviewData>;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') throw new Error('payload is not a JSON object');
+    data = parsed as Partial<ReviewData>;
+  } catch (e) {
+    return void fail(`JSON parse failed: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  const coverage = loadCoverage(pr as number);
+  const bundle = reviewDataToBundle(data, {
+    repo,
+    ...(pr !== undefined ? { pr } : {}),
+    headSha: sha,
+    recipeVersion,
+    coverage,
+  });
+
+  process.stdout.write(JSON.stringify(bundle) + '\n');
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -133,6 +133,8 @@ function parseArgs(argv) {
     else if (a === '--source') args.source = argv[++i];
     else if (a === '--strict') args.strict = true;
     else if (a === '--no-strict') args.strict = false;
+    else if (a === '--notary') args.notary = true;
+    else if (a === '--no-notary') args.notary = false;
     else if (a === '--owner') args.owner = argv[++i];
     else if (a === '--details-url') args.detailsUrl = argv[++i];
     // Phase Z: notary attestation bundle (JSON path) for `post-check-run`.
@@ -240,7 +242,8 @@ Commands:
   post-check-run        Post the \`clud-bug-review\` GitHub check so branch
                         protection can gate the merge (H3). --verdict
                         clean|critical|failed --sha <sha> [--critical-count N]
-                        [--source local|ci] [--strict|--no-strict] [--dry-run].
+                        [--source local|ci] [--strict|--no-strict]
+                        [--notary|--no-notary] [--dry-run].
                         clean→success, critical+strict→failure, else neutral.
                         With CLUD_BUG_NOTARY_URL set + --bundle <file>, submits a
                         notary attestation bundle instead (Phase Z); the notary

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -33,6 +33,7 @@ import { renderAuditHeader } from '../core/audit.js';
 import { runUpdate } from './update.js';
 import { runReviewPrompt } from './review-prompt.js';
 import { runPostCheckRun } from './post-check-run.js';
+import { runBuildBundle } from './build-bundle.js';
 import { getPendingWorkflowEdits, makeBranchName, git as gitCmd } from './edit-workflow.js';
 import { applyToRepo as applyAgentDocs } from './agents-md.js';
 import { detectRepo, detectDefaultBranch, getProtectionState, enableConversationResolution } from './branch-protection.js';
@@ -69,7 +70,12 @@ function parseArgs(argv) {
     // .claude/commands/clud-bug-review.md so `/clud-bug-review` works in a
     // Claude Code session (reviews the current PR with the session's tokens).
     withLocalReview: false,
-    withHooks: false,
+    // Phase ZP3: `clud-bug init` now installs BOTH the max-mode commit hook AND
+    // the GitHub Action enforcer by DEFAULT (was off-by-default) — the two are
+    // complementary (the hook reviews on your session's subscription at commit
+    // time; the Action gates the merge on CI). Opt out of the hook with
+    // `--no-hooks`. `--local-only` (max mode, no Action) still forces it on.
+    withHooks: true,
     // rc.16: `clud-bug init --with-design` installs the design-critic kit
     // (4 `kind: design` skills) and flips the off-by-default `design` block to
     // enabled so the visual review lens runs (local recipe + hosted bot).
@@ -110,6 +116,9 @@ function parseArgs(argv) {
     else if (a === '--with-skdd') args.withSkdd = true;
     else if (a === '--with-local-review') args.withLocalReview = true;
     else if (a === '--with-hooks') args.withHooks = true;
+    // Phase ZP3: negation of the now-default commit hook (mirrors --no-strict /
+    // --no-artifacts). --local-only re-forces it on (max mode IS the hook).
+    else if (a === '--no-hooks') args.withHooks = false;
     else if (a === '--with-design') args.withDesign = true;
     else if (a === '--local-only') args.localOnly = true;
     else if (a === '--dry-run') args.dryRun = true;
@@ -128,6 +137,8 @@ function parseArgs(argv) {
     else if (a === '--details-url') args.detailsUrl = argv[++i];
     // Phase Z: notary attestation bundle (JSON path) for `post-check-run`.
     else if (a === '--bundle') args.bundle = argv[++i];
+    // Phase ZP3: `clud-bug build-bundle` provenance flag.
+    else if (a === '--recipe-version') args.recipeVersion = argv[++i];
     else args._.push(a);
   }
   return args;
@@ -235,6 +246,15 @@ Commands:
                         notary attestation bundle instead (Phase Z); the notary
                         issues the check. Falls back to the self-attested post if
                         the endpoint is unreachable.
+  build-bundle          Transform a review's structured_output JSON (piped via
+   --stdin               stdin) into a notary attestation bundle (Phase ZP3), for
+                        the self-hosted Action to hand to \`post-check-run
+                        --bundle\`. Flattens critical/minor/preexisting findings,
+                        derives the verdict from the critical count (not the
+                        self-reported counts), and derives coverage from a fresh
+                        \`gh pr diff <pr> --name-only\`. Flags: --repo owner/name
+                        --pr N --sha <sha> --recipe-version <v>. Emits bundle
+                        JSON to stdout.
 
 Options:
   --offline             Skip skills.sh; pin only the bundled baseline specimens.
@@ -248,7 +268,12 @@ Options:
                         commit-review hook into .claude/settings.json — on every
                         \`git commit\` / \`logmind log\`, it fetches a review recipe and
                         surfaces it to the agent (on this session's subscription)
-                        via asyncRewake. Implies --with-local-review. Off by default.
+                        via asyncRewake. Implies --with-local-review. ON by
+                        default (ZP3) — \`init\` installs both the hook and the
+                        GitHub Action enforcer. Flag kept for explicitness.
+  --no-hooks            (init) Skip the commit-review hook — install only the
+                        GitHub Action enforcer (+ skills). --local-only overrides
+                        (max mode IS the hook, so it stays installed).
   --with-design         (init) Install the design-critic kit (4 \`kind: design\`
                         skills) and enable the off-by-default visual review
                         lens — renders changed UI and critiques it. Off by default.
@@ -302,7 +327,7 @@ async function main() {
   // terminal, and never for the machine-consumed verbs (the hook runs
   // review-prompt in a non-TTY subprocess, so this is doubly skipped there).
   // Best-effort + cache-backed, so it adds no latency to the command.
-  const MACHINE_VERBS = new Set(['review-prompt', 'post-check-run', 'render', 'update-skill-usage']);
+  const MACHINE_VERBS = new Set(['review-prompt', 'post-check-run', 'build-bundle', 'render', 'update-skill-usage']);
   if (process.stderr.isTTY && !MACHINE_VERBS.has(cmd)) {
     const { maybeNotifyUpdate } = await import('./update-notifier.js');
     await maybeNotifyUpdate(await readPkgVersion());
@@ -327,6 +352,7 @@ async function main() {
     case 'resolve-threads': return runResolveThreads(args);
     case 'review-prompt': return runReviewPrompt(args);
     case 'post-check-run': return runPostCheckRun(args);
+    case 'build-bundle': return runBuildBundle(args);
     default:
       process.stderr.write(`Unknown command: ${cmd || '(none)'}\n\n${HELP}`);
       process.exit(2);
@@ -1486,6 +1512,13 @@ async function runInit(args) {
       log('  → git push.');
     }
   } else {
+    if (args.withHooks) {
+      log('  Both review surfaces installed: the commit-review hook (reviews on your');
+      log('  Claude Code session at commit time) AND the GitHub Action enforcer (gates');
+      log('  the merge on CI). Pass --no-hooks to install only the Action.');
+    } else {
+      log('  GitHub Action enforcer installed (--no-hooks: no commit-review hook).');
+    }
     log('  1. Set ANTHROPIC_API_KEY in your repo secrets:');
     log('     Settings → Secrets and variables → Actions → New repository secret');
     if (!args.commit) {

--- a/src/cli/post-check-run.ts
+++ b/src/cli/post-check-run.ts
@@ -5,7 +5,11 @@
 // Usage:
 //   clud-bug post-check-run --sha <sha> --verdict clean|critical|failed|unverified \
 //     [--critical-count N] [--source local|ci] [--strict|--no-strict] \
-//     [--owner O --repo R] [--details-url URL] [--dry-run]
+//     [--notary|--no-notary] [--owner O --repo R] [--details-url URL] [--dry-run]
+//
+// --notary / --no-notary OVERRIDE the repo manifest's notary setting (mirrors
+// --strict/--no-strict). CI derives this from the BASE ref so a PR cannot
+// self-disable independent notary certification via its own HEAD .clud-bug.json.
 //
 // Verdict → conclusion is the shared `deriveCheck` brain. strictMode defaults to
 // the repo's `.clud-bug.json` (so `critical` blocks only where the repo opted in)
@@ -37,6 +41,10 @@ interface PostCheckRunArgs {
   criticalCount?: number;
   source?: string;
   strict?: boolean;
+  /** Explicit notary enable/disable that OVERRIDES the manifest (mirrors
+   *  --strict/--no-strict). CI derives this from the BASE ref so a PR cannot
+   *  self-disable the notary by editing its own HEAD `.clud-bug.json`. */
+  notary?: boolean;
   owner?: string;
   repo?: string;
   detailsUrl?: string;
@@ -271,7 +279,10 @@ export async function runPostCheckRun(args: PostCheckRunArgs): Promise<void> {
   // (endpoint unreachable / not entitled) continues to the self-attested
   // self-post below; 'posted'/'rejected' are terminal.
   let fallbackBundle: NotaryBundle | null = null;
-  const notaryUrl = readNotaryConfig(manifest);
+  // `args.notary` (from --notary/--no-notary) OVERRIDES the manifest when set —
+  // CI passes it derived from the BASE ref so a PR cannot self-disable the
+  // notary via its own HEAD manifest. Unset → local default-on precedence.
+  const notaryUrl = readNotaryConfig(manifest, args.notary);
   if (notaryUrl && typeof args.bundle === 'string' && args.bundle && !args.dryRun) {
     const { outcome, bundle } = await submitToNotary(notaryUrl, args.bundle, warn);
     if (outcome !== 'fallback') return;

--- a/src/cli/post-check-run.ts
+++ b/src/cli/post-check-run.ts
@@ -285,14 +285,24 @@ export async function runPostCheckRun(args: PostCheckRunArgs): Promise<void> {
     typeof args.strict === 'boolean' ? args.strict : (manifest as { strictMode?: unknown }).strictMode === true;
 
   // A bundle-fallback self-post reflects what was actually VALIDATED (bundle
-  // verdict + its critical count, local source); otherwise the raw flags.
+  // verdict + its critical count); otherwise the raw flags.
   const verdict = fallbackBundle
     ? fallbackBundle.verdict
     : normalizeVerdict(typeof args.verdict === 'string' ? args.verdict : undefined);
   const criticalCount = fallbackBundle
     ? fallbackBundle.findings.filter((f) => f.severity === 'critical').length
     : Number(args.criticalCount ?? 0) || 0;
-  const source: 'local' | 'ci' = fallbackBundle ? 'local' : args.source === 'local' ? 'local' : 'ci';
+  // Source honors an explicit --source in BOTH paths. On the bundle-fallback
+  // path a CI-originated invocation passes `--source ci` (the Action self-attests
+  // as CI, not local), so only DEFAULT to 'local' there when --source is unset;
+  // the non-bundle path keeps its 'ci'-unless-`--source local` default.
+  const source: 'local' | 'ci' = fallbackBundle
+    ? args.source === 'ci'
+      ? 'ci'
+      : 'local'
+    : args.source === 'local'
+      ? 'local'
+      : 'ci';
   const { conclusion, title, summary } = deriveCheck({ verdict, strictMode, criticalCount, source });
 
   // --- resolve owner/repo (flags, else gh) ------------------------------

--- a/src/core/notary-config.ts
+++ b/src/core/notary-config.ts
@@ -36,9 +36,24 @@ export const DEFAULT_NOTARY_URL = 'https://app.cludbug.dev';
  * callers' `+ '/notarize'` / `+ '/notarize/challenge'` path-joins stay
  * correct without each call site re-normalizing.
  */
-export function readNotaryConfig(manifest: unknown): string | null {
-  const raw = (manifest as { notary?: unknown } | null | undefined)?.notary;
-  if (raw === false) return null;
+export function readNotaryConfig(
+  manifest: unknown,
+  override?: boolean,
+): string | null {
+  // An EXPLICIT override (the CLI `--notary` / `--no-notary` flag) WINS over the
+  // manifest, mirroring how `--strict` / `--no-strict` override
+  // manifest.strictMode. CI derives notary enablement from the BASE ref and
+  // passes it here, so a PR CANNOT self-disable independent certification by
+  // setting `"notary": false` in its own HEAD `.clud-bug.json`. Absent an
+  // override (undefined), the local default-on precedence below applies.
+  if (override === false) return null;
+
+  if (override !== true) {
+    // Local precedence: a maintainer-committed `notary: false` opts out. Only
+    // reached when no explicit flag forced the notary on.
+    const raw = (manifest as { notary?: unknown } | null | undefined)?.notary;
+    if (raw === false) return null;
+  }
 
   const envUrl = process.env.CLUD_BUG_NOTARY_URL?.trim();
   if (envUrl) {

--- a/src/core/prompts.ts
+++ b/src/core/prompts.ts
@@ -270,6 +270,27 @@ If strictMode is unset or absent, set \`status_header: "bare"\` —
 the renderer emits the bare \`## 🐛 Clud Bug review\` (no suffix),
 matching the v0.6.21- visible behaviour for non-strict-mode repos.
 
+Grounding (REQUIRED on every 🔴 critical — notary attestation §10.3.3):
+This review's structured output is assembled into a NOTARY ATTESTATION
+BUNDLE for independent certification. The notary REJECTS an ungrounded
+critical, refusing the WHOLE bundle (no green check). So populate the
+\`grounding\` + \`grounding_kind\` schema fields on EVERY critical, one of:
+  - \`quote\` — the offending line copied VERBATIM from the diff (with a
+    matching \`line\`). The notary re-verifies this span is a byte-exact
+    substring of a changed line; PREFER it (the only form checked
+    deterministically) whenever a single changed line carries the bug.
+  - \`reproduction\` — a command you ran + its observed output (only under
+    the execution-safety rule; never run an untrusted contributor/fork
+    diff). Stronger evidence than a quote, not weaker.
+  - \`invariant\` — a one-sentence named property the change breaks + the
+    input that breaks it. For a bug on no single changed line (emergent,
+    combinatorial, or cross-cutting), reproduce it or name the invariant
+    instead of staying silent.
+Default \`grounding_kind\` to \`quote\`; \`reproduction\`/\`invariant\` are
+audit-verified. A repro you ran, or a named invariant, SATISFIES any
+skill that says "quote the exact line or drop". Drop only what NONE of
+the three grounds. \`grounding\` is optional on 🟡 minor / 🟣 pre-existing.
+
 Tone: conversational, concise field-naturalist voice (you are Clud
 Bug examining specimens of code) — never at the cost of clarity,
 evidence, or critical-issues-only discipline. Let precision speak.

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -296,6 +296,40 @@ jobs:
 
           $CALIBRATION"
 
+      # Phase ZP3 — route this Action's review through the NOTARY.
+      # See workflow.yml.tmpl for full design notes (base-ref trust guard;
+      # continue-on-error coexists with the strict-mode-gate backstop).
+      - name: Notarize review
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -uo pipefail
+
+          # strictMode from the BASE ref's manifest — a PR can't opt itself out
+          # (or disable the notary) by editing its own HEAD .clud-bug.json.
+          STRICT_FLAG=--no-strict
+          if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
+            if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
+              STRICT_FLAG=--strict
+            fi
+          fi
+
+          printf '%s\n' "$STRUCTURED" \
+            | npx --yes clud-bug@{{CLUD_BUG_VERSION}} build-bundle \
+                --repo "$REPO" --pr "$PR_NUMBER" --sha "$HEAD_SHA" \
+                --recipe-version "ci-{{CLUD_BUG_VERSION}}" \
+            > bundle.json
+
+          npx --yes clud-bug@{{CLUD_BUG_VERSION}} post-check-run \
+            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG"
+
       # Wave 5a (D.2.X) — see workflow.yml.tmpl for design notes.
       - name: Post inline review threads
         if: success() && steps.clud-bug-review.outputs.structured_output != ''

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -312,12 +312,17 @@ jobs:
         run: |
           set -uo pipefail
 
-          # strictMode from the BASE ref's manifest — a PR can't opt itself out
-          # (or disable the notary) by editing its own HEAD .clud-bug.json.
+          # strictMode + notary enablement from the BASE ref's manifest — a PR
+          # can't opt itself out of strict mode OR disable the notary by editing
+          # its own HEAD .clud-bug.json. Unreadable base → --no-strict + --notary.
           STRICT_FLAG=--no-strict
+          NOTARY_FLAG=--notary
           if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
             if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
               STRICT_FLAG=--strict
+            fi
+            if jq -e '.notary == false' /tmp/base-manifest.json > /dev/null 2>&1; then
+              NOTARY_FLAG=--no-notary
             fi
           fi
 
@@ -328,7 +333,7 @@ jobs:
             > bundle.json
 
           npx --yes clud-bug@{{CLUD_BUG_VERSION}} post-check-run \
-            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG"
+            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG" "$NOTARY_FLAG"
 
       # Wave 5a (D.2.X) — see workflow.yml.tmpl for design notes.
       - name: Post inline review threads

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -296,6 +296,40 @@ jobs:
 
           $CALIBRATION"
 
+      # Phase ZP3 — route this Action's review through the NOTARY.
+      # See workflow.yml.tmpl for full design notes (base-ref trust guard;
+      # continue-on-error coexists with the strict-mode-gate backstop).
+      - name: Notarize review
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -uo pipefail
+
+          # strictMode from the BASE ref's manifest — a PR can't opt itself out
+          # (or disable the notary) by editing its own HEAD .clud-bug.json.
+          STRICT_FLAG=--no-strict
+          if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
+            if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
+              STRICT_FLAG=--strict
+            fi
+          fi
+
+          printf '%s\n' "$STRUCTURED" \
+            | npx --yes clud-bug@{{CLUD_BUG_VERSION}} build-bundle \
+                --repo "$REPO" --pr "$PR_NUMBER" --sha "$HEAD_SHA" \
+                --recipe-version "ci-{{CLUD_BUG_VERSION}}" \
+            > bundle.json
+
+          npx --yes clud-bug@{{CLUD_BUG_VERSION}} post-check-run \
+            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG"
+
       # Wave 5a (D.2.X) — see workflow.yml.tmpl for design notes.
       - name: Post inline review threads
         if: success() && steps.clud-bug-review.outputs.structured_output != ''

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -312,12 +312,17 @@ jobs:
         run: |
           set -uo pipefail
 
-          # strictMode from the BASE ref's manifest — a PR can't opt itself out
-          # (or disable the notary) by editing its own HEAD .clud-bug.json.
+          # strictMode + notary enablement from the BASE ref's manifest — a PR
+          # can't opt itself out of strict mode OR disable the notary by editing
+          # its own HEAD .clud-bug.json. Unreadable base → --no-strict + --notary.
           STRICT_FLAG=--no-strict
+          NOTARY_FLAG=--notary
           if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
             if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
               STRICT_FLAG=--strict
+            fi
+            if jq -e '.notary == false' /tmp/base-manifest.json > /dev/null 2>&1; then
+              NOTARY_FLAG=--no-notary
             fi
           fi
 
@@ -328,7 +333,7 @@ jobs:
             > bundle.json
 
           npx --yes clud-bug@{{CLUD_BUG_VERSION}} post-check-run \
-            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG"
+            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG" "$NOTARY_FLAG"
 
       # Wave 5a (D.2.X) — see workflow.yml.tmpl for design notes.
       - name: Post inline review threads

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -550,13 +550,19 @@ jobs:
         run: |
           set -uo pipefail
 
-          # Resolve strictMode from the BASE ref's manifest — a PR cannot opt
-          # itself out of strict mode (or the notary) by editing its own HEAD
-          # .clud-bug.json. Best-effort: any error falls through to --no-strict.
+          # Resolve strictMode AND notary enablement from the BASE ref's
+          # manifest — a PR cannot opt itself out of strict mode OR disable the
+          # notary by editing its own HEAD .clud-bug.json. Best-effort: an
+          # unreadable base manifest falls through to --no-strict + --notary
+          # (fail SAFE toward independent certification).
           STRICT_FLAG=--no-strict
+          NOTARY_FLAG=--notary
           if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
             if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
               STRICT_FLAG=--strict
+            fi
+            if jq -e '.notary == false' /tmp/base-manifest.json > /dev/null 2>&1; then
+              NOTARY_FLAG=--no-notary
             fi
           fi
 
@@ -567,7 +573,7 @@ jobs:
             > bundle.json
 
           npx --yes clud-bug@{{CLUD_BUG_VERSION}} post-check-run \
-            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG"
+            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG" "$NOTARY_FLAG"
 
       # v0.7.0-rc.7 / Wave 5a (D.2.X): post per-finding inline review
       # threads alongside the summary comment. Each thread is anchored

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -516,6 +516,59 @@ jobs:
 
           $CALIBRATION"
 
+      # Phase ZP3 — route this self-hosted Action's review through the NOTARY.
+      #
+      # Transform the SAME structured_output the render step consumed into a
+      # notary attestation bundle (`build-bundle`: flattens the finding buckets,
+      # derives the verdict from the critical count, derives coverage from a
+      # fresh `gh pr diff --name-only`), then submit it via `post-check-run
+      # --bundle`. With CLUD_BUG_NOTARY_URL resolved (default-on since ZP2), the
+      # CLI POSTs the bundle to the notary, which re-validates it against
+      # GitHub's ground-truth diff and — as the SOLE issuer — posts the pinned
+      # `clud-bug-review` check. If the endpoint is unreachable, post-check-run
+      # falls back to a self-attested check tagged `--source ci`.
+      #
+      # SECURITY — base-ref trust guard: strictMode is resolved from the BASE
+      # ref's `.clud-bug.json` (same discipline as the strict-mode-gate + Formal
+      # review steps), NOT the PR's HEAD, so a PR cannot set `strictMode: false`
+      # (or `notary: false`) in its own head to defang the merge gate.
+      #
+      # `continue-on-error: true` — notarization must NEVER be the source of job
+      # failure. The Strict-mode gate step below remains the AUTHORITATIVE merge
+      # backstop; this step deliberately does NOT double-gate it (a notary
+      # outage or fallback can't turn a clean review red on its own).
+      - name: Notarize review
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -uo pipefail
+
+          # Resolve strictMode from the BASE ref's manifest — a PR cannot opt
+          # itself out of strict mode (or the notary) by editing its own HEAD
+          # .clud-bug.json. Best-effort: any error falls through to --no-strict.
+          STRICT_FLAG=--no-strict
+          if git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json" > /tmp/base-manifest.json 2>/dev/null; then
+            if jq -e '.strictMode == true' /tmp/base-manifest.json > /dev/null 2>&1; then
+              STRICT_FLAG=--strict
+            fi
+          fi
+
+          printf '%s\n' "$STRUCTURED" \
+            | npx --yes clud-bug@{{CLUD_BUG_VERSION}} build-bundle \
+                --repo "$REPO" --pr "$PR_NUMBER" --sha "$HEAD_SHA" \
+                --recipe-version "ci-{{CLUD_BUG_VERSION}}" \
+            > bundle.json
+
+          npx --yes clud-bug@{{CLUD_BUG_VERSION}} post-check-run \
+            --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG"
+
       # v0.7.0-rc.7 / Wave 5a (D.2.X): post per-finding inline review
       # threads alongside the summary comment. Each thread is anchored
       # to a file + line in the diff and is a first-class GitHub review

--- a/test/build-bundle.test.js
+++ b/test/build-bundle.test.js
@@ -52,6 +52,19 @@ describe('reviewDataToBundle', () => {
     expect(b.findings[0]).toMatchObject({ severity: 'critical', summary: 'c1', file: 'a.ts', line: 1 });
   });
 
+  it('skips null/non-object finding entries (and a non-array bucket) instead of crashing', () => {
+    const data = {
+      // Malformed / truncated structured_output: null, a number, a non-array bucket.
+      critical_findings: [null, { skill: 's', summary: 'real' }, 42],
+      minor_findings: [undefined],
+      preexisting_findings: 'not-an-array',
+    };
+    const b = reviewDataToBundle(data, meta); // must NOT throw
+    expect(b.findings).toHaveLength(1);
+    expect(b.findings[0]).toMatchObject({ severity: 'critical', summary: 'real' });
+    expect(b.verdict).toBe('critical');
+  });
+
   it('carries grounding + grounding_kind through onto critical findings', () => {
     const data = {
       critical_findings: [

--- a/test/build-bundle.test.js
+++ b/test/build-bundle.test.js
@@ -1,0 +1,91 @@
+// Phase ZP3 — `clud-bug build-bundle`: the ReviewData → NotaryBundle transform.
+//
+// The self-hosted Action routes its review through the notary by transforming
+// the review's structured_output (ReviewData) into an attestation bundle. These
+// tests pin the pure transform: the finding buckets flatten 1:1, the verdict is
+// DERIVED from the actual critical count (not the model's self-reported
+// summary_counts — matching validateConsistency), and coverage passes through.
+
+import { describe, expect, it } from 'vitest';
+
+import { reviewDataToBundle } from '../src/cli/build-bundle.js';
+import { NOTARY_BUNDLE_VERSION, NOTARY_PROTOCOL_VERSION, validateConsistency } from '../src/core/index.js';
+
+const SHA = 'deadbeefcafefeed0000';
+const meta = { repo: 'o/r', pr: 7, headSha: SHA, recipeVersion: 'ci-0.0.0', coverage: ['a.ts', 'b.ts'] };
+
+describe('reviewDataToBundle', () => {
+  it('derives verdict=critical from a non-empty critical bucket (not summary_counts)', () => {
+    const data = {
+      // Deliberately LIE in summary_counts to prove the verdict ignores it.
+      summary_counts: { critical: 0, minor: 0, preexisting: 0, resolved_from_prior: 0, still_open: 0 },
+      critical_findings: [{ skill: 'critical-issues-only', summary: 'off-by-one', file: 'a.ts', line: 4, grounding: 'i <= n', grounding_kind: 'quote' }],
+      minor_findings: [],
+      preexisting_findings: [],
+    };
+    const b = reviewDataToBundle(data, meta);
+    expect(b.verdict).toBe('critical');
+    // The bundle it produces never trips the notary's own consistency check.
+    expect(validateConsistency(b.verdict, b.findings).ok).toBe(true);
+  });
+
+  it('derives verdict=clean when the critical bucket is empty (even if counts claim otherwise)', () => {
+    const data = {
+      summary_counts: { critical: 9, minor: 0, preexisting: 0, resolved_from_prior: 0, still_open: 0 },
+      critical_findings: [],
+      minor_findings: [{ skill: 's', summary: 'nit' }],
+      preexisting_findings: [],
+    };
+    const b = reviewDataToBundle(data, meta);
+    expect(b.verdict).toBe('clean');
+    expect(validateConsistency(b.verdict, b.findings).ok).toBe(true);
+  });
+
+  it('flattens all three buckets to NotaryFinding[] with 1:1 severity names', () => {
+    const data = {
+      critical_findings: [{ skill: 's', summary: 'c1', file: 'a.ts', line: 1 }],
+      minor_findings: [{ skill: 's', summary: 'm1' }, { skill: 's', summary: 'm2' }],
+      preexisting_findings: [{ skill: 's', summary: 'p1' }],
+    };
+    const b = reviewDataToBundle(data, meta);
+    expect(b.findings.map((f) => f.severity)).toEqual(['critical', 'minor', 'minor', 'preexisting']);
+    expect(b.findings[0]).toMatchObject({ severity: 'critical', summary: 'c1', file: 'a.ts', line: 1 });
+  });
+
+  it('carries grounding + grounding_kind through onto critical findings', () => {
+    const data = {
+      critical_findings: [
+        { skill: 's', summary: 'c', grounding: 'const x = y', grounding_kind: 'quote' },
+      ],
+      minor_findings: [],
+      preexisting_findings: [],
+    };
+    const b = reviewDataToBundle(data, meta);
+    expect(b.findings[0].grounding).toBe('const x = y');
+    expect(b.findings[0].grounding_kind).toBe('quote');
+  });
+
+  it('sets coverage from meta (the caller passes GitHub ground-truth changed files), not the findings', () => {
+    const b = reviewDataToBundle({ critical_findings: [], minor_findings: [], preexisting_findings: [] }, meta);
+    expect(b.coverage).toEqual(['a.ts', 'b.ts']);
+    expect(Array.isArray(b.coverage)).toBe(true);
+  });
+
+  it('stamps repo/pr/head_sha/recipe + the wire & protocol versions', () => {
+    const b = reviewDataToBundle({ critical_findings: [], minor_findings: [], preexisting_findings: [] }, meta);
+    expect(b).toMatchObject({
+      repo: 'o/r',
+      pr: 7,
+      head_sha: SHA,
+      recipe_version: 'ci-0.0.0',
+      bundle_version: NOTARY_BUNDLE_VERSION,
+      protocol_version: NOTARY_PROTOCOL_VERSION,
+    });
+  });
+
+  it('tolerates missing finding buckets (degrades to empty, verdict=clean)', () => {
+    const b = reviewDataToBundle({}, meta);
+    expect(b.findings).toEqual([]);
+    expect(b.verdict).toBe('clean');
+  });
+});

--- a/test/check-verdict.test.js
+++ b/test/check-verdict.test.js
@@ -85,4 +85,20 @@ describe('post-check-run --dry-run', () => {
   it('critical + --no-strict → neutral (advisory)', () => {
     expect(dryRun(['--verdict', 'critical', '--no-strict']).stdout).toMatch(/conclusion=neutral/);
   });
+
+  // Phase ZP3 — the CI-originated notarize step passes `--source ci`. The source
+  // must be honored (not hard-coded), so the self-attested fallback a CI run
+  // posts is tagged `ci`, not `local`. Dry-run surfaces the resolved source.
+  describe('--source is honored (ZP3)', () => {
+    it('defaults to ci when --source is unset', () => {
+      expect(dryRun(['--verdict', 'clean']).stdout).toMatch(/source=ci\b/);
+    });
+    it('--source ci → source=ci', () => {
+      expect(dryRun(['--verdict', 'clean', '--source', 'ci']).stdout).toMatch(/source=ci\b/);
+    });
+    it('--source local → source=local (adds the self-attested note)', () => {
+      const out = dryRun(['--verdict', 'clean', '--source', 'local']).stdout;
+      expect(out).toMatch(/source=local\b/);
+    });
+  });
 });

--- a/test/core/notary-config.test.js
+++ b/test/core/notary-config.test.js
@@ -78,4 +78,28 @@ describe('readNotaryConfig', () => {
     expect(readNotaryConfig({ notary: 0 })).toBe(DEFAULT_NOTARY_URL);
     expect(readNotaryConfig({ notary: null })).toBe(DEFAULT_NOTARY_URL);
   });
+
+  describe('explicit override (--notary / --no-notary → the CI base-ref guard)', () => {
+    it('override=false forces self-attest (null) regardless of manifest/env', () => {
+      delete process.env[ENV_KEY];
+      expect(readNotaryConfig({}, false)).toBeNull();
+      expect(readNotaryConfig({ notary: true }, false)).toBeNull();
+    });
+
+    it('override=true forces the notary ON, IGNORING a manifest `notary:false` — a PR head cannot self-disable in CI', () => {
+      delete process.env[ENV_KEY];
+      // The security fix: CI derives the flag from the BASE ref and passes
+      // override=true, so a PR that sets notary:false in its own HEAD manifest
+      // still gets independently certified.
+      expect(readNotaryConfig({ notary: false }, true)).toBe(DEFAULT_NOTARY_URL);
+      process.env[ENV_KEY] = 'https://staging.example.com';
+      expect(readNotaryConfig({ notary: false }, true)).toBe('https://staging.example.com');
+    });
+
+    it('override=undefined preserves local precedence (manifest `notary:false` honored)', () => {
+      delete process.env[ENV_KEY];
+      expect(readNotaryConfig({ notary: false }, undefined)).toBeNull();
+      expect(readNotaryConfig({}, undefined)).toBe(DEFAULT_NOTARY_URL);
+    });
+  });
 });

--- a/test/golden/byte-budget.json
+++ b/test/golden/byte-budget.json
@@ -1,11 +1,11 @@
 {
   "$schema-comment": "Size caps for the rendered prompt. UTF-8 byte counts. The CI gate fails if the actual size exceeds the cap. Caps are intentionally close to current size so 0.0.P trim work has headroom without inviting regression.",
   "max_prompt_bytes": {
-    "value": 17500,
-    "why": "Current rendered prompt is ~16.6 KB post-v0.6.27 §5.5 Layer 3 (added ~600 bytes of mid-review self-check-in rules: [budget] heartbeat-every-5-turns pattern + pace-behind pivot strategy). Cap bumped 16000 → 17500 with v0.6.27; still well below the 18500 pre-0.0.P cap. Each Smart Budget layer compounds prompt-side rules to give the AI a tighter model of its own pacing; rule shrinkage candidates land when calibration data validates the wording can be tighter. See CHANGELOG [0.6.27]."
+    "value": 18700,
+    "why": "Current rendered prompt is ~18.2 KB post-ZP3 (added a ~1.5 KB Grounding block: every 🔴 critical must carry grounding + grounding_kind, since the CI review's structured_output is assembled into a notary attestation bundle and validateGrounding REJECTS an ungrounded critical → the whole bundle is refused). This is load-bearing, not decorative: without it the self-hosted Action can never get a green notarized check on any PR with a critical. Cap bumped 17500 → 18700 with ZP3 (headroom above the 18.2 KB current, at the 18500 pre-0.0.P ceiling ballpark). Earlier: v0.6.27 §5.5 Layer 3 mid-review self-check-in rules. See CHANGELOG [Unreleased] ZP3 + [0.6.27]."
   },
   "max_prompt_lines": {
-    "value": 365,
-    "why": "Current is ~351 lines post-v0.6.27 §5.5 Layer 3 (+~26 lines for the Mid-review self-check-in section). Cap bumped 340 → 365 with v0.6.27. See CHANGELOG [0.6.27]."
+    "value": 385,
+    "why": "Current is ~375 lines post-ZP3 (+~24 lines for the Grounding block — see max_prompt_bytes.why). Cap bumped 365 → 385 with ZP3. Earlier: v0.6.27 §5.5 Layer 3 (+~26 lines). See CHANGELOG [Unreleased] ZP3 + [0.6.27]."
   }
 }

--- a/test/init-local-review.test.js
+++ b/test/init-local-review.test.js
@@ -45,18 +45,46 @@ test('init --with-local-review scaffolds the /clud-bug-review slash command', as
   assert.match(body, /repos\/\{owner\}\/\{repo\}\/issues\/<PR_NUMBER>\/comments/);
 });
 
-test('init without --with-local-review does NOT scaffold the slash command', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-nolr-'));
+test('init installs BOTH the commit hook and the slash command by default (ZP3)', async () => {
+  // Phase ZP3: --with-hooks is now ON by default (it implies --with-local-review),
+  // so a bare `init` installs the commit-review hook AND the /clud-bug-review
+  // slash command alongside the GitHub Action enforcer.
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-default-'));
   await mkdir(join(dir, '.git'), { recursive: true });
   const r = runInit(dir, []);
   assert.equal(r.status, 0, r.stderr);
-  let exists = true;
-  try {
-    await access(join(dir, '.claude', 'commands', 'clud-bug-review.md'));
-  } catch {
-    exists = false;
+  // slash command scaffolded (withHooks → withLocalReview)
+  await access(join(dir, '.claude', 'commands', 'clud-bug-review.md'));
+  // commit-review hook merged into settings.json
+  const settings = JSON.parse(await readFile(join(dir, '.claude', 'settings.json'), 'utf8'));
+  assert.equal(settings.hooks.PostToolUse[0].hooks[0].type, 'command');
+});
+
+test('init --no-hooks skips the commit hook (and the implied slash command)', async () => {
+  // The negation flag installs only the GitHub Action enforcer (+ skills) —
+  // no commit hook, and without withHooks the slash command isn't implied.
+  const dir = await mkdtemp(join(tmpdir(), 'clud-bug-nohooks-'));
+  await mkdir(join(dir, '.git'), { recursive: true });
+  const r = runInit(dir, ['--no-hooks']);
+  assert.equal(r.status, 0, r.stderr);
+  for (const p of [
+    join(dir, '.claude', 'settings.json'),
+    join(dir, '.claude', 'commands', 'clud-bug-review.md'),
+  ]) {
+    let exists = true;
+    try {
+      await access(p);
+    } catch {
+      exists = false;
+    }
+    assert.equal(exists, false, `${p} should not exist under --no-hooks`);
   }
-  assert.equal(exists, false, 'slash command should not exist without the flag');
+});
+
+test('--no-hooks is advertised in --help', () => {
+  const r = spawnSync(process.execPath, [CLI, '--help'], { encoding: 'utf8' });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /--no-hooks/);
 });
 
 test('init --with-hooks scaffolds the native commit-review hook + the slash command', async () => {

--- a/test/prompts.test.js
+++ b/test/prompts.test.js
@@ -83,6 +83,32 @@ test('reviewPrompt includes the core review-discipline sections', () => {
   }
 });
 
+test('reviewPrompt instructs the CI review to ground every critical (notary attestation)', () => {
+  // Phase ZP3 — the CI review's structured_output is assembled into a notary
+  // attestation bundle; validateGrounding REJECTS an ungrounded critical, which
+  // would notary-reject the whole bundle. So the prompt MUST tell the model to
+  // populate grounding + grounding_kind on every critical, naming the three forms.
+  const out = reviewPrompt({ projectDescription: 'p' });
+  assert.match(out, /Grounding \(REQUIRED on every 🔴 critical/);
+  assert.match(out, /\bgrounding\b/);
+  assert.match(out, /\bgrounding_kind\b/);
+  assert.match(out, /notary/i);
+  // The three grounding forms are all named.
+  for (const kind of ['quote', 'reproduction', 'invariant']) {
+    assert.match(out, new RegExp(`\`${kind}\``), `missing grounding form: ${kind}`);
+  }
+});
+
+test('rendered workflow templates carry the grounding instruction into the CI prompt', async () => {
+  for (const tmpl of ['workflow.yml.tmpl', 'workflow-ts.yml.tmpl', 'workflow-py.yml.tmpl']) {
+    const out = await renderFile(join(TEMPLATES, tmpl), {
+      REVIEW_PROMPT: reviewPrompt({ projectDescription: 'p', language: templateLanguage(tmpl) }),
+    });
+    assert.match(out, /Grounding \(REQUIRED on every 🔴 critical/, `${tmpl}: missing grounding block`);
+    assert.match(out, /grounding_kind/, `${tmpl}: missing grounding_kind`);
+  }
+});
+
 // --- 0.A.3: per-section budgets (v0.6.4) ---
 // The prompt instructs Claude to cap per-PR fetches with `head -c
 // $MAX_DIFF_BYTES` etc. Combined with the env vars + Bash(head:*)


### PR DESCRIPTION
## ZP3 — route the self-hosted GitHub Action through the notary

Local max mode already notarizes reviews (ZP2), but the self-hosted GitHub Action
posted only a **self-attested** `clud-bug-review` check — so the un-forgeable notary
trust boundary never covered the Action path. This PR closes that gap.

### Bundle assembly (`build-bundle`)

New `clud-bug build-bundle` verb (`src/cli/build-bundle.ts`) reads the review's
`structured_output` (`ReviewData`) via `--stdin` and transforms it into a
`NotaryBundle`:

- **Flattens** `critical_findings` / `minor_findings` / `preexisting_findings` into
  `NotaryFinding[]` — severity names map 1:1 — carrying `file` / `line` /
  `grounding` / `grounding_kind` through.
- **Verdict is derived from `critical_findings.length > 0`**, NOT the model's
  self-reported `summary_counts`. This matches `validateConsistency`, so a bundle we
  build never trips the notary's own consistency check on a miscounted header.
- **Coverage is a fresh `gh pr diff <pr> --name-only`** (GitHub's ground-truth changed
  files), NOT the incremental `$CHANGED` scan set — the notary set-diffs coverage
  against GitHub's full changed files (③), so a partial view can't be certified complete.
- Flags: `--repo --pr --sha --recipe-version`; emits bundle JSON to stdout.

### Base-ref trust guard (the security-critical bit)

The new **"Notarize review"** workflow step (all 3 templates) pipes
`structured_output → build-bundle → post-check-run --bundle --source ci`. `strictMode`
is resolved from the **base ref** (`git show "origin/${BASE_REF}:.claude/skills/.clud-bug.json"`,
reusing the exact block the Formal-review + strict-mode-gate steps use) and passed as
`--strict` / `--no-strict`. A PR therefore **cannot** set `notary:false` /
`strictMode:false` in its own head to defang the check.

`post-check-run` was also fixed to honor an explicit `--source ci` on the
bundle-fallback path (it was hard-coded `local`), so a CI-originated self-attested
fallback tags itself correctly.

### `continue-on-error` coexistence with strict-mode-gate

The Notarize step is `continue-on-error: true` and gated on a non-empty payload — it can
**never** be the source of job failure. The **Strict-mode gate** step remains the
authoritative merge backstop; the notarize step deliberately does **not** double-gate it,
so a notary outage or a fallback can't turn a clean review red on its own.

### Grounding on CI criticals (hard prerequisite)

`reviewPrompt()` now mandates `grounding` + `grounding_kind` on every 🔴 critical.
Without it, `validateGrounding` rejects every CI-found critical and the whole bundle is
notary-rejected. The ~1.5 KB block bumped the prompt byte/line caps
(17500→18700 bytes, 365→385 lines) — documented in `test/golden/byte-budget.json` +
CHANGELOG.

### `init` installs both surfaces by default

`--with-hooks` is now ON by default (added `--no-hooks` to opt out), so a fresh
`clud-bug init` scaffolds BOTH the max-mode commit hook AND the GitHub Action enforcer.
`--local-only` keeps its meaning (max mode, no Action).

### Deferred to follow-up

- **CODEOWNERS** entry for the notary-touching workflow paths.
- The **`::warning::` annotation** surfacing a notary rejection in the Actions run
  summary (today a rejection is a silent no-post; the review still stands via the gate).

### Verification

- `npx tsc -p tsconfig.json --noEmit` — clean.
- `npm test` — **1005 passed / 0 failed** (48 files), including new build-bundle
  transform tests, the CI-prompt grounding assertion, and the `post-check-run --source`
  dry-run tests.
- `npm run test:fixtures` — 5/5 golden fixtures pass.
- `actionlint` on all 3 regenerated `.ci-rendered/*.yml` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnvyVPvKfy81AgcS6NFTku
