### PR TITLE
chore: bump to 0.7.0-rc.26 — publishes ZP4 verdict parity + #239/#240 hook coverage + §17 citations

### DIFF
--- a/.ci-rendered/workflow-py.yml
+++ b/.ci-rendered/workflow-py.yml
@@ -667,7 +667,7 @@ jobs:
           THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 render --stdin)
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.26 render --stdin)
           CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
           gh pr comment "$PR_NUMBER" --body "$BODY
 
@@ -704,12 +704,12 @@ jobs:
           fi
 
           printf '%s\n' "$STRUCTURED" \
-            | npx --yes clud-bug@0.7.0-rc.25 build-bundle \
+            | npx --yes clud-bug@0.7.0-rc.26 build-bundle \
                 --repo "$REPO" --pr "$PR_NUMBER" --sha "$HEAD_SHA" \
-                --recipe-version "ci-0.7.0-rc.25" \
+                --recipe-version "ci-0.7.0-rc.26" \
             > bundle.json
 
-          npx --yes clud-bug@0.7.0-rc.25 post-check-run \
+          npx --yes clud-bug@0.7.0-rc.26 post-check-run \
             --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG" "$NOTARY_FLAG"
 
       # Wave 5a (D.2.X) — see workflow.yml.tmpl for design notes.
@@ -724,7 +724,7 @@ jobs:
           STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
         run: |
           set -euo pipefail
-          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 post-inline-threads --stdin)
+          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.26 post-inline-threads --stdin)
           echo "::notice title=inline-threads::$RESULT"
 
       # Wave 5b (D.2.6) — see workflow.yml.tmpl for design notes.
@@ -743,7 +743,7 @@ jobs:
           CLUD_BUG_RESOLVE_PAT: ${{ secrets.CLUD_BUG_RESOLVE_PAT }}
         run: |
           set -euo pipefail
-          RESULT=$(npx --yes clud-bug@0.7.0-rc.25 resolve-threads)
+          RESULT=$(npx --yes clud-bug@0.7.0-rc.26 resolve-threads)
           echo "::notice title=auto-resolve::$RESULT"
 
       # v0.6.29 / Component 4 — see workflow.yml.tmpl for design notes.
@@ -758,7 +758,7 @@ jobs:
           if [ ! -f .claude/skills/.clud-bug.json ]; then
             echo '{"version": 1}' > .claude/skills/.clud-bug.json
           fi
-          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 update-skill-usage --stdin
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.26 update-skill-usage --stdin
           echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
 
       - name: Upload skill-usage artifact
@@ -829,7 +829,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.25
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.26
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].
@@ -864,7 +864,7 @@ jobs:
           fi
           export STRICT_MODE
           VERDICT=$(printf '%s\n' "$STRUCTURED" \
-            | npx --yes clud-bug@0.7.0-rc.25 select-review-event --stdin \
+            | npx --yes clud-bug@0.7.0-rc.26 select-review-event --stdin \
             | tail -n1)
           VERDICT="${VERDICT:-skip}"
           echo "::notice title=Clud Bug 🐛::Formal review verdict: $VERDICT (strictMode=$STRICT_MODE, author_assoc=$PR_AUTHOR_ASSOCIATION)"

--- a/.ci-rendered/workflow-ts.yml
+++ b/.ci-rendered/workflow-ts.yml
@@ -668,7 +668,7 @@ jobs:
           THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 render --stdin)
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.26 render --stdin)
           CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
           gh pr comment "$PR_NUMBER" --body "$BODY
 
@@ -705,12 +705,12 @@ jobs:
           fi
 
           printf '%s\n' "$STRUCTURED" \
-            | npx --yes clud-bug@0.7.0-rc.25 build-bundle \
+            | npx --yes clud-bug@0.7.0-rc.26 build-bundle \
                 --repo "$REPO" --pr "$PR_NUMBER" --sha "$HEAD_SHA" \
-                --recipe-version "ci-0.7.0-rc.25" \
+                --recipe-version "ci-0.7.0-rc.26" \
             > bundle.json
 
-          npx --yes clud-bug@0.7.0-rc.25 post-check-run \
+          npx --yes clud-bug@0.7.0-rc.26 post-check-run \
             --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG" "$NOTARY_FLAG"
 
       # Wave 5a (D.2.X) — see workflow.yml.tmpl for design notes.
