### PR TITLE
chore(skills): refresh bundled clud-bug-collaboration from agent-skills@bd1b554

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.7.NaN] — 2026-07-25
+
+### Changed
+
+- **Bundled `clud-bug-collaboration` SKILL.md refreshed** from `thrillmade/agent-skills@bd1b554`. `BASELINE_SKILLS_REF` in `src/cli/skills.ts` pinned to the same commit so the install-time fetch path and the bundled offline-fallback path resolve to byte-identical content. Auto-synced by `agent-skills/.github/workflows/notify-clud-bug.yml`.
+
+
 ## [0.7.0-rc.26] — 2026-07-25
 
 **The honesty release: three false-greens removed, and the hook now covers what it claimed to.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.26",
+  "version": "0.7.NaN",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/src/cli/skills.ts
+++ b/src/cli/skills.ts
@@ -31,7 +31,7 @@ export const MANIFEST_VERSION = 1;
 // skill content, bump BASELINE_SKILLS_REF below in the same clud-bug PR
 // that ships the corresponding bundled fallback update.
 // See thrillmade/agent-skills — skills.sh `skills/<name>/SKILL.md` layout.
-const BASELINE_SKILLS_REF = '436963ed37cbd9c6a9b7a07e907d5a0a432fab59';
+const BASELINE_SKILLS_REF = 'bd1b554037ec08d4150e9fee89a087cc937092b5';
 const AGENT_SKILLS_BASE =
   process.env['CLUD_BUG_AGENT_SKILLS_BASE'] ??
   `https://raw.githubusercontent.com/thrillmade/agent-skills/${BASELINE_SKILLS_REF}/skills`;

--- a/templates/skills/baseline/clud-bug-collaboration.md
+++ b/templates/skills/baseline/clud-bug-collaboration.md
@@ -74,52 +74,20 @@ move the bot's behavior.
 
 ### Example: a good custom skill
 
-Don't write generic prose like "be careful with database code." That's
-not actionable. Instead, anchor to specific files + behaviors:
+Don't write generic prose like "be careful with database code" — not
+actionable. Anchor to specific files + behaviors: name the exact path
+(e.g. `lib/db/queries.ts`), the exact pattern to flag, and what to quote.
 
-````markdown
----
-name: db-query-review
-description: How to review changes under lib/db/. Always flag missing parameterization, N+1 query patterns, and missing transaction boundaries on multi-statement writes.
----
+```ts
+// BAD — flag: string-interpolated SQL
+db.query(`SELECT * FROM users WHERE id = ${userId}`)
+// GOOD — parameterized
+db.query('SELECT * FROM users WHERE id = ?', [userId])
+```
 
-# Reviewing lib/db/ changes
-
-When the diff touches `lib/db/queries.ts` or any file under `lib/db/`,
-apply these rules:
-
-## Always flag
-
-1. **SQL string interpolation** — anything that builds a query via `+`,
-   template literals, or `string.format` rather than parameterized
-   queries. Example to flag:
-
-   ```ts
-   // BAD — flag this
-   db.query(`SELECT * FROM users WHERE id = ${userId}`)
-   // GOOD — uses parameterization
-   db.query('SELECT * FROM users WHERE id = ?', [userId])
-   ```
-
-2. **N+1 patterns** — flag any `await` inside a `for`/`map` loop that
-   calls `db.query` or `db.queryOne`. The fix is usually a single
-   `WHERE id IN (...)` query or a join.
-
-3. **Multi-statement writes without `db.transaction`** — if a diff
-   adds two or more `db.query` calls that all write, demand a
-   transaction wrapper. Quote the lines.
-
-## Style of finding
-
-Cite the specific line. "This is a SQL injection risk" alone isn't
-enough — quote the unsafe interpolation directly and propose the
-parameterized alternative.
-````
-
-That's what "evidence-anchored" looks like: specific file paths, runnable
-code examples for both bad and good, and explicit instructions on what
-to quote in the finding. The bot loads this and uses it as concrete
-review criteria, not vague guidance.
+Pair each rule with a bad/good snippet like this. A generic warning gets
+ignored; a rule anchored to a real path and pattern moves the bot's
+review behavior.
 
 ## When you edit `.github/workflows/clud-bug-*.yml`
 
@@ -150,6 +118,107 @@ the workflow's guard step fails loudly with an `::error::` annotation
 explaining how to set it. (For bot/fork PRs where the secret legitimately
 isn't passed, the guard posts a one-line advisory comment and exits 0
 instead of failing red.)
