### PR TITLE
Fix 0.7.NaN on main, cut rc.27, guard version validity

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.26
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.27
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+      # Release-gate guard (#251): package.json + CHANGELOG version strings
+      # must be valid SemVer. Runs before install — it needs no deps, and a
+      # bad version should fail in seconds, not after a full build.
+      - run: node scripts/check-version.mjs
       # v0.7.0: vitest replaces node:test; needs install before npm test.
       - run: npm ci
       - run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,57 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
-## [0.7.NaN] — 2026-07-25
+## [0.7.0-rc.27] — 2026-07-26
+
+**Review independence: the reviewer stops borrowing the author's confidence, and the hook stops
+crying wolf.**
+
+### Fixed
+
+- **🔴 The reviewer no longer folds in what it recalls from the authoring session (#246 → #254).**
+  A `§2b trusted-context` block told the review pass to take the surrounding session's account of
+  the change as established. That is precisely the channel by which an author waves their own bug
+  through: the recollection is unfalsifiable, a validator cannot check it, and it arrives
+  pre-loaded with the author's own confidence. The prompt now instructs the reviewer to read the
+  diff on its own terms, as someone who did not write it would, and to **try to refute the change
+  before accepting it**.
+
+- **The local commit hook stops re-firing on commits it already reviewed (#249 → #252).**
+  `git pull`, `merge`, `rebase`, and `cherry-pick` all move `HEAD` to commits authored by other
+  people — the hook queued a fresh review for every one. Reproduced three times in a day. The
+  hook now applies an authorship filter (fires when the new HEAD commit matches the local
+  `user.email` *or* `user.name`; one identity under several emails is common). It **fails open**:
+  if git identity is unset or unreadable, the hook still fires. Recurring false reviews eroded
+  trust in exactly the tier we are trying to make trustworthy.
+
+- **Invalid version strings are now caught directly (`scripts/check-version.mjs`).**
+  An upstream refresh workflow bumped our version with logic that assumed `X.Y.Z`; on the
+  prerelease `0.7.0-rc.26` it produced a literal **`0.7.NaN`** in both `package.json` and a
+  CHANGELOG heading (#251). The existing `release-discipline` suite *did* catch it and CI went
+  red — but it caught it only **incidentally**, by noticing the composite-action pins no longer
+  matched `package.json`. Had the same bad bump also rewritten those pins, everything would have
+  agreed on an unpublishable string and the suite would have gone green. The new guard checks
+  **validity** rather than **consistency**, runs before `npm ci` so it fails in seconds, and
+  covers CHANGELOG headings as well as `package.json`. The upstream generator has separately
+  been fixed — it no longer assigns versions at all, since choosing one is the publisher's act,
+  not the content producer's.
 
 ### Changed
 
-- **Bundled `clud-bug-collaboration` SKILL.md refreshed** from `thrillmade/agent-skills@bd1b554`. `BASELINE_SKILLS_REF` in `src/cli/skills.ts` pinned to the same commit so the install-time fetch path and the bundled offline-fallback path resolve to byte-identical content. Auto-synced by `agent-skills/.github/workflows/notify-clud-bug.yml`.
+- **Bundled `clud-bug-collaboration` SKILL.md refreshed** from `thrillmade/agent-skills@bd1b554`
+  (#251). `BASELINE_SKILLS_REF` in `src/cli/skills.ts` is pinned to the same commit, so the
+  install-time fetch path and the bundled offline-fallback path resolve to byte-identical
+  content.
+
+### Notes
+
+- **Server-side, no client change required:** the hosted notary now **refuses to certify a
+  self-review** (clud-bug-app#109). When the PR author and the bundle submitter resolve to the
+  same forge account, the notary declines to certify rather than issuing a certified check. When
+  either principal cannot be established it says so — `independence unestablished` — instead of
+  silently claiming independence it did not verify. Identity binds to immutable numeric forge
+  account IDs the notary fetches itself, never to logins, emails, or git author/committer
+  trailers, all of which the submitter controls.
 
 
 ## [0.7.0-rc.26] — 2026-07-25

--- a/docs/decisions-branches/fix__rc27-version-guard.md
+++ b/docs/decisions-branches/fix__rc27-version-guard.md
@@ -13,3 +13,12 @@
 
 ---
 
+## 2026-07-26 21:33 - check-version: skip fenced code blocks when scanning CHANGELOG headings
+
+**Reasoning:** Self-review of 7c0bcf6 (the commit-review hook) found a false-positive in my own new guard, confirmed by reproduction: the heading scan used /^## \[/gm on raw text, so any '## [x]' line inside a  and ~~~ both handled, unclosed fence swallows the remainder (conservative, matches markdown)
+
+**Implications:**
+- Verified with 3 controls that must STILL fail: a real bad heading, a bad package.json, and an unclosed-fence case — the fix does not blind the guard
+
+---
+

--- a/docs/decisions-branches/fix__rc27-version-guard.md
+++ b/docs/decisions-branches/fix__rc27-version-guard.md
@@ -1,0 +1,15 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-26 21:31 - Fix 0.7.NaN on main; cut rc.27; add SemVer validity guard
+
+**Reasoning:** clud-bug#251 (automated skills refresh from agent-skills) bumped package.json with logic assuming X.Y.Z. On the prerelease 0.7.0-rc.26 that yielded a literal 0.7.NaN in package.json AND a CHANGELOG heading. CI went RED (release-discipline caught it) but the PR merged anyway — org-wide required_status_checks were removed 2026-07-24, so a red test no longer blocks. Crucially release-discipline caught it only incidentally, by noticing composite pins no longer matched package.json; a bad bump that also rewrote the pins would have been self-consistent and gone green. So we needed a validity check, not just a consistency check.
+
+**Alternatives considered:** Revert #251 entirely — rejected: its content (skill refresh + BASELINE_SKILLS_REF pin) is correct and wanted; only the version bump was wrong, Rely on release-discipline alone — rejected: it tests consistency, which a uniformly-wrong bump satisfies, Fix upstream only — insufficient: upstream is already fixed (agent-skills no longer assigns versions), but that does not repair the value already on main
+
+**Implications:**
+- scripts/check-version.mjs validates package.json + every CHANGELOG '## [x]' heading against the official SemVer grammar; runs before npm ci so it fails in seconds
+- Version 0.7.0-rc.27; all four strict-mode-gate composite pins synced (3 templates + action.yml docstring)
+- OPEN GOVERNANCE GAP: a red CI check does not block merge anywhere in the org. The guard reports; it cannot stop. Requiring checks is the CEO's deferred Z7 decision.
+
+---
+

--- a/docs/decisions-branches/fix__rc27-version-guard.md
+++ b/docs/decisions-branches/fix__rc27-version-guard.md
@@ -15,10 +15,28 @@
 
 ## 2026-07-26 21:33 - check-version: skip fenced code blocks when scanning CHANGELOG headings
 
-**Reasoning:** Self-review of 7c0bcf6 (the commit-review hook) found a false-positive in my own new guard, confirmed by reproduction: the heading scan used /^## \[/gm on raw text, so any '## [x]' line inside a  and ~~~ both handled, unclosed fence swallows the remainder (conservative, matches markdown)
+**Reasoning:** Self-review of 7c0bcf6 (triggered by the commit-review hook) found a false-positive in my own new guard, confirmed by reproduction: the heading scan ran /^## \[/gm over raw text, so any "## [x]" line inside a fenced code block was read as a release heading. A CHANGELOG that DOCUMENTS a bad version — exactly what rc.27's own entry does about 0.7.NaN — would have red-CI'd a correct file. The guard is meant to catch a bad release, not a correct piece of documentation.
+
+**Alternatives considered:**
+- Reword the CHANGELOG to avoid the pattern — rejected: makes prose contort around a tool bug, and the next author hits it again
+- Match a stricter heading shape, e.g. require a trailing date — rejected: couples the guard to entry formatting it has no business enforcing
 
 **Implications:**
+- Fenced blocks are stripped before scanning; both ``` and ~~~ delimiters handled, and an unclosed fence swallows the remainder (conservative, matches markdown)
 - Verified with 3 controls that must STILL fail: a real bad heading, a bad package.json, and an unclosed-fence case — the fix does not blind the guard
+- Process note: the original `logmind log` call was mangled by zsh globbing on unquoted parens/backticks in the -r/-a text. Repaired by hand. Quote logmind argument text.
+
+---
+
+## 2026-07-26 21:35 - check-version: honor CommonMark fence length so nested blocks do not close early
+
+**Reasoning:** Adversarial self-review of the previous commit reproduced two edge cases. Case E, a 4-backtick block containing a 3-backtick sample, was a FALSE POSITIVE: the inner delimiter closed the outer fence early, so documentation inside it was scanned and flagged. That is the same red-CI-on-a-correct-file failure the fence-stripping was added to prevent. Case F, an unclosed fence hiding a later bad heading, is a silent miss but is CommonMark-correct behavior and matches how any renderer reads the file, so it is documented rather than worked around.
+
+**Alternatives considered:** Leave it: nested fences are rare in a CHANGELOG. Rejected because the cost is three lines and the failure mode is a false red on a correct file, which erodes trust in the guard itself., Use a real markdown parser. Rejected: this runs before npm ci precisely so it needs zero dependencies.
+
+**Implications:**
+- A closing fence must now use the same character as the opening and be at least as long
+- Control matrix of 6 cases, including one that must still FAIL, all behave as specified
 
 ---
 

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -38,6 +38,7 @@ clud-bug
 ├── fixtures
 │   └── reviews
 ├── scripts
+│   ├── check-version.mjs
 │   ├── fixture-check.mjs
 │   └── gen-version.mjs
 ├── site

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (37 decisions)
+## 2026-07 (38 decisions)
 
-- **2026-07-26** — check-version: skip fenced code blocks when scanning CHANGELOG headings *(fix/rc27-version-guard)* — [decisions-branches/fix__rc27-version-guard.md](decisions-branches/fix__rc27-version-guard.md)
-- *... 35 more decisions ...*
+- **2026-07-26** — check-version: honor CommonMark fence length so nested blocks do not close early *(fix/rc27-version-guard)* — [decisions-branches/fix__rc27-version-guard.md](decisions-branches/fix__rc27-version-guard.md)
+- *... 36 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (35 decisions)
+## 2026-07 (36 decisions)
 
-- **2026-07-26** — Delete the §2b trusted-context fold-in from the local review recipe; replace with diff-only, refute-first framing (clud-bug#246 safe half) *(feat-246-no-notarize-self-review)* — [decisions-branches/feat-246-no-notarize-self-review.md](decisions-branches/feat-246-no-notarize-self-review.md)
-- *... 33 more decisions ...*
+- **2026-07-26** — Fix 0.7.NaN on main; cut rc.27; add SemVer validity guard *(fix/rc27-version-guard)* — [decisions-branches/fix__rc27-version-guard.md](decisions-branches/fix__rc27-version-guard.md)
+- *... 34 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (36 decisions)
+## 2026-07 (37 decisions)
 
-- **2026-07-26** — Fix 0.7.NaN on main; cut rc.27; add SemVer validity guard *(fix/rc27-version-guard)* — [decisions-branches/fix__rc27-version-guard.md](decisions-branches/fix__rc27-version-guard.md)
-- *... 34 more decisions ...*
+- **2026-07-26** — check-version: skip fenced code blocks when scanning CHANGELOG headings *(fix/rc27-version-guard)* — [decisions-branches/fix__rc27-version-guard.md](decisions-branches/fix__rc27-version-guard.md)
+- *... 35 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.NaN",
+  "version": "0.7.0-rc.27",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/scripts/check-version.mjs
+++ b/scripts/check-version.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Release-gate guard: every version string this repo publishes or documents
+// must be valid SemVer.
+//
+// Why this exists (clud-bug #251, 2026-07-25): an upstream skills-refresh
+// workflow bumped our version with `p.version.split('.').map(Number)`, which
+// assumes X.Y.Z. We ship PRERELEASES — `0.7.0-rc.26` splits to
+// ["0","7","0-rc","26"], `Number("0-rc")` is NaN, and the PR wrote a literal
+// `"version": "0.7.NaN"` into package.json AND a `## [0.7.NaN]` CHANGELOG
+// heading. Full CI passed. It merged to main. `npm publish` would have failed
+// at the registry — the first place anything would have noticed.
+//
+// The generator has since been fixed upstream (it no longer assigns versions
+// at all — that is the publisher's act). This guard is the local backstop:
+// whatever writes a version, valid SemVer is checked here, on every PR.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// The official SemVer 2.0.0 regex (semver.org, "Backus-Naur Form Grammar for
+// Valid SemVer Versions"). Anchored, no capture groups needed here.
+const SEMVER =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+const errors = [];
+
+// 1. package.json — the string npm publishes under.
+const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+if (typeof pkg.version !== 'string' || !SEMVER.test(pkg.version)) {
+  errors.push(
+    `package.json version is not valid SemVer: ${JSON.stringify(pkg.version)}`,
+  );
+}
+
+// 2. CHANGELOG.md release headings — `## [x.y.z] — date`, plus the literal
+//    `## [Unreleased]` staging header. #251 corrupted this file too, so
+//    checking only package.json would have caught half the damage.
+const changelog = readFileSync(join(root, 'CHANGELOG.md'), 'utf8');
+for (const [, heading] of changelog.matchAll(/^## \[([^\]]+)\]/gm)) {
+  if (heading === 'Unreleased') continue;
+  if (!SEMVER.test(heading)) {
+    errors.push(`CHANGELOG.md heading is not valid SemVer: ## [${heading}]`);
+  }
+}
+
+if (errors.length > 0) {
+  for (const e of errors) console.error(`::error::${e}`);
+  console.error(
+    `\ncheck-version: ${errors.length} invalid version string(s). ` +
+      `See scripts/check-version.mjs for why this guard exists.`,
+  );
+  process.exit(1);
+}
+
+console.log(`check-version: ok (package.json ${pkg.version})`);

--- a/scripts/check-version.mjs
+++ b/scripts/check-version.mjs
@@ -47,22 +47,35 @@ if (typeof pkg.version !== 'string' || !SEMVER.test(pkg.version)) {
 //    column 0, so an indented fence cannot contain a matching line anyway.
 const changelog = readFileSync(join(root, 'CHANGELOG.md'), 'utf8');
 
-let inFence = null;
+//    Follows CommonMark's fence rules in the two ways that matter here:
+//      - a closing fence must use the SAME character as the opening one and
+//        be AT LEAST as long. Without the length rule, a nested ```` block
+//        containing a ``` sample closes early and the guard flags the
+//        documentation inside it (reproduced).
+//      - an unclosed fence runs to end of document. That means a malformed
+//        CHANGELOG can hide later headings from this scan — accepted, since
+//        it matches how every markdown renderer reads the same file, and the
+//        package.json check (the publish-blocking one) is unaffected.
+let fenceChar = null;
+let fenceLen = 0;
 const scannable = changelog
   .split('\n')
   .filter((line) => {
-    const fence = line.match(/^(```|~~~)/);
+    const fence = line.match(/^(`{3,}|~{3,})/);
     if (fence) {
-      if (inFence === null) {
-        inFence = fence[1];
+      const [delim] = fence;
+      if (fenceChar === null) {
+        fenceChar = delim[0];
+        fenceLen = delim.length;
         return false; // opening delimiter
       }
-      if (line.startsWith(inFence)) {
-        inFence = null;
+      if (delim[0] === fenceChar && delim.length >= fenceLen) {
+        fenceChar = null;
+        fenceLen = 0;
         return false; // closing delimiter
       }
     }
-    return inFence === null;
+    return fenceChar === null;
   })
   .join('\n');
 

--- a/scripts/check-version.mjs
+++ b/scripts/check-version.mjs
@@ -38,8 +38,35 @@ if (typeof pkg.version !== 'string' || !SEMVER.test(pkg.version)) {
 // 2. CHANGELOG.md release headings — `## [x.y.z] — date`, plus the literal
 //    `## [Unreleased]` staging header. #251 corrupted this file too, so
 //    checking only package.json would have caught half the damage.
+//
+//    Fenced code blocks are stripped first. A release note that *quotes* a
+//    bad heading — e.g. this repo's own rc.27 entry describing the `0.7.NaN`
+//    incident — is documentation, not a release. Scanning raw text flagged
+//    it and red-CI'd a correct CHANGELOG (reproduced before this fix).
+//    Only ``` / ~~~ fences at column 0 are handled: `^## [` already requires
+//    column 0, so an indented fence cannot contain a matching line anyway.
 const changelog = readFileSync(join(root, 'CHANGELOG.md'), 'utf8');
-for (const [, heading] of changelog.matchAll(/^## \[([^\]]+)\]/gm)) {
+
+let inFence = null;
+const scannable = changelog
+  .split('\n')
+  .filter((line) => {
+    const fence = line.match(/^(```|~~~)/);
+    if (fence) {
+      if (inFence === null) {
+        inFence = fence[1];
+        return false; // opening delimiter
+      }
+      if (line.startsWith(inFence)) {
+        inFence = null;
+        return false; // closing delimiter
+      }
+    }
+    return inFence === null;
+  })
+  .join('\n');
+
+for (const [, heading] of scannable.matchAll(/^## \[([^\]]+)\]/gm)) {
   if (heading === 'Unreleased') continue;
   if (!SEMVER.test(heading)) {
     errors.push(`CHANGELOG.md heading is not valid SemVer: ## [${heading}]`);

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -452,7 +452,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.26
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.27
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -452,7 +452,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.26
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.27
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -776,7 +776,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.26
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.27
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow


### PR DESCRIPTION
## What happened

**#251 put an unpublishable version string on `main`.** The automated skills-refresh PR from `agent-skills` bumped our version using `p.version.split('.').map(Number)`, which assumes `X.Y.Z`. We ship prereleases — `0.7.0-rc.26` splits to `["0","7","0-rc","26"]`, `Number("0-rc")` is `NaN`, and the PR wrote a literal **`0.7.NaN`** into `package.json` and a `## [0.7.NaN]` CHANGELOG heading.

`npm publish` would have rejected it. rc.27 was blocked until this landed.

## The part worth reading

**CI caught it. The `test` check went red on #251 and it was merged anyway** — org-wide `required_status_checks` were removed on 2026-07-24, so a red check no longer blocks a merge. The detection worked; the gate is gone.

**And it only caught it by accident.** `release-discipline` compares the composite-action pins against `package.json`. It failed because the pins still said `rc.26` while `package.json` said `0.7.NaN` — i.e. it noticed an *inconsistency*, not an *invalid version*. Had the same bad bump also rewritten those pins, every file would have agreed on an unpublishable string and the suite would have gone **green**.

That is the gap this PR closes: we tested consistency and assumed it implied validity.

## Changes

| | |
|---|---|
| `package.json` | `0.7.NaN` → `0.7.0-rc.27` |
| `CHANGELOG.md` | `## [0.7.NaN]` → a real `## [0.7.0-rc.27]` section covering #251, #252, #254, and the server-side app#109 note |
| `scripts/check-version.mjs` | **new** — validates `package.json` + every `## [x]` CHANGELOG heading against the official SemVer 2.0.0 grammar |
| `.github/workflows/ci.yml` | runs the guard **before `npm ci`** — no deps needed, fails in seconds rather than after a full build |
| 3 templates + `action.yml` | `strict-mode-gate@v0.7.0-rc.26` → `rc.27` (satisfies `release-discipline`) |

## Upstream

Already fixed independently, in `agent-skills@bd1b554` — the workflow no longer assigns versions **at all**, on the reasoning that choosing a version is the publisher's act, not the content producer's. So this class won't recur from that source. This guard is the local backstop for whatever writes a version next.

## Verification

- Guard run against the **broken** tree first (the control): exits 1, flags both sites.
- Guard on the fixed tree: `check-version: ok (package.json 0.7.0-rc.27)`.
- `npm test` → **1057 passed / 49 files**, including the 3 `release-discipline` + `prompts` failures that #251 introduced.
- `npm run test:fixtures` → 5 passed.

## Not fixed here

- `package-lock.json` still reads `0.7.0-rc.5` — pre-existing drift across many releases, unrelated to #251, and `npm publish` reads `package.json`. Out of scope; flagged rather than silently churned.
- **A red check still cannot block a merge.** This guard reports; it cannot stop. That is the deferred Z7 decision and it is the CEO's call, not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)