@@ -725,7 +725,7 @@ jobs:
           STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
         run: |
           set -euo pipefail
-          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 post-inline-threads --stdin)
+          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.26 post-inline-threads --stdin)
           echo "::notice title=inline-threads::$RESULT"
 
       # Wave 5b (D.2.6) — see workflow.yml.tmpl for design notes.
@@ -744,7 +744,7 @@ jobs:
           CLUD_BUG_RESOLVE_PAT: ${{ secrets.CLUD_BUG_RESOLVE_PAT }}
         run: |
           set -euo pipefail
-          RESULT=$(npx --yes clud-bug@0.7.0-rc.25 resolve-threads)
+          RESULT=$(npx --yes clud-bug@0.7.0-rc.26 resolve-threads)
           echo "::notice title=auto-resolve::$RESULT"
 
       # v0.6.29 / Component 4 — see workflow.yml.tmpl for design notes.
@@ -759,7 +759,7 @@ jobs:
           if [ ! -f .claude/skills/.clud-bug.json ]; then
             echo '{"version": 1}' > .claude/skills/.clud-bug.json
           fi
-          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 update-skill-usage --stdin
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.26 update-skill-usage --stdin
           echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
 
       - name: Upload skill-usage artifact
@@ -830,7 +830,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.25
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.26
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].
@@ -865,7 +865,7 @@ jobs:
           fi
           export STRICT_MODE
           VERDICT=$(printf '%s\n' "$STRUCTURED" \
-            | npx --yes clud-bug@0.7.0-rc.25 select-review-event --stdin \
+            | npx --yes clud-bug@0.7.0-rc.26 select-review-event --stdin \
             | tail -n1)
           VERDICT="${VERDICT:-skip}"
           echo "::notice title=Clud Bug 🐛::Formal review verdict: $VERDICT (strictMode=$STRICT_MODE, author_assoc=$PR_AUTHOR_ASSOCIATION)"

--- a/.ci-rendered/workflow.yml
+++ b/.ci-rendered/workflow.yml
@@ -884,7 +884,7 @@ jobs:
           THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 render --stdin)
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.26 render --stdin)
           CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
           gh pr comment "$PR_NUMBER" --body "$BODY
 
@@ -941,12 +941,12 @@ jobs:
           fi
 
           printf '%s\n' "$STRUCTURED" \
-            | npx --yes clud-bug@0.7.0-rc.25 build-bundle \
+            | npx --yes clud-bug@0.7.0-rc.26 build-bundle \
                 --repo "$REPO" --pr "$PR_NUMBER" --sha "$HEAD_SHA" \
-                --recipe-version "ci-0.7.0-rc.25" \
+                --recipe-version "ci-0.7.0-rc.26" \
             > bundle.json
 
-          npx --yes clud-bug@0.7.0-rc.25 post-check-run \
+          npx --yes clud-bug@0.7.0-rc.26 post-check-run \
             --sha "$HEAD_SHA" --bundle bundle.json --source ci "$STRICT_FLAG" "$NOTARY_FLAG"
 
       # v0.7.0-rc.7 / Wave 5a (D.2.X): post per-finding inline review
@@ -975,7 +975,7 @@ jobs:
           STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
         run: |
           set -euo pipefail
-          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 post-inline-threads --stdin)
+          RESULT=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.26 post-inline-threads --stdin)
           echo "::notice title=inline-threads::$RESULT"
 
       # v0.7.0-rc.8 / Wave 5b (D.2.6): on fix-push events
@@ -1009,7 +1009,7 @@ jobs:
           CLUD_BUG_RESOLVE_PAT: ${{ secrets.CLUD_BUG_RESOLVE_PAT }}
         run: |
           set -euo pipefail
-          RESULT=$(npx --yes clud-bug@0.7.0-rc.25 resolve-threads)
+          RESULT=$(npx --yes clud-bug@0.7.0-rc.26 resolve-threads)
           echo "::notice title=auto-resolve::$RESULT"
 
       # v0.6.29 / Component 4: pipe structured_output through
@@ -1038,7 +1038,7 @@ jobs:
           if [ ! -f .claude/skills/.clud-bug.json ]; then
             echo '{"version": 1}' > .claude/skills/.clud-bug.json
           fi
