### PR TITLE
ZP4: verdict-contract parity — canonical VERDICT_CONCLUSION_TABLE

### DIFF
--- a/docs/decisions-branches/feat-zp4-verdict-parity.md
+++ b/docs/decisions-branches/feat-zp4-verdict-parity.md
@@ -1,0 +1,14 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-25 16:11 - ZP4: verdict-contract parity — publish VERDICT_CONCLUSION_TABLE as the canonical (verdict,strictMode)->conclusion oracle
+
+**Reasoning:** clud-bug-app posts the clud-bug-review check from 3 places (deriveCheck here, deriveNotaryCheck, the webhook route) that must never disagree before Z6 can safely pin the check. deriveCheck's own mapping already matched the target contract; the gap was that nothing made the contract assertable outside this module, so clud-bug-app's notary + webhook paths had silently drifted (notary ignored strictMode entirely; the webhook posted success on any completed review regardless of critical findings).
+
+**Alternatives considered:** Export nothing and rely on prose docs in each repo (rejected: exactly how the drift happened once already), Duplicate the table by hand in clud-bug-app (done as a stopgap, but only this exported table is the source of truth going forward)
+
+**Implications:**
+- clud-bug-app cannot import VERDICT_CONCLUSION_TABLE yet — it pins its clud-bug npm dependency to 0.7.0-rc.23, which predates this export; the App-side parity test mirrors the same literal cases until that pin is bumped in a future release
+- check-verdict.ts's module doc no longer claims the hosted bot intentionally diverges — that divergence is retired in the companion clud-bug-app PR
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (31 decisions)
+## 2026-07 (32 decisions)
 
-- **2026-07-25** — Emit usage[<slug>] in SPEC protocol §1.12.1 shape (§17 interop item 3) *(feat-usage-citations)* — [decisions-branches/feat-usage-citations.md](decisions-branches/feat-usage-citations.md)
-- *... 29 more decisions ...*
+- **2026-07-25** — ZP4: verdict-contract parity — publish VERDICT_CONCLUSION_TABLE as the canonical (verdict,strictMode)->conclusion oracle *(feat-zp4-verdict-parity)* — [decisions-branches/feat-zp4-verdict-parity.md](decisions-branches/feat-zp4-verdict-parity.md)
+- *... 30 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/src/core/check-verdict.ts
+++ b/src/core/check-verdict.ts
@@ -5,16 +5,35 @@
 // The check name is HARD-CODED `clud-bug-review` everywhere — consumers attach
 // branch-protection rules by that exact string (see clud-bug-app/lib/check-runs.ts).
 //
-// CONCLUSION MODEL for the local + Action surfaces (this module):
+// ZP4 (verdict-contract parity): this is now THE canonical conclusion mapping
+// for ALL THREE surfaces that can post the `clud-bug-review` check —
+//   1. local CLI + self-hosted Action        → calls `deriveCheck` directly.
+//   2. the hosted notary (clud-bug-app)      → `lib/notary.ts`'s
+//      `deriveNotaryCheck` calls this SAME `deriveCheck` internally.
+//   3. the hosted bot's webhook (clud-bug-app) → `app/api/webhook/route.ts`
+//      derives a `ReviewVerdict` from the review outcome/coverage/findings and
+//      calls this SAME `deriveCheck`.
+//
+// Through ZP3 the hosted bot's webhook posted `success` on ANY completed
+// review regardless of critical findings, blocking merges only via a SEPARATE
+// `request_changes` formal review event — a documented, deliberate divergence
+// from this module. ZP4 retired that divergence: a check whose producers
+// disagree about what a verdict MEANS can't be safely pinned as a required
+// status (the inconsistency becomes un-forgeable), so all three surfaces now
+// agree on ONE conclusion for a given (verdict, strictMode). The formal-review
+// event on the hosted bot still fires ALONGSIDE this — both signals move in
+// lockstep now, neither replaces the other.
+//
+// CONCLUSION MODEL (identical across all three surfaces):
 //   clean              → success  (review ran, no critical findings)
 //   critical + strict  → failure  (BLOCKS merge — fix the criticals)
 //   critical + !strict → neutral  (advisory; does not block)
 //   failed             → neutral  (couldn't run; never blocks — add signal, not outages)
+//   unverified         → neutral  (ran, but coverage/verification couldn't be confirmed)
 //
-// This intentionally differs from the HOSTED bot, whose check is success-on-run
-// and whose strict-mode block is a separate `request_changes` formal review. In
-// local/Action mode there is no formal review, so the check IS the gate — its
-// conclusion reflects the findings directly.
+// See `VERDICT_CONCLUSION_TABLE` below for the exhaustive, test-asserted form
+// of this table — the cross-repo parity tests in clud-bug-app assert their
+// two surfaces against the same cases.
 
 /** The check name MUST match consumer branch-protection rules. Do not rename. */
 export const CLUD_BUG_CHECK_NAME = 'clud-bug-review';
@@ -103,3 +122,33 @@ export function normalizeVerdict(raw: string | undefined): ReviewVerdict {
   // Unknown/empty → 'failed' (safe: neutral check, never a false-green).
   return 'failed';
 }