+
+## Reading review comments (v0.6.5+ format)
+
+Since v0.6.5, every Clud Bug summary comment leads with a stats line for
+fast triage:
+
+```
+Found: N 🔴 / N 🟡 / N 🟣
+```
+
+Three severity tiers, applied per finding via emoji prefix:
+
+- **🔴 important** — bug, security, performance, missing test coverage. In
+  strict-mode repos these fail the check.
+- **🟡 nit** — style, naming, micro-optimization. Advisory.
+- **🟣 pre-existing** — issue that pre-dates this PR. Don't fix here unless
+  the user asks; flag for a follow-up issue.
+
+Each finding follows this shape:
+
+```
+🔴 [skill-name]: One-line claim anchored to file:line.
+<details><summary>Reasoning</summary>
+
+Longer explanation with quoted evidence.
+
+</details>
+```
+
+Re-reads (other agents picking up the PR) can skip the collapsed `Reasoning`
+block when they trust the headline; expand only when chasing a finding.
+GitHub renders the `<details>` natively for human readers. **If a review
+emits zero findings**, the entire comment is just the `Found: 0 🔴 / 0 🟡 / 0 🟣`
+stats line plus the standard summary header — no per-finding bullets.
+
+## Agent-invocation mode: `CLUD_BUG_QUIET=1` (v0.6.7+)
+
+When invoking the `clud-bug` CLI from an agent session (vs interactively),
+set `CLUD_BUG_QUIET=1` or pass `--quiet` / `-q` to suppress multi-line
+progress chatter. Each command emits a single `ok <key-value>` summary line
+so the agent's context stays lean. Errors still print on stderr.
+
+```bash
+CLUD_BUG_QUIET=1 clud-bug update
+# → ok updated: @v0.6.11, N changed, M unchanged
+
+CLUD_BUG_QUIET=1 clud-bug init
+# → ok initialized: .claude/skills/ N specimens, workflow @v0.6.11
+
+CLUD_BUG_QUIET=1 clud-bug add evidence-based-review
+# → ok added: .claude/skills/evidence-based-review/SKILL.md
+```
+
+## Why reviews are cheap (cost-control wiring)
+
+The bot is engineered for token frugality, several layers deep:
+
+- **Prompt caching** (v0.6.3): the stable review-prompt + skill catalog +
+  AGENTS.md from base ref land in the Claude Code CLI's auto-cached system
+  layer. Cached input is billed at 10% of standard input within a 5-minute
+  window. The first review in a fresh window writes the cache (1.25×); the
+  next ones in that window read at 10%. Visible via `cache_read_input_tokens`
+  in the run's result JSON (`show_full_output: true`).
+- **Per-section byte budgets**: `MAX_COMMENT_BYTES=20000`,
+  `MAX_SKILL_BYTES=4000`, and **`MAX_DIFF_BYTES=5000000`** (bumped from an
+  original 80000 by a 2026-06-08 directive — the old 80KB default silently
+  truncated any real-world PR diff over that size, producing half-reviews;
+  5MB is far above a realistic single-PR diff but bounded enough that the
+  runner doesn't OOM). Caps the PR diff / prior-comment / skill-content
+  section the bot ingests per run; when a section hits its cap, an explicit
+  truncation marker appears and the bot is told to request the omitted
+  hunks if relevant.
+- **`MAX_THINKING_TOKENS=8000`** (v0.6.8) caps the extended-thinking budget
+  per turn.
+- **Two independent fast paths — don't conflate them**:
+  - **Workflow-only PRs** (clud-bug-update's own output: a workflow file
+    plus an allowlist like `AGENTS.md` / the baseline skills) skip review
+    entirely. The classify step emits `model=$MODEL` then `exit 0` —
+    **no `max_turns` is emitted at all** — and the review job itself is
+    gated `if: needs.paths-check.outputs.is_workflow_only != 'true'`, so
+    it never runs.
+  - **Trivial PRs** (dependency-bump bot authors, or a <2KB diff touching
+    only dependency-manifest files) get a flat `max-turns=10` and route
+    to Haiku 4.5 (`claude-haiku-4-5-20251001`, pinned in the template) —
+    roughly a third of Sonnet's per-input-token cost.
+  - **Everything else**: a pre-flight classify step estimates turns from
+    PR size (files/lines/prior threads) and sets `max(estimated × 1.2,
+    15)`, capped at 60, on the default `claude-sonnet-4-6` (not Opus —
+    per Anthropic docs, "Sonnet handles most coding tasks well and costs
+    less than Opus").
+- **Incremental-diff on fix-push** (v0.6.10): on a re-review, the bot reads
+  only the delta since its prior pass (`git diff <prior_sha>..HEAD`),
+  identified via a `<!-- last-reviewed-sha: <sha> -->` HTML marker in the
+  prior summary comment. Force-push or rebase invalidates the ancestry
+  check and falls back to full `gh pr diff`. ~67% fewer bytes ingested
+  across a fix-push-heavy PR's lifetime.
+
+You don't need to invoke any of this — it's wired into every clud-bug
+template. Override per-repo (e.g., `MAX_DIFF_BYTES=999999`) by setting the
+env var in your consuming repo's `clud-bug-review.yml`, which is visible in
+PRs and clud-bug-reviewable.
 
 ## Updating clud-bug itself
 


### PR DESCRIPTION
Automated bundled-copy sync from `thrillmade/agent-skills`.

**Trigger:** `push` on `thrillmade/agent-skills`.
**Source SKILL.md:** https://github.com/thrillmade/agent-skills/blob/bd1b554037ec08d4150e9fee89a087cc937092b5/skills/clud-bug-collaboration/SKILL.md
**Source commit:** https://github.com/thrillmade/agent-skills/commit/bd1b554037ec08d4150e9fee89a087cc937092b5

## Changes applied

- `templates/skills/baseline/clud-bug-collaboration.md` ← byte-for-byte copy of the source above.
- `src/cli/skills.ts` — `BASELINE_SKILLS_REF` bumped to `bd1b554037ec08d4150e9fee89a087cc937092b5` so the install-time fetch from `thrillmade/agent-skills` and the bundled offline-fallback both resolve to identical content.
- `package.json` — patch version bump to `0.7.NaN`.
- `CHANGELOG.md` — entry under [Unreleased] documenting the refresh.

## How this was generated

`agent-skills/.github/workflows/notify-clud-bug.yml` — fires on push to `main` matching one of the tracked baseline-skill paths, or via manual `workflow_dispatch` for a chosen skill.