-          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.25 update-skill-usage --stdin
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.7.0-rc.26 update-skill-usage --stdin
           echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
 
       - name: Upload skill-usage artifact
@@ -1150,7 +1150,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.25
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.26
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow
@@ -1228,7 +1228,7 @@ jobs:
           # caller-side error (malformed JSON, missing env), so we never
           # need a fallback in shell.
           VERDICT=$(printf '%s\n' "$STRUCTURED" \
-            | npx --yes clud-bug@0.7.0-rc.25 select-review-event --stdin \
+            | npx --yes clud-bug@0.7.0-rc.26 select-review-event --stdin \
             | tail -n1)
           VERDICT="${VERDICT:-skip}"
 

--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.25
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.26
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.7.0-rc.26] — 2026-07-25
+
+**The honesty release: three false-greens removed, and the hook now covers what it claimed to.**
+Every item here was merged to `main` after rc.25 and is invisible to consumers until this publish.
+
+### Fixed
+
+- **🔴 The check no longer goes green on critical findings (ZP4, #248 + clud-bug-app#108).**
+  Three code paths derived the `clud-bug-review` conclusion and had drifted apart. The hosted
+  path **never consulted the critical-finding count** — a review that found real bugs posted
+  the same `success` as a clean one, with blocking carried entirely by a separate
+  `REQUEST_CHANGES` review event. All three now call ONE `deriveCheck` from `clud-bug/core`
+  (a shared brain, not three parallel mappings), and `CLUD_BUG_CHECK_NAME` is re-exported
+  rather than hardcoded twice. A cross-producer parity test asserts one
+  (verdict, strictMode, conclusion) table against every producer, so a future edit to one
+  path fails the test instead of silently drifting.
+  > ⚠️ **Behavior change:** strict-mode repos will now see `clud-bug-review` **fail** on
+  > critical findings where it previously passed. That is the fix working.
+- **🔴 Commits in linked worktrees are now reviewed (#245, closes #240).** Hook scope resolves
+  via `git rev-parse --git-common-dir` — `--git-dir` is worktree-*private*, which is why
+  worktree commits silently escaped review entirely. Orchestrated sessions use worktrees
+  routinely, so this was a standing coverage hole, not an edge case.
+- **🔴 A usage-limit-killed review can no longer look completed (#245, closes #239).** The
+  reviewed-marker was written *before* the review ran, so an interrupted session left a marker
+  saying "reviewed" and the next fire exited clean — a dead review was indistinguishable from a
+  finished one. Now two-phase: `pending` pre-recipe, `done` only via an explicit
+  **`clud-bug review-done <sha>`**. A `pending` sha re-fires, and a durable
+  `.git/clud-bug-pending` queue is drainable with **`clud-bug review --pending`**.
+- **The hook no longer fires on read-only commands (#245).** Firing keys on git *state* — a
+  worktree-local HEAD baseline plus `git reflog` confirming the move was a
+  commit/rebase/merge, not a checkout/reset — instead of pattern-matching the command string.
+- **`git commit --no-verify` is flagged** as a review finding where the repo declares mandated
+  hooks, rather than silently bypassing them.
+
+### Added
+
+- **`usage[<slug>]` emits in SPEC §1.12.1 shape (#247, §17 interop item 3).** We were already
+  recording `loads`/`citations` truthfully — the *shape* was a near-miss: `last_cited` written
+  as literal `null` where the SPEC requires the key be **omitted**, millisecond timestamps
+  where it requires **second** precision, and `last_loaded` missing entirely. The agent-skills
+  census read this and got nothing usable. Legacy `null` entries self-heal on next merge.
+- **`clud-bug review-done <sha>`** and **`clud-bug review --pending`** (see #239 above).
+
 ## [0.7.0-rc.25] — 2026-07-25
 
 **The mode-parity release: the notary now works in every mode.** Ships ZP2 + ZP3 — until

--- a/docs/decisions-branches/chore-bump-rc26.md
+++ b/docs/decisions-branches/chore-bump-rc26.md
@@ -1,0 +1,14 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-25 16:21 - chore: bump to 0.7.0-rc.26 (publishes ZP4 verdict parity, #239/#240 hook coverage, §17 citations)
+
+**Reasoning:** Everything merged after rc.25 is invisible to consumers until published — the exact gap rc.25 existed to close, which reopens on every merge. rc.26 ships three false-green fixes (the hosted check never consulted the critical count; worktree commits escaped review entirely; a limit-killed review looked completed) plus the §17 usage[] emission a downstream lane was idling on. Release discipline requires the strict-mode-gate composite pin in 3 templates + action.yml to move lock-step with package.json, so those bump together and the .ci-rendered goldens regenerate.
+
+**Alternatives considered:** Wait and batch more work into one rc (rejected: consumers including our own dogfood float @next, so unpublished fixes are simply not in effect — the ZP4 false-green in particular is a live correctness issue)
+
+**Implications:**
+- BEHAVIOR CHANGE on publish: strict-mode repos will see clud-bug-review FAIL on criticals where it previously passed — correct, but visible, and it will block PRs that used to merge
+- After merge, tag v0.7.0-rc.26 triggers OIDC publish -> dist-tag next; then clud-bug update our repos
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (32 decisions)
+## 2026-07 (33 decisions)
 
-- **2026-07-25** — ZP4: verdict-contract parity — publish VERDICT_CONCLUSION_TABLE as the canonical (verdict,strictMode)->conclusion oracle *(feat-zp4-verdict-parity)* — [decisions-branches/feat-zp4-verdict-parity.md](decisions-branches/feat-zp4-verdict-parity.md)
-- *... 30 more decisions ...*
+- **2026-07-25** — chore: bump to 0.7.0-rc.26 (publishes ZP4 verdict parity, #239/#240 hook coverage, §17 citations) *(chore-bump-rc26)* — [decisions-branches/chore-bump-rc26.md](decisions-branches/chore-bump-rc26.md)
+- *... 31 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.25",
+  "version": "0.7.0-rc.26",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -452,7 +452,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.25
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.26
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -452,7 +452,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.25
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.26
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -776,7 +776,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.25
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.26
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow


### PR DESCRIPTION
Everything merged since rc.25 is **invisible to consumers until published** — the exact gap rc.25 existed to close, which reopens on every merge. Our own dogfood floats `@next`, so unpublished fixes simply aren't in effect anywhere.

## What ships

**Three false-greens removed:**
1. **The check went green on critical findings** (ZP4, #248 + clud-bug-app#108). The hosted path *never consulted the critical count* — a review that found real bugs posted the same `success` as a clean one. All three producers now call one `deriveCheck` from `clud-bug/core`, with a cross-producer parity test so a future edit to one path fails the test instead of drifting silently.
2. **Worktree commits escaped review entirely** (#245 / #240) — scope now resolves via `--git-common-dir`, since `--git-dir` is worktree-*private*.
3. **A usage-limit-killed review looked completed** (#245 / #239) — two-phase `pending`→`done` marker via the new `clud-bug review-done <sha>`, plus a drainable `.git/clud-bug-pending` queue.

**Plus:** the hook no longer fires on read-only commands, `--no-verify` is flagged where hooks are mandated, and `usage[<slug>]` now emits in SPEC §1.12.1 shape (#247) — unblocking the agent-skills census, which was reading our manifest and getting nothing usable because of a shape near-miss (`null` instead of an omitted key, ms instead of second precision, `last_loaded` missing).

## ⚠️ Behavior change on publish

**Strict-mode repos will see `clud-bug-review` FAIL on critical findings where it previously passed.** That is the fix working — the check has been green on failing reviews — but it will block PRs that used to merge. Worth knowing before the tag goes up rather than after.

## Release discipline

`package.json` + the `strict-mode-gate` composite pin move lock-step (enforced by `test/release-discipline.test.js`), so all four pin sites bump — 3 workflow templates + `action.yml` — and the 3 `.ci-rendered` goldens regenerate. The goldens' larger diff is expected: `{{CLUD_BUG_VERSION}}` renders into ~7 call sites per workflow.

## Verification

`npm test` **1051 passed** (49 files) · `test:fixtures` **5/5** · `actionlint` clean on all 3 regenerated goldens · `npm run build` clean · no stale `rc.25` in any live surface.

**After merge:** push tag `v0.7.0-rc.26` → OIDC trusted-publish → dist-tag `next`, then `clud-bug update` our repos.