### PR TITLE
Emit usage[<slug>] in SPEC §1.12.1 shape (§17 interop item 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ clud-bug refresh                                    # re-query skills.sh, diff v
 
 Skills are tracked in `.claude/skills/.clud-bug.json` (a small manifest). Anything in `.claude/skills/` that *isn't* in the manifest is treated as your custom work and never modified by `clud-bug` commands.
 
+The manifest's `usage[<slug>].citations` counter is emitted in the [protocol SPEC §1.12.1](https://github.com/thrillmade/protocol) shape and is consumed by the [agent-skills](https://github.com/thrillmade/agent-skills) skill census as its "which skills actually fire in review" signal.
+
 ## Adding your own skills
 
 Drop any `.md` file into `.claude/skills/<your-skill>/SKILL.md` — Claude Code auto-discovers it on the next PR. Same format as skills from skills.sh:

--- a/docs/decisions-branches/feat-usage-citations.md
+++ b/docs/decisions-branches/feat-usage-citations.md
@@ -1,0 +1,15 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-25 15:53 - Emit usage[<slug>] in SPEC protocol §1.12.1 shape (§17 interop item 3)
+
+**Reasoning:** agent-skills' skill census reads usage[<slug>].citations as its §17.3 'usage citations' signal but our emission (v0.6.29) never matched the SPEC shape: last_cited was written as a literal null when unset (SPEC requires the key be OMITTED, not null) and timestamps carried millisecond precision instead of the required second-precision ISO-8601. A near-miss shape looked wired but wouldn't parse cleanly for a strict consumer. Also added the missing last_loaded counter-timestamp (loads has no last-fired marker today).
+
+**Alternatives considered:** Leave the shape as-is and let agent-skills special-case null/ms-precision on read, Bump manifest to SPEC schema v2 wholesale in this change
+
+**Implications:**
+- mergeSkillUsage now normalizes timestamps via formatSpecTimestamp (strips ms, omits key when unset) and independently tracks last_loaded alongside last_cited
+- Legacy last_cited: null entries self-heal to omitted on their next merge — no migration script needed
+- Manifest stays at version 1 in this repo; the v1->v2 SPEC schema bump (reviewContext, invariants, catalogSources, etc.) is out of scope for this interop item and left for a separate change
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (30 decisions)
+## 2026-07 (31 decisions)
 
-- **2026-07-25** — Fix commit-review hook coverage holes: worktree commits, --no-verify, over-firing (#240) and dead-review markers (#239) *(fix-hook-coverage-239-240)* — [decisions-branches/fix-hook-coverage-239-240.md](decisions-branches/fix-hook-coverage-239-240.md)
-- *... 28 more decisions ...*
+- **2026-07-25** — Emit usage[<slug>] in SPEC protocol §1.12.1 shape (§17 interop item 3) *(feat-usage-citations)* — [decisions-branches/feat-usage-citations.md](decisions-branches/feat-usage-citations.md)
+- *... 29 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -52,6 +52,7 @@ export {
 export {
   computeSkillUsageDelta,
   mergeSkillUsage,
+  formatSpecTimestamp,
   assessSkillHealth,
   formatHealthDashboard,
   DEFAULT_GH_RUNNER,

--- a/src/cli/skill-usage.ts
+++ b/src/cli/skill-usage.ts
@@ -31,6 +31,29 @@
 //
 // No automation acts on this output. It's a READ-ONLY dashboard.
 // Humans read; humans decide; humans act.
+//
+// SPEC §1.12.1 shape (v0.7.0, §17 interop item 3) — the `usage[<slug>]`
+// entry we emit into `.claude/skills/.clud-bug.json` MUST match:
+//
+//   "usage": {
+//     "<slug>": {
+//       "loads": 0,
+//       "citations": 0,
+//       "last_cited": "YYYY-MM-DDTHH:MM:SSZ",
+//       "last_loaded": "YYYY-MM-DDTHH:MM:SSZ"
+//     }
+//   }
+//
+// Two normative constraints from §1.12.1 that are easy to near-miss:
+//   - "`usage[<slug>].last_*` timestamps MUST be ISO-8601 UTC with a
+//     `Z` suffix and second precision." — `Date#toISOString()` emits
+//     millisecond precision, so `formatSpecTimestamp` below truncates.
+//   - "Unset is represented by omitting the key, not by an empty
+//     string." — we extend this to "not by `null`" too, since a bare
+//     `null` is neither an ISO-8601 string nor an absent key; a
+//     consumer parsing this field as a Date will choke on it. Entries
+//     with no citation/load event yet simply omit `last_cited` /
+//     `last_loaded` rather than carrying a `null` placeholder.
 
 import { spawn } from 'node:child_process';
 
@@ -40,11 +63,32 @@ export interface SkillDelta {
   citations: number;
 }
 
-// Per-skill usage record (accumulated across reviews).
+// Per-skill usage record (accumulated across reviews). `last_cited` /
+// `last_loaded` are OPTIONAL — per SPEC §1.12.1, "unset" means the key
+// is absent, never `null` or `""`.
 export interface SkillUsageEntry {
   loads: number;
   citations: number;
-  last_cited: string | null;
+  last_cited?: string;
+  last_loaded?: string;
+}
+
+/**
+ * Normalize a timestamp to the SPEC §1.12.1 shape: ISO-8601 UTC, `Z`
+ * suffix, SECOND precision (no milliseconds). Returns `undefined` for
+ * anything that doesn't parse to a valid instant, so callers can treat
+ * "no valid timestamp" the same as "omit the key."
+ *
+ * Idempotent: re-normalizing an already-second-precision timestamp
+ * (or one produced by a prior call) yields the same string.
+ */
+export function formatSpecTimestamp(input: string | null | undefined): string | undefined {
+  if (typeof input !== 'string' || input.length === 0) return undefined;
+  const ms = Date.parse(input);
+  if (Number.isNaN(ms)) return undefined;
+  // toISOString() always includes milliseconds (".SSSZ") — strip them
+  // down to second precision per SPEC §1.12.1.
+  return new Date(ms).toISOString().replace(/\.\d{3}Z$/, 'Z');
 }
 
 // Map keyed by skill slug.
@@ -129,7 +173,15 @@ export function computeSkillUsageDelta(reviewJson: unknown): SkillDeltaMap {
  *   - existing.citations + delta.citations → new.citations
  *   - last_cited updates only when delta.citations > 0 (i.e., cited
  *     in THIS review). Stays at the prior value otherwise.
+ *   - last_loaded updates only when delta.loads > 0 (SPEC §1.12.1
+ *     tracks loads and citations as independent counters, each with
+ *     its own `last_*` timestamp).
  *   - New skills (not in existing) get initialized fresh.
+ *   - Both `last_*` fields are normalized to SPEC §1.12.1 shape
+ *     (second-precision ISO-8601, `Z` suffix) via `formatSpecTimestamp`,
+ *     and OMITTED entirely (not `null`) while unset — this also cures
+ *     any legacy `last_cited: null` entries written before this fix on
+ *     their next merge.
  */
 export function mergeSkillUsage(
   existing: unknown,
@@ -143,26 +195,36 @@ export function mergeSkillUsage(
   // Copy all existing skills first (preserve skills NOT in this delta).
   for (const [slug, entry] of Object.entries(safeExisting)) {
     if (entry && typeof entry === 'object') {
-      const e = entry as { loads?: unknown; citations?: unknown; last_cited?: unknown };
-      result[slug] = {
+      const e = entry as { loads?: unknown; citations?: unknown; last_cited?: unknown; last_loaded?: unknown };
+      const row: SkillUsageEntry = {
         loads: Number(e.loads) || 0,
         citations: Number(e.citations) || 0,
-        last_cited: typeof e.last_cited === 'string' ? e.last_cited : null,
       };
+      const lastCited = formatSpecTimestamp(typeof e.last_cited === 'string' ? e.last_cited : undefined);
+      if (lastCited) row.last_cited = lastCited;
+      const lastLoaded = formatSpecTimestamp(typeof e.last_loaded === 'string' ? e.last_loaded : undefined);
+      if (lastLoaded) row.last_loaded = lastLoaded;
+      result[slug] = row;
     }
   }
 
   // Merge delta.
+  const ts = formatSpecTimestamp(timestamp);
   for (const [slug, d] of Object.entries(delta || {})) {
     let row = result[slug];
     if (!row) {
-      row = { loads: 0, citations: 0, last_cited: null };
+      row = { loads: 0, citations: 0 };
       result[slug] = row;
     }
-    row.loads += Number(d.loads) || 0;
-    row.citations += Number(d.citations) || 0;
-    if ((Number(d.citations) || 0) > 0 && timestamp) {
-      row.last_cited = timestamp;
+    const loadsDelta = Number(d.loads) || 0;
+    const citationsDelta = Number(d.citations) || 0;
+    row.loads += loadsDelta;
+    row.citations += citationsDelta;
+    if (loadsDelta > 0 && ts) {
+      row.last_loaded = ts;
+    }
+    if (citationsDelta > 0 && ts) {
+      row.last_cited = ts;
     }
   }
 

--- a/test/skill-usage.test.js
+++ b/test/skill-usage.test.js
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict';
 import {
   computeSkillUsageDelta,
   mergeSkillUsage,
+  formatSpecTimestamp,
   assessSkillHealth,
   formatHealthDashboard,
 } from '../src/cli/skill-usage.js';
@@ -129,6 +130,81 @@ test('mergeSkillUsage: does not mutate inputs', () => {
   mergeSkillUsage(existing, delta, '2026-05-30T00:00:00Z');
   assert.equal(existing.X.loads, 1, 'input untouched');
   assert.equal(existing.X.citations, 0);
+});
+
+
+// ---------------------------------------------------------------------------
+// formatSpecTimestamp — SPEC §1.12.1 "ISO-8601 UTC, Z suffix, second
+// precision" normalization for usage[<slug>].last_cited / last_loaded.
+// ---------------------------------------------------------------------------
+
+test('formatSpecTimestamp: strips milliseconds to second precision', () => {
+  assert.equal(formatSpecTimestamp('2026-05-30T12:00:00.123Z'), '2026-05-30T12:00:00Z');
+});
+
+test('formatSpecTimestamp: already-second-precision input is idempotent', () => {
+  assert.equal(formatSpecTimestamp('2026-05-30T12:00:00Z'), '2026-05-30T12:00:00Z');
+});
+
+test('formatSpecTimestamp: invalid / empty / null / undefined all resolve to undefined (omit-key signal)', () => {
+  assert.equal(formatSpecTimestamp('not-a-date'), undefined);
+  assert.equal(formatSpecTimestamp(''), undefined);
+  assert.equal(formatSpecTimestamp(null), undefined);
+  assert.equal(formatSpecTimestamp(undefined), undefined);
+});
+
+
+// ---------------------------------------------------------------------------
+// SPEC §1.12.1 shape conformance — `usage[<slug>]` MUST match:
+//   { "loads": 0, "citations": 0, "last_cited": "...Z", "last_loaded": "...Z" }
+// with last_cited / last_loaded OMITTED (not null) while unset, and
+// second-precision ISO-8601 timestamps when set. This is the shape the
+// agent-skills census (§17.3 "usage citations" signal) reads.
+// ---------------------------------------------------------------------------
+
+test('SPEC §1.12.1: fresh skill with a citation gets loads, citations, last_cited, last_loaded — no null placeholders', () => {
+  const delta = { 'critical-issues-only': { loads: 1, citations: 1 } };
+  const result = mergeSkillUsage({}, delta, '2026-07-24T10:15:30.456Z');
+  const entry = result['critical-issues-only'];
+
+  assert.equal(entry.loads, 1);
+  assert.equal(entry.citations, 1);
+  assert.equal(entry.last_cited, '2026-07-24T10:15:30Z', 'second precision, Z suffix');
+  assert.equal(entry.last_loaded, '2026-07-24T10:15:30Z');
+  assert.equal('last_cited' in entry, true);
+  assert.notEqual(entry.last_cited, null, 'omitted-when-unset, never null — but here it IS set');
+});
+
+test('SPEC §1.12.1: a load-only skill (never cited) OMITS last_cited entirely — not null, not ""', () => {
+  const delta = { 'never-cited-skill': { loads: 1, citations: 0 } };
+  const result = mergeSkillUsage({}, delta, '2026-07-24T10:15:30Z');
+  const entry = result['never-cited-skill'];
+
+  assert.equal(entry.loads, 1);
+  assert.equal(entry.citations, 0);
+  assert.equal(entry.last_loaded, '2026-07-24T10:15:30Z');
+  assert.equal('last_cited' in entry, false, 'unset key is OMITTED per SPEC §1.12.1, not present as null');
+  assert.equal(JSON.stringify(entry).includes('last_cited'), false, 'confirms omission survives serialization');
+});
+
+test('SPEC §1.12.1: a legacy last_cited:null entry is cured (omitted) on next merge', () => {
+  // Simulates reading an old-shape .clud-bug.json written before this fix.
+  const existing = { 'legacy-skill': { loads: 3, citations: 0, last_cited: null } };
+  const result = mergeSkillUsage(existing, {}, null);
+  assert.equal('last_cited' in result['legacy-skill'], false, 'null is normalized away, not round-tripped');
+});
+
+test('SPEC §1.12.1: citations counter is truthful — only skills actually cited get citations > 0', () => {
+  // A skill that loaded but was never cited in any finding bucket MUST
+  // report citations: 0, not a fabricated non-zero value.
+  const delta = computeSkillUsageDelta({
+    per_skill_scan: [
+      { skill: 'loaded-not-cited', outcome: 'scanned, no findings' },
+    ],
+  });
+  const result = mergeSkillUsage({}, delta, '2026-07-24T00:00:00Z');
+  assert.equal(result['loaded-not-cited'].citations, 0);
+  assert.equal(result['loaded-not-cited'].loads, 1);
 });
 
 

--- a/test/update-skill-usage.test.js
+++ b/test/update-skill-usage.test.js
@@ -111,3 +111,49 @@ test('update-skill-usage: skips with warning when .clud-bug.json missing', async
   assert.equal(r.status, 0, r.stderr);
   assert.match(r.stderr, /no \.clud-bug\.json/);
 });
+
+// ---------------------------------------------------------------------------
+// SPEC §1.12.1 round-trip — emit through the real CLI, then parse the
+// written manifest exactly as an independent consumer (the agent-skills
+// census, per §17.3's "usage citations" signal) would: read the raw
+// bytes off disk, JSON.parse them, and pull `usage[<slug>].citations`.
+// This is the interop point §17 item 3 exists to unblock.
+// ---------------------------------------------------------------------------
+
+test('SPEC §1.12.1 round-trip: emitted usage[<slug>] survives an independent JSON.parse with the exact shape', async () => {
+  const dir = await makeWorkspace();
+  await writeFile(join(dir, '.claude/skills/.clud-bug.json'), '{"version": 1}');
+  const payload = JSON.stringify({
+    per_skill_scan: [
+      { skill: 'critical-issues-only', outcome: 'scanned 3 files' },
+      { skill: 'evidence-based-review', outcome: '0 findings' },
+    ],
+    critical_findings: [
+      { skill: 'critical-issues-only', summary: 'nullderef', file: 'a.js', line: 12 },
+    ],
+  });
+  const r = run(dir, ['update-skill-usage', '--stdin'], { input: payload });
+  assert.equal(r.status, 0, r.stderr);
+
+  // Read the manifest bytes fresh (independent of any in-process state)
+  // and parse them the way a consumer implementation would.
+  const rawBytes = await readFile(join(dir, '.claude/skills/.clud-bug.json'), 'utf8');
+  const consumerView = JSON.parse(rawBytes);
+
+  // 1. Cited skill: full §1.12.1 shape present, both timestamps set,
+  //    second-precision ISO-8601 with a Z suffix.
+  const cited = consumerView.usage['critical-issues-only'];
+  assert.equal(cited.loads, 1);
+  assert.equal(cited.citations, 1, 'the census reads THIS field for the "usage citations" signal');
+  assert.match(cited.last_cited, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/, 'ISO-8601 UTC, Z suffix, second precision');
+  assert.match(cited.last_loaded, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+
+  // 2. Loaded-but-never-cited skill: citations truthfully 0, and
+  //    last_cited is OMITTED (not null, not "") — the near-miss this
+  //    fix specifically guards against, since a consumer parsing
+  //    last_cited as a Date would choke on either alternative.
+  const loadedOnly = consumerView.usage['evidence-based-review'];
+  assert.equal(loadedOnly.citations, 0);
+  assert.equal(Object.prototype.hasOwnProperty.call(loadedOnly, 'last_cited'), false);
+  assert.match(loadedOnly.last_loaded, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+});


### PR DESCRIPTION
## Summary

- Conforms our `usage[<slug>]` emission in `.claude/skills/.clud-bug.json` to protocol SPEC §1.12.1 exactly, so the agent-skills census (§17.3 "usage citations" signal) can parse it.
- Two near-miss gaps fixed:
  - `last_cited` / `last_loaded` are now **omitted** when unset, never a literal `null` (SPEC: "Unset is represented by omitting the key, not by an empty string" — a bare `null` is neither, and a strict Date-parsing consumer chokes on it).
  - Timestamps are normalized to **second-precision** ISO-8601 with a `Z` suffix (`Date#toISOString()` emits milliseconds; SPEC requires second precision).
- Adds the previously-missing `last_loaded` counter-timestamp (tracked independently of `last_cited`, mirroring how `loads` and `citations` are independent counters).
- Legacy manifests with `last_cited: null` self-heal to the omitted-key shape on their next `update-skill-usage` merge — no migration script needed.
- `citations` remains truthful: it is only ever non-zero for skills that actually appear in a finding bucket (`computeSkillUsageDelta`), never fabricated.

Out of scope (left for a separate change): bumping the manifest to SPEC schema v2 wholesale (`reviewContext`, `invariants`, `catalogSources`, etc.) — this PR only touches the `usage` block.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 1043 passed (49 files), up from the 1035 baseline (+8 new tests, 0 removed/weakened)
- [x] `npm run test:fixtures` — 5 passed, 0 failed
- [x] New unit tests assert the exact emitted JSON shape against SPEC §1.12.1 (`test/skill-usage.test.js`)
- [x] New round-trip test: emit via the real `update-skill-usage` CLI, re-read the manifest bytes off disk, `JSON.parse` as an independent consumer would, and assert `usage[<slug>].citations` / `last_cited` / `last_loaded` survive with the exact SPEC shape (`test/update-skill-usage.test.js`)
- [x] `templates/skills/**` untouched

Does not touch CI or merge anything — human approving review required per org policy.