### PR TITLE
chore: bump to 0.7.0-rc.25 — publishes ZP2 (notary default-on) + ZP3 (Action→notary)

### DIFF
--- a/.ci-rendered/workflow-py.yml
+++ b/.ci-rendered/workflow-py.yml
@@ -667,7 +667,7 @@ jobs:
           THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 render --stdin)
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 render --stdin)
           CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
           gh pr comment "$PR_NUMBER" --body "$BODY
 
@@ -704,12 +704,12 @@ jobs:
           fi
 
           printf '%s\n' "$STRUCTURED" \
-            | npx --yes clud-bug@0.7.0-rc.24 build-bundle \
+            | npx --yes clud-bug@0.7.0-rc.25 build-bundle \
                 --repo "$REPO" --pr "$PR_NUMBER" --sha "$HEAD_SHA" \
-                --recipe-version "ci-0.7.0-rc.24" \
+                --recipe-version "ci-0.7.0-rc.25" \
             > bundle.json
 
-          npx --yes clud-bug@0.7.0-rc.24 post-check-run \
+          npx --yes clud-bug@0.7.0-rc.25 post-check-run \
             --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG" "$NOTARY_FLAG"
 
       # Wave 5a (D.2.X) — see workflow.yml.tmpl for design notes.
@@ -724,7 +724,7 @@ jobs:
           STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
         run: |
           set -euo pipefail
-          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 post-inline-threads --stdin)
+          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 post-inline-threads --stdin)
           echo "::notice title=inline-threads::$RESULT"
 
       # Wave 5b (D.2.6) — see workflow.yml.tmpl for design notes.
@@ -743,7 +743,7 @@ jobs:
           CLUD_BUG_RESOLVE_PAT: ${{ secrets.CLUD_BUG_RESOLVE_PAT }}
         run: |
           set -euo pipefail
-          RESULT=$(npx --yes clud-bug@0.7.0-rc.24 resolve-threads)
+          RESULT=$(npx --yes clud-bug@0.7.0-rc.25 resolve-threads)
           echo "::notice title=auto-resolve::$RESULT"
 
       # v0.6.29 / Component 4 — see workflow.yml.tmpl for design notes.
@@ -758,7 +758,7 @@ jobs:
           if [ ! -f .claude/skills/.clud-bug.json ]; then
             echo '{"version": 1}' > .claude/skills/.clud-bug.json
           fi
-          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 update-skill-usage --stdin
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 update-skill-usage --stdin
           echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
 
       - name: Upload skill-usage artifact
@@ -829,7 +829,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.24
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.25
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].
@@ -864,7 +864,7 @@ jobs:
           fi
           export STRICT_MODE
           VERDICT=$(printf '%s\n' "$STRUCTURED" \
-            | npx --yes clud-bug@0.7.0-rc.24 select-review-event --stdin \
+            | npx --yes clud-bug@0.7.0-rc.25 select-review-event --stdin \
             | tail -n1)
           VERDICT="${VERDICT:-skip}"
           echo "::notice title=Clud Bug 🐛::Formal review verdict: $VERDICT (strictMode=$STRICT_MODE, author_assoc=$PR_AUTHOR_ASSOCIATION)"

--- a/.ci-rendered/workflow-ts.yml
+++ b/.ci-rendered/workflow-ts.yml
@@ -668,7 +668,7 @@ jobs:
           THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 render --stdin)
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 render --stdin)
           CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
           gh pr comment "$PR_NUMBER" --body "$BODY
 
@@ -705,12 +705,12 @@ jobs:
           fi
 
           printf '%s\n' "$STRUCTURED" \
-            | npx --yes clud-bug@0.7.0-rc.24 build-bundle \
+            | npx --yes clud-bug@0.7.0-rc.25 build-bundle \
                 --repo "$REPO" --pr "$PR_NUMBER" --sha "$HEAD_SHA" \
-                --recipe-version "ci-0.7.0-rc.24" \
+                --recipe-version "ci-0.7.0-rc.25" \
             > bundle.json
 
-          npx --yes clud-bug@0.7.0-rc.24 post-check-run \
+          npx --yes clud-bug@0.7.0-rc.25 post-check-run \
             --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG" "$NOTARY_FLAG"
 
       # Wave 5a (D.2.X) — see workflow.yml.tmpl for design notes.
@@ -725,7 +725,7 @@ jobs:
           STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
         run: |
           set -euo pipefail
-          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 post-inline-threads --stdin)
+          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 post-inline-threads --stdin)
           echo "::notice title=inline-threads::$RESULT"
 
       # Wave 5b (D.2.6) — see workflow.yml.tmpl for design notes.
@@ -744,7 +744,7 @@ jobs:
           CLUD_BUG_RESOLVE_PAT: ${{ secrets.CLUD_BUG_RESOLVE_PAT }}
         run: |
           set -euo pipefail
-          RESULT=$(npx --yes clud-bug@0.7.0-rc.24 resolve-threads)
+          RESULT=$(npx --yes clud-bug@0.7.0-rc.25 resolve-threads)
           echo "::notice title=auto-resolve::$RESULT"
 
       # v0.6.29 / Component 4 — see workflow.yml.tmpl for design notes.
@@ -759,7 +759,7 @@ jobs:
           if [ ! -f .claude/skills/.clud-bug.json ]; then
             echo '{"version": 1}' > .claude/skills/.clud-bug.json
           fi
-          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 update-skill-usage --stdin
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 update-skill-usage --stdin
           echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
 
       - name: Upload skill-usage artifact
@@ -830,7 +830,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.24
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.25
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].
@@ -865,7 +865,7 @@ jobs:
           fi
           export STRICT_MODE
           VERDICT=$(printf '%s\n' "$STRUCTURED" \
-            | npx --yes clud-bug@0.7.0-rc.24 select-review-event --stdin \
+            | npx --yes clud-bug@0.7.0-rc.25 select-review-event --stdin \
             | tail -n1)
           VERDICT="${VERDICT:-skip}"
           echo "::notice title=Clud Bug 🐛::Formal review verdict: $VERDICT (strictMode=$STRICT_MODE, author_assoc=$PR_AUTHOR_ASSOCIATION)"

--- a/.ci-rendered/workflow.yml
+++ b/.ci-rendered/workflow.yml
@@ -884,7 +884,7 @@ jobs:
           THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 render --stdin)
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 render --stdin)
           CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
           gh pr comment "$PR_NUMBER" --body "$BODY
 
@@ -941,12 +941,12 @@ jobs:
           fi
 
           printf '%s\n' "$STRUCTURED" \
-            | npx --yes clud-bug@0.7.0-rc.24 build-bundle \
+            | npx --yes clud-bug@0.7.0-rc.25 build-bundle \
                 --repo "$REPO" --pr "$PR_NUMBER" --sha "$HEAD_SHA" \
-                --recipe-version "ci-0.7.0-rc.24" \
+                --recipe-version "ci-0.7.0-rc.25" \
             > bundle.json
 
-          npx --yes clud-bug@0.7.0-rc.24 post-check-run \
+          npx --yes clud-bug@0.7.0-rc.25 post-check-run \
             --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG" "$NOTARY_FLAG"
 
       # v0.7.0-rc.7 / Wave 5a (D.2.X): post per-finding inline review
@@ -975,7 +975,7 @@ jobs:
           STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
         run: |
           set -euo pipefail
-          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 post-inline-threads --stdin)
+          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 post-inline-threads --stdin)
           echo "::notice title=inline-threads::$RESULT"
 
       # v0.7.0-rc.8 / Wave 5b (D.2.6): on fix-push events
@@ -1009,7 +1009,7 @@ jobs:
           CLUD_BUG_RESOLVE_PAT: ${{ secrets.CLUD_BUG_RESOLVE_PAT }}
         run: |
           set -euo pipefail
-          RESULT=$(npx --yes clud-bug@0.7.0-rc.24 resolve-threads)
+          RESULT=$(npx --yes clud-bug@0.7.0-rc.25 resolve-threads)
           echo "::notice title=auto-resolve::$RESULT"
 
       # v0.6.29 / Component 4: pipe structured_output through
@@ -1038,7 +1038,7 @@ jobs:
           if [ ! -f .claude/skills/.clud-bug.json ]; then
             echo '{"version": 1}' > .claude/skills/.clud-bug.json
           fi
-          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.24 update-skill-usage --stdin
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 update-skill-usage --stdin
           echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
 
       - name: Upload skill-usage artifact
@@ -1150,7 +1150,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.24
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.25
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow
@@ -1228,7 +1228,7 @@ jobs:
           # caller-side error (malformed JSON, missing env), so we never
           # need a fallback in shell.
           VERDICT=$(printf '%s\n' "$STRUCTURED" \
-            | npx --yes clud-bug@0.7.0-rc.24 select-review-event --stdin \
+            | npx --yes clud-bug@0.7.0-rc.25 select-review-event --stdin \
             | tail -n1)
           VERDICT="${VERDICT:-skip}"
 

--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.24
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.25
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,32 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.7.0-rc.25] — 2026-07-25
+
+**The mode-parity release: the notary now works in every mode.** Ships ZP2 + ZP3 — until
+this rc, both were merged to `main` but unpublished, so local max mode and the self-hosted
+Action could not reach the notary at all.
+
+> **Note on history:** rc.16–rc.24 shipped without CHANGELOG entries. Rather than
+> reconstruct nine releases from memory (and risk recording them wrong), the gap is left
+> explicit; `git log` between the `v0.7.0-rc.15` and `v0.7.0-rc.25` tags is the accurate
+> record for that window. Entries resume here.
+
 ### Added
+
+- **ZP2 — the notary is DEFAULT-ON for local max mode.** New `src/core/notary-config.ts`
+  (`readNotaryConfig`, `DEFAULT_NOTARY_URL = https://app.cludbug.dev`) is the shared resolver
+  for both `post-check-run` (the submit path) and `review-prompt` (§5 recipe rendering), so
+  policy cannot fork between them. Precedence: an explicit `--notary` / `--no-notary` flag
+  overrides everything → `.clud-bug.json` `"notary": false` opts a repo out → the
+  `CLUD_BUG_NOTARY_URL` env var overrides the origin → otherwise the hosted default.
+  A degenerate env value (`/`, `///`) normalizes to empty and falls through to the default —
+  it is never mistaken for the opt-out. The §5 recipe now renders **deterministically** from
+  the resolved value (exactly one of bundle-submit or self-attest, never an env check the
+  agent has to evaluate itself).
+- **`--notary` / `--no-notary` on `post-check-run`** — mirrors `--strict` / `--no-strict`.
+  CI derives it from the **base ref**, so a PR cannot disable independent certification by
+  setting `"notary": false` in its own head manifest.
 
 - **ZP3 — self-hosted Action → notary.** The self-hosted GitHub Action now routes its
   review through the notary, at parity with local max mode.

--- a/docs/decisions-branches/chore-bump-rc25.md
+++ b/docs/decisions-branches/chore-bump-rc25.md
@@ -1,0 +1,14 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-25 14:35 - chore: bump to 0.7.0-rc.25 (publishes ZP2 notary default-on + ZP3 Action→notary)
+
+**Reasoning:** ZP2 (#237) and ZP3 (#238) merged to main but npm dist-tag next was still rc.24, so local max mode and the self-hosted Action could not reach the notary AT ALL for any consumer — including our own dogfood, which floats @next (the Action's notarize step silently no-ops because build-bundle does not exist in rc.24). This is the single highest-leverage unblock on the launch critical path (clud-bug#243). Release discipline requires the strict-mode-gate composite pin in all 3 workflow templates + action.yml to move lock-step with package.json, so those bump together and the .ci-rendered goldens are regenerated.
+
+**Alternatives considered:** Publish from main without a version bump (rejected: the tag drives OIDC trusted-publish off package.json; version must match the tag), Reconstruct CHANGELOG rc.16-rc.24 retroactively (rejected: nine releases from memory risks recording them WRONG; the gap is marked explicitly and git log between tags is the accurate record)
+
+**Implications:**
+- After merge, pushing tag v0.7.0-rc.25 triggers OIDC npm-publish -> dist-tag next; then clud-bug update our repos so local+Action modes go live
+- CHANGELOG entries resume at rc.25; the rc.16-rc.24 gap is documented as a gap rather than fabricated
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (28 decisions)
+## 2026-07 (29 decisions)
 
-- **2026-07-17** — ZP3 fix (critical): base-ref-guard the notary toggle — a PR could self-disable independent certification from its own HEAD *(feat-zp3-action-notary)* — [decisions-branches/feat-zp3-action-notary.md](decisions-branches/feat-zp3-action-notary.md)
-- *... 26 more decisions ...*
+- **2026-07-25** — chore: bump to 0.7.0-rc.25 (publishes ZP2 notary default-on + ZP3 Action→notary) *(chore-bump-rc25)* — [decisions-branches/chore-bump-rc25.md](decisions-branches/chore-bump-rc25.md)
+- *... 27 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.24",
+  "version": "0.7.0-rc.25",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -452,7 +452,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.24
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.25
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -452,7 +452,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.24
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.25
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -776,7 +776,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.24
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.25
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow


### PR DESCRIPTION
**The single highest-leverage unblock on the launch critical path** (clud-bug#243 §1).

ZP2 (#237) and ZP3 (#238) have been sitting on `main` **unpublished** — npm `next` is still **rc.24**. Consequence: **local max mode and the self-hosted Action cannot reach the notary at all**, for anyone, including our own dogfood (which floats `@next`). The Action's notarize step silently no-ops, because `build-bundle` doesn't exist in rc.24.

## What's in it
- **ZP2** — notary DEFAULT-ON for local max mode (`readNotaryConfig` resolver, `.clud-bug.json` `"notary": false` opt-out, `CLUD_BUG_NOTARY_URL` override, deterministic §5 recipe).
- **ZP3** — self-hosted Action → notary (`build-bundle` verb, base-ref-guarded notarize step in all 3 templates, `init` installs hook + Action) plus the `--notary`/`--no-notary` base-ref guard that closes the self-disable-from-HEAD hole.

## Release discipline
`package.json` and the `strict-mode-gate` composite pin move **lock-step** (enforced by `test/release-discipline.test.js`), so this bumps all four pin sites — 3 workflow templates + `action.yml` — and regenerates the 3 `.ci-rendered` goldens. The goldens' larger diff is expected: `{{CLUD_BUG_VERSION}}` renders into ~9 call sites per workflow (`render`, `build-bundle`, `--recipe-version`, `post-check-run`, `post-inline-threads`, …), all bumped together.

## CHANGELOG
Entries **resume** at rc.25 with ZP2 + ZP3 documented. rc.16–rc.24 shipped without entries; rather than reconstruct nine releases from memory and risk recording them wrong, **the gap is marked explicitly** and `git log` between the `v0.7.0-rc.15` and `v0.7.0-rc.25` tags is named as the accurate record for that window.

## Verification
`npm test` **1009 passed** (48 files) · `test:fixtures` **5/5** · `actionlint` clean on all 3 regenerated goldens · `npm run build` clean · lock-step check confirms all four pin sites at `0.7.0-rc.25` with no stale `rc.24` in any live surface.

**After merge:** push tag `v0.7.0-rc.25` → OIDC trusted-publish → dist-tag `next`, then `clud-bug update` our repos so local + Action modes actually go live.