+
+/**
+ * ZP4 — the exhaustive (verdict, strictMode) → conclusion contract, as a data
+ * table rather than prose, so it can be asserted directly instead of just
+ * documented. This module's own test iterates this table against `deriveCheck`
+ * (the canonical source); clud-bug-app's cross-producer parity test mirrors
+ * the SAME literal cases against `deriveNotaryCheck` and the webhook route,
+ * since the App's pinned `clud-bug` dependency can't import this constant
+ * directly across the npm version boundary (see the ZP4 PR description for
+ * the version-skew note).
+ *
+ * `strictMode: undefined` cases are omitted — `deriveCheck` treats an absent
+ * strictMode identically to `false` (see the destructuring default above);
+ * every producer that doesn't yet know the base-ref config resolves to that
+ * same safe default rather than inventing a third state.
+ */
+export const VERDICT_CONCLUSION_TABLE: ReadonlyArray<{
+  verdict: ReviewVerdict;
+  strictMode: boolean;
+  conclusion: CheckConclusion;
+}> = [
+  { verdict: 'clean', strictMode: false, conclusion: 'success' },
+  { verdict: 'clean', strictMode: true, conclusion: 'success' },
+  { verdict: 'critical', strictMode: true, conclusion: 'failure' },
+  { verdict: 'critical', strictMode: false, conclusion: 'neutral' },
+  { verdict: 'failed', strictMode: false, conclusion: 'neutral' },
+  { verdict: 'failed', strictMode: true, conclusion: 'neutral' },
+  { verdict: 'unverified', strictMode: false, conclusion: 'neutral' },
+  { verdict: 'unverified', strictMode: true, conclusion: 'neutral' },
+];

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -325,6 +325,7 @@ export {
   deriveCheck,
   normalizeVerdict,
   CLUD_BUG_CHECK_NAME,
+  VERDICT_CONCLUSION_TABLE,
   type ReviewVerdict,
   type CheckConclusion,
   type CheckSource,

--- a/test/check-verdict.test.js
+++ b/test/check-verdict.test.js
@@ -5,9 +5,29 @@ import { spawnSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { deriveCheck, normalizeVerdict, CLUD_BUG_CHECK_NAME } from '../src/core/index.js';
+import {
+  deriveCheck,
+  normalizeVerdict,
+  CLUD_BUG_CHECK_NAME,
+  VERDICT_CONCLUSION_TABLE,
+} from '../src/core/index.js';
 
 const CLI = join(dirname(dirname(fileURLToPath(import.meta.url))), 'bin', 'clud-bug.js');
+
+// ZP4 — verdict-contract parity. `VERDICT_CONCLUSION_TABLE` is the single
+// source of truth for the (verdict, strictMode) → conclusion mapping that ALL
+// THREE `clud-bug-review` producers (this module, the notary's
+// deriveNotaryCheck, the hosted webhook) must agree on. This suite pins
+// `deriveCheck` — the canonical implementation — against every row; the
+// clud-bug-app repo mirrors the SAME literal cases against its two producers.
+describe('VERDICT_CONCLUSION_TABLE — cross-producer parity oracle', () => {
+  it.each(VERDICT_CONCLUSION_TABLE)(
+    'verdict=$verdict strictMode=$strictMode → conclusion=$conclusion',
+    ({ verdict, strictMode, conclusion }) => {
+      expect(deriveCheck({ verdict, strictMode }).conclusion).toBe(conclusion);
+    },
+  );
+});
 
 describe('deriveCheck', () => {
   it('clean → success regardless of strict mode', () => {


### PR DESCRIPTION
## Summary

Gate to Z6: three code paths derive the `clud-bug-review` check's conclusion
(this repo's `deriveCheck`, clud-bug-app's `deriveNotaryCheck`, and
clud-bug-app's webhook route), and they must never disagree before the check
can be safely pinned as a required status.

Auditing all three found `deriveCheck` here already implements the correct
(verdict, strictMode) → conclusion contract (H3 + Phase R). The divergences
were entirely on the clud-bug-app side — see the companion PR. This PR:

- Exports `VERDICT_CONCLUSION_TABLE`, the exhaustive (verdict, strictMode) →
  conclusion truth table, as data rather than prose, so it's assertable
  directly instead of just documented.
- Adds a self-consistency test (`check-verdict.test.js`) asserting `deriveCheck`
  against every row of the table.
- Updates the module doc: it no longer claims the hosted bot intentionally
  diverges from this mapping — ZP4 retires that divergence (see the
  companion clud-bug-app PR).

No behavior change in this repo — `deriveCheck`'s mapping was already correct;
this PR makes the contract exportable and test-asserted so the companion PR's
producers can be pinned against it (and so future edits here can't silently
drift without failing a test).

## Companion PR

thrillmade/clud-bug-app#108 — unifies `deriveNotaryCheck` and the webhook
route's conclusion mapping to call this repo's `deriveCheck` (already
available at the pinned `0.7.0-rc.23`, no dependency bump needed), and adds
a cross-producer parity test.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 1043 passed (baseline 1035, +8)
- [x] `npm run test:fixtures` — 5 passed, 0 failed

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
https://claude.ai/code/session_01NnvyVPvKfy81AgcS6NFTku