### PR TITLE
F1a: fix the forgeable clud-bug-review merge gate (integration_id pin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+### Fixed
+
+- **🔴 The `clud-bug-review` merge gate was forgeable — `configure-github` shipped it unpinned, and
+  stripped the pin if you set one by hand.** SPEC §10.3.3 point 2 requires the required-status-check
+  entry to pin `integration_id` to the clud-bug App, so that only the App can satisfy the gate. Without
+  it the context is just a string: **any actor with `checks:write` — including the PR author — could post
+  a check run named `clud-bug-review`**, and GitHub's latest-run-wins semantics let that forged run
+  satisfy the gate over the App's real verdict.
+
+  Three defects, all fixed:
+  - The vendored presets (`data/rulesets/clud-bug.json`, `skdd.json`, `canonical-v1.json`) omitted the
+    pin. reporulez — the canonical source these are vendored from — has carried it since the Z6 pin
+    landed; our copies were stale.
+  - `mergeForPut` rebuilt every entry as a bare `{ context }`, **silently dropping the pin on every
+    apply** — including one an operator had set manually in the GitHub UI. A correctly-configured repo
+    was downgraded back to a forgeable one by the next `configure-github` run.
+  - The diff treated an unpinned context as canonical, so an affected repo reported **"already
+    canonical"** while its gate stayed open.
+
+  A repo's own extra required checks keep their own pins (the superset contract is unchanged).
+  Re-run `clud-bug configure-github <owner>/<repo>` to converge an already-configured repo.
+
 ## [0.7.0-rc.27] — 2026-07-26
 
 **Review independence: the reviewer stops borrowing the author's confidence, and the hook stops

--- a/data/canonical-v1.json
+++ b/data/canonical-v1.json
@@ -31,7 +31,7 @@
         "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
-          { "context": "clud-bug-review" },
+          { "context": "clud-bug-review", "integration_id": 3944857 },
           { "context": "check-derived-docs" },
           { "context": "check-decisions" },
           { "context": "check-links" }

--- a/data/rulesets/clud-bug.json
+++ b/data/rulesets/clud-bug.json
@@ -31,7 +31,7 @@
         "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
-          { "context": "clud-bug-review" }
+          { "context": "clud-bug-review", "integration_id": 3944857 }
         ]
       }
     }

--- a/data/rulesets/skdd.json
+++ b/data/rulesets/skdd.json
@@ -31,7 +31,7 @@
         "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
-          { "context": "clud-bug-review" },
+          { "context": "clud-bug-review", "integration_id": 3944857 },
           { "context": "check-derived-docs" },
           { "context": "check-decisions" },
           { "context": "check-links" }

--- a/docs/decisions-branches/fix__f1a-integration-id-pin.md
+++ b/docs/decisions-branches/fix__f1a-integration-id-pin.md
@@ -15,3 +15,16 @@
 
 ---
 
+## 2026-07-28 00:27 - F1a follow-up: pin precedence is per-FIELD, never per-entry
+
+**Reasoning:** Adversarial self-review of the F1a commit found the same forgeability regression one level over, confirmed by reproduction before fixing. The merge took our desired entry wholesale for any context we ship, so a repo that had pinned a context we ship UNPINNED — skdd ships check-links with no integration_id — had its own pin stripped on every apply. Identical class to the headline bug: an apply that silently reduces pin strength.
+
+**Alternatives considered:** Leave it: we only promise to manage contexts we ship. Rejected — we do not ship check-links pinned, so under that reading we would be free to strip a pin a repo deliberately set, which is the exact harm the fix exists to prevent.
+
+**Implications:**
+- Correct rule: our pin wins where we specify one so it cannot be downgraded; the repo pin is preserved where we specify none; repo extra contexts carry verbatim. We only ever ADD pin strength.
+- Regression test control-tested: reverting to take-ours-wholesale fails it
+- SPEC gap to propose upstream: 10.3.3 point 2 says pin clud-bug-review but says nothing about an applier never DOWNGRADING an existing pin. That is the normative rule this work produced.
+
+---
+

--- a/docs/decisions-branches/fix__f1a-integration-id-pin.md
+++ b/docs/decisions-branches/fix__f1a-integration-id-pin.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-28 00:20 - F1a: fix the forgeable clud-bug-review merge gate — integration_id pin
+
+**Reasoning:** SPEC 10.3.3 point 2 requires the required-status-check entry to pin integration_id to the clud-bug App, so only the App can satisfy the gate. Three independent defects meant no repo configured by clud-bug ever had it. One: the vendored presets omitted the pin, while reporulez the canonical source has carried it since Z6 landed — our copies were stale. Two: mergeForPut rebuilt every entry as a bare context object, dropping the pin on every apply including one set by hand in the GitHub UI, so a correctly-configured repo was downgraded back to forgeable on the next run. Three: the diff treated an unpinned context as canonical, reporting already-canonical while the gate stayed open. Net effect: any actor with checks:write, including the PR author, could post a check named clud-bug-review and win on latest-run-wins semantics.
+
+**Alternatives considered:** Re-vendor all preset files wholesale from reporulez — rejected: JSON.stringify reformatting buried the one semantic change in ~100 lines of whitespace noise, which is the wrong diff to hand a reviewer for a security fix. Surgical edit instead., Only add the pin to the presets — insufficient: mergeForPut would strip it again on the next apply, so the fix would silently undo itself.
+
+**Implications:**
+- New statusCheckEntries helper preserves context plus integration_id; the string-only statusCheckContexts stays for human-readable diff labels
+- unionContexts deleted rather than left dead — a string-only union is exactly the convenient helper a future edit would reach for, reintroducing the strip
+- Precedence on merge: our entry wins for contexts we ship, so the canonical pin cannot be downgraded; a repo extra context keeps its own pin
+- Three regression tests, control-tested: reintroducing the strip fails 2 of them; the third covers the diff half independently
+- Re-run clud-bug configure-github to converge repos already configured with the unpinned gate
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (38 decisions)
+## 2026-07 (40 decisions)
 
-- **2026-07-26** — check-version: honor CommonMark fence length so nested blocks do not close early *(fix/rc27-version-guard)* — [decisions-branches/fix__rc27-version-guard.md](decisions-branches/fix__rc27-version-guard.md)
-- *... 36 more decisions ...*
+- **2026-07-28** — F1a follow-up: pin precedence is per-FIELD, never per-entry *(fix/f1a-integration-id-pin)* — [decisions-branches/fix__f1a-integration-id-pin.md](decisions-branches/fix__f1a-integration-id-pin.md)
+- *... 38 more decisions ...*
 - **2026-07-03** — Phase R keystone: add src/core/invariants.ts — executable-probe invariants config + in-scope gate *(phase-r1-invariants-module)* — [decisions-branches/phase-r1-invariants-module.md](decisions-branches/phase-r1-invariants-module.md)
 
 ## 2026-06 (81 decisions)

--- a/src/core/configure-github.ts
+++ b/src/core/configure-github.ts
@@ -741,13 +741,27 @@ function mergeForPut(
       // a correctly-configured repo back into an insecure one on the next
       // `configure-github` run.
       //
-      // Precedence: OUR entry wins for contexts we ship (so the canonical pin
-      // is applied and cannot be downgraded); the repo's own extra contexts
-      // are carried through verbatim, keeping any pin their owner chose.
+      // Precedence is per-FIELD, not per-entry:
+      //   - a context we ship PINNED keeps OUR pin (it cannot be downgraded);
+      //   - a context we ship UNPINNED keeps the repo's own pin if it set one
+      //     (e.g. a repo pinning `check-links` to its own App);
+      //   - the repo's extra contexts carry through verbatim.
+      //
+      // Taking our entry wholesale would strip a repo's pin on every context
+      // we happen to ship without one — the same forgeability regression this
+      // fix exists to prevent, just one level over. We only ever ADD pin
+      // strength here, never remove it.
       const desiredEntries = statusCheckEntries(rule.parameters);
+      const existingEntries = statusCheckEntries(ex?.parameters ?? {});
+      const existingByContext = new Map(existingEntries.map((e) => [e.context, e]));
       const desiredByContext = new Map(desiredEntries.map((e) => [e.context, e]));
-      const mergedEntries: StatusCheckEntry[] = [...desiredEntries];
-      for (const existingEntry of statusCheckEntries(ex?.parameters ?? {})) {
+
+      const mergedEntries: StatusCheckEntry[] = desiredEntries.map((wanted) => {
+        if (wanted.integration_id !== undefined) return wanted;
+        const theirs = existingByContext.get(wanted.context);
+        return theirs?.integration_id !== undefined ? theirs : wanted;
+      });
+      for (const existingEntry of existingEntries) {
         if (!desiredByContext.has(existingEntry.context)) {
           mergedEntries.push(existingEntry);
         }

--- a/src/core/configure-github.ts
+++ b/src/core/configure-github.ts
@@ -531,6 +531,39 @@ function statusCheckContexts(params: Record<string, unknown>): string[] {
     .filter((c): c is string => typeof c === 'string');
 }
 
+/** One required-status-check entry: the context plus its optional App pin. */
+interface StatusCheckEntry {
+  context: string;
+  integration_id?: number;
+}
+
+/**
+ * Like `statusCheckContexts`, but preserves each entry's `integration_id`.
+ *
+ * SPEC §10.3.3 point 2 pins `clud-bug-review` to the clud-bug App's own
+ * `integration_id`. Without the pin the context name is just a string: ANY
+ * actor with checks:write — including the PR author — can post a check run
+ * named `clud-bug-review`, and GitHub's latest-run-wins semantics let that
+ * forged run satisfy the gate over the App's real verdict.
+ *
+ * The string-only `statusCheckContexts` above is still correct for the
+ * places that genuinely only need names (human-readable diff labels), but
+ * anything that ROUND-TRIPS entries back to the API must use this instead —
+ * rebuilding entries as bare `{ context }` silently drops the pin.
+ */
+function statusCheckEntries(params: Record<string, unknown>): StatusCheckEntry[] {
+  const list = params.required_status_checks;
+  if (!Array.isArray(list)) return [];
+  const out: StatusCheckEntry[] = [];
+  for (const c of list) {
+    if (!c || typeof c !== 'object') continue;
+    const { context, integration_id: pin } = c as StatusCheckEntry;
+    if (typeof context !== 'string') continue;
+    out.push(typeof pin === 'number' ? { context, integration_id: pin } : { context });
+  }
+  return out;
+}
+
 /**
  * Diffs an existing ruleset against the canonical desired payload. Returns
  * one human-readable line per difference the apply path would fix; an empty
@@ -614,13 +647,32 @@ function diffRuleParams(
   const changes: string[] = [];
   for (const [key, want] of Object.entries(desired)) {
     if (key === 'required_status_checks') {
-      const wantCtx = statusCheckContexts({ required_status_checks: want });
-      const haveCtx = new Set(
-        statusCheckContexts({ required_status_checks: existing[key] }),
+      const wantEntries = statusCheckEntries({ required_status_checks: want });
+      const haveByContext = new Map(
+        statusCheckEntries({ required_status_checks: existing[key] }).map((e) => [
+          e.context,
+          e,
+        ]),
       );
-      const missing = wantCtx.filter((c) => !haveCtx.has(c));
+      const missing = wantEntries
+        .filter((e) => !haveByContext.has(e.context))
+        .map((e) => e.context);
       if (missing.length > 0) {
         changes.push(`${type}.required_status_checks: add ${JSON.stringify(missing)}`);
+      }
+      // An UNPINNED (or wrong-pin) context that we ship pinned is drift, not
+      // a no-op. Without this the gate reports "already canonical" while the
+      // check name remains forgeable — the repo looks configured and isn't.
+      for (const wantEntry of wantEntries) {
+        if (wantEntry.integration_id === undefined) continue;
+        const have = haveByContext.get(wantEntry.context);
+        if (!have) continue; // already reported as missing above
+        if (have.integration_id !== wantEntry.integration_id) {
+          changes.push(
+            `${type}.required_status_checks["${wantEntry.context}"].integration_id: ` +
+              `${have.integration_id ?? '(unpinned)'} → ${wantEntry.integration_id}`,
+          );
+        }
       }
       continue;
     }
@@ -680,15 +732,31 @@ function mergeForPut(
   const rules = desired.rules.map((rule) => {
     const ex = existingByType.get(rule.type);
     if (rule.type === 'required_status_checks' && rule.parameters) {
-      const merged = unionContexts(
-        statusCheckContexts(ex?.parameters ?? {}),
-        statusCheckContexts(rule.parameters),
-      );
+      // Union by context, PRESERVING each entry's `integration_id`.
+      //
+      // This previously rebuilt every entry as a bare `{ context }`, which
+      // silently dropped the SPEC §10.3.3 App pin on every apply — including
+      // one an operator had set by hand in the GitHub UI. A pinless context
+      // is a forgeable gate (see `statusCheckEntries`), so the strip turned
+      // a correctly-configured repo back into an insecure one on the next
+      // `configure-github` run.
+      //
+      // Precedence: OUR entry wins for contexts we ship (so the canonical pin
+      // is applied and cannot be downgraded); the repo's own extra contexts
+      // are carried through verbatim, keeping any pin their owner chose.
+      const desiredEntries = statusCheckEntries(rule.parameters);
+      const desiredByContext = new Map(desiredEntries.map((e) => [e.context, e]));
+      const mergedEntries: StatusCheckEntry[] = [...desiredEntries];
+      for (const existingEntry of statusCheckEntries(ex?.parameters ?? {})) {
+        if (!desiredByContext.has(existingEntry.context)) {
+          mergedEntries.push(existingEntry);
+        }
+      }
       return {
         ...rule,
         parameters: {
           ...rule.parameters,
-          required_status_checks: merged.map((context) => ({ context })),
+          required_status_checks: mergedEntries,
         },
       };
     }
@@ -716,18 +784,10 @@ function mergeForPut(
   };
 }
 
-/** Union of two context lists, preserving existing order then appending new. */
-function unionContexts(existing: string[], desired: string[]): string[] {
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const c of [...existing, ...desired]) {
-    if (!seen.has(c)) {
-      seen.add(c);
-      out.push(c);
-    }
-  }
-  return out;
-}
+// `unionContexts` (string-only union) removed: `mergeForPut` now unions
+// entries via `statusCheckEntries` so the `integration_id` pin survives.
+// Leaving a string-only union in place invites the same strip to be
+// reintroduced by a future edit that reaches for the convenient helper.
 
 /** Compares two values as sets (order-insensitive). Non-arrays fall back to ===. */
 function arraysEqualAsSet(a: unknown, b: unknown): boolean {

--- a/test/core/configure-github.test.js
+++ b/test/core/configure-github.test.js
@@ -425,6 +425,62 @@ test('apply: an UNPINNED clud-bug-review is drift, not already-canonical', async
   assert.equal(calls.updateRepoRuleset, 1);
 });
 
+test("apply: a repo's pin on a context WE ship unpinned is preserved", async () => {
+  // Self-review catch: taking our desired entry wholesale stripped the repo's
+  // pin on every context we happen to ship WITHOUT one (skdd ships
+  // check-links unpinned). Same forgeability regression as the headline bug,
+  // one level over. Precedence is per-FIELD: we only ever ADD pin strength.
+  const existing = canonicalRuleset();
+  existing.rules = existing.rules.map((r) =>
+    r.type === 'required_status_checks'
+      ? {
+          ...r,
+          parameters: {
+            ...r.parameters,
+            required_status_checks: r.parameters.required_status_checks.map((c) =>
+              c.context === 'check-links'
+                ? { context: c.context, integration_id: 12345 }
+                : c,
+            ),
+          },
+        }
+      : r,
+  );
+  // Drift an unrelated context so a PUT actually fires.
+  existing.rules = existing.rules.map((r) =>
+    r.type === 'required_status_checks'
+      ? {
+          ...r,
+          parameters: {
+            ...r.parameters,
+            required_status_checks: r.parameters.required_status_checks.filter(
+              (c) => c.context !== 'check-decisions',
+            ),
+          },
+        }
+      : r,
+  );
+  const { octokit, calls } = makeOctokitMock({ rulesets: [existing] });
+  await applyCanonicalRuleset(octokit, { owner: 'octo', repo: 'demo' });
+  assert.equal(calls.updateRepoRuleset, 1);
+  const rule = calls.lastUpdatePayload.rules.find(
+    (r) => r.type === 'required_status_checks',
+  );
+  const links = rule.parameters.required_status_checks.find(
+    (c) => c.context === 'check-links',
+  );
+  assert.equal(
+    links.integration_id,
+    12345,
+    `repo's own pin stripped: ${JSON.stringify(rule.parameters.required_status_checks)}`,
+  );
+  // ...and ours is still applied on the context we DO pin.
+  const review = rule.parameters.required_status_checks.find(
+    (c) => c.context === 'clud-bug-review',
+  );
+  assert.equal(review.integration_id, 3944857);
+});
+
 test("apply: a repo's own extra context keeps its own integration_id", async () => {
   // Superset contract: we own `clud-bug-review`, but a repo pinning its own
   // `lint` check to some other App must not have that pin clobbered either.

--- a/test/core/configure-github.test.js
+++ b/test/core/configure-github.test.js
@@ -104,8 +104,10 @@ function makeOctokitMock({ rulesets = [], repoSettings } = {}) {
 // (data/rulesets/skdd.json). Used to seed the mock's "already-canonical"
 // state. Kept inline (not derived from loadPreset) so the test also documents
 // the NORMATIVE contract: the ruleset is named `reporulez-default` (vendored
-// from reporulez), 0 approvals, clud-bug-review as a required check, empty
-// bypass_actors (repo extras are preserved as a superset on PUT).
+// from reporulez), 0 approvals, clud-bug-review as a required check PINNED to
+// the clud-bug App's `integration_id` (SPEC §10.3.3 point 2 — an unpinned
+// context name is forgeable by the PR author), empty bypass_actors (repo
+// extras are preserved as a superset on PUT).
 function canonicalRuleset(overrides = {}) {
   return {
     id: 42,
@@ -135,7 +137,7 @@ function canonicalRuleset(overrides = {}) {
           strict_required_status_checks_policy: true,
           do_not_enforce_on_create: false,
           required_status_checks: [
-            { context: 'clud-bug-review' },
+            { context: 'clud-bug-review', integration_id: 3944857 },
             { context: 'check-decisions' },
             { context: 'check-derived-docs' },
             { context: 'check-links' },
@@ -319,7 +321,7 @@ test('apply: missing status check context — superset PUT preserves extras', as
           parameters: {
             ...r.parameters,
             required_status_checks: [
-              { context: 'clud-bug-review' },
+              { context: 'clud-bug-review', integration_id: 3944857 },
               { context: 'check-decisions' },
               { context: 'check-derived-docs' },
               { context: 'lint' },
@@ -344,6 +346,114 @@ test('apply: missing status check context — superset PUT preserves extras', as
   const merged = contextsOf(calls.lastUpdatePayload.rules);
   assert.ok(merged.includes('check-links'));
   assert.ok(merged.includes('lint'));
+});
+
+// ---------------------------------------------------------------------------
+// SPEC §10.3.3 point 2 — the `integration_id` App pin.
+//
+// An unpinned `clud-bug-review` context is just a string: any actor with
+// checks:write (including the PR author) can post a check run by that name,
+// and GitHub's latest-run-wins semantics let the forged run satisfy the gate.
+// These three tests pin the three ways that guarantee can be lost.
+// ---------------------------------------------------------------------------
+
+test('apply: PUT preserves the integration_id pin (regression — it was stripped)', async () => {
+  // The exact defect: mergeForPut rebuilt every entry as a bare `{ context }`,
+  // so ANY apply silently downgraded a correctly-pinned repo to a forgeable
+  // one. Drift something unrelated (a missing context) to force the PUT, then
+  // assert the pin survived the round-trip.
+  const existing = canonicalRuleset();
+  existing.rules = existing.rules.map((r) =>
+    r.type === 'required_status_checks'
+      ? {
+          ...r,
+          parameters: {
+            ...r.parameters,
+            required_status_checks: [
+              { context: 'clud-bug-review', integration_id: 3944857 },
+              { context: 'check-decisions' },
+              { context: 'check-derived-docs' },
+              // check-links missing → forces a PUT
+            ],
+          },
+        }
+      : r,
+  );
+  const { octokit, calls } = makeOctokitMock({ rulesets: [existing] });
+  await applyCanonicalRuleset(octokit, { owner: 'octo', repo: 'demo' });
+  assert.equal(calls.updateRepoRuleset, 1);
+  const rule = calls.lastUpdatePayload.rules.find(
+    (r) => r.type === 'required_status_checks',
+  );
+  const review = rule.parameters.required_status_checks.find(
+    (c) => c.context === 'clud-bug-review',
+  );
+  assert.equal(
+    review.integration_id,
+    3944857,
+    `pin stripped from PUT payload: ${JSON.stringify(rule.parameters.required_status_checks)}`,
+  );
+});
+
+test('apply: an UNPINNED clud-bug-review is drift, not already-canonical', async () => {
+  // Before the fix this reported "already canonical" — the repo looked
+  // configured while its gate stayed forgeable.
+  const existing = canonicalRuleset();
+  existing.rules = existing.rules.map((r) =>
+    r.type === 'required_status_checks'
+      ? {
+          ...r,
+          parameters: {
+            ...r.parameters,
+            required_status_checks: r.parameters.required_status_checks.map((c) =>
+              c.context === 'clud-bug-review' ? { context: c.context } : c,
+            ),
+          },
+        }
+      : r,
+  );
+  const { octokit, calls } = makeOctokitMock({ rulesets: [existing] });
+  const result = await applyCanonicalRuleset(octokit, {
+    owner: 'octo',
+    repo: 'demo',
+  });
+  assert.equal(result.alreadyCanonical, false);
+  assert.ok(
+    result.changes.some((c) => /integration_id.*\(unpinned\).*3944857/.test(c)),
+    `expected an integration_id drift line; got: ${result.changes.join(' | ')}`,
+  );
+  assert.equal(calls.updateRepoRuleset, 1);
+});
+
+test("apply: a repo's own extra context keeps its own integration_id", async () => {
+  // Superset contract: we own `clud-bug-review`, but a repo pinning its own
+  // `lint` check to some other App must not have that pin clobbered either.
+  const existing = canonicalRuleset();
+  existing.rules = existing.rules.map((r) =>
+    r.type === 'required_status_checks'
+      ? {
+          ...r,
+          parameters: {
+            ...r.parameters,
+            required_status_checks: [
+              ...r.parameters.required_status_checks.filter(
+                (c) => c.context !== 'check-links',
+              ),
+              { context: 'lint', integration_id: 99999 },
+            ],
+          },
+        }
+      : r,
+  );
+  const { octokit, calls } = makeOctokitMock({ rulesets: [existing] });
+  await applyCanonicalRuleset(octokit, { owner: 'octo', repo: 'demo' });
+  const rule = calls.lastUpdatePayload.rules.find(
+    (r) => r.type === 'required_status_checks',
+  );
+  const lint = rule.parameters.required_status_checks.find(
+    (c) => c.context === 'lint',
+  );
+  assert.equal(lint.integration_id, 99999);
 });
 
 test('apply: extra status check context alone → no-op (superset preserved)', async () => {


### PR DESCRIPTION
## The defect

**The `clud-bug-review` merge gate has been forgeable in every repo `clud-bug configure-github` has ever configured.**

SPEC §10.3.3 point 2 requires the required-status-check entry to pin `integration_id` to the clud-bug App, so that only the App can satisfy the gate. Without the pin the context is just a string: **any actor with `checks:write` — including the PR author — can post a check run named `clud-bug-review`**, and GitHub's latest-run-wins semantics let that forged run satisfy the gate over the App's real verdict.

Three independent defects, each sufficient on its own:

| # | Defect | Evidence |
|---|---|---|
| 1 | The vendored presets omitted the pin | `data/rulesets/clud-bug.json`, `skdd.json`, `canonical-v1.json` shipped `{ "context": "clud-bug-review" }`. reporulez — the canonical source these are *vendored from* — has carried `integration_id: 3944857` since the Z6 pin landed. **Our copies were stale.** |
| 2 | `mergeForPut` **stripped** the pin on every apply | `required_status_checks: merged.map((context) => ({ context }))` rebuilt every entry as a bare `{ context }`. A repo correctly pinned by hand in the GitHub UI was **downgraded back to forgeable by the next `configure-github` run.** |
| 3 | The diff treated an unpinned context as canonical | An affected repo reported **"already canonical"** — it looked configured while its gate stayed open. |

## The fix

- **Presets**: pin added to the three presets that require `clud-bug-review`. Surgical edit rather than a wholesale re-vendor — re-vendoring reformatted ~100 lines of JSON and buried the one semantic change, which is the wrong diff to hand a reviewer for a security fix.
- **`statusCheckEntries`** (new): preserves `{ context, integration_id }`. The string-only `statusCheckContexts` stays for human-readable diff labels; anything that **round-trips entries back to the API** must use the new one.
- **`mergeForPut`**: precedence is now per-**field**, not per-entry — our pin wins where we specify one (cannot be downgraded), the repo's pin is preserved where we don't, extras carry verbatim. **We only ever ADD pin strength.**
- **`diffRuleParams`**: an unpinned/wrong-pinned context we ship pinned is now reported as drift.
- **`unionContexts` deleted** rather than left dead — a string-only union is exactly the convenient helper a future edit reaches for, reintroducing the strip.

## Self-review caught a second instance of the same bug

The first version of this fix took our desired entry wholesale for any context we ship — which **stripped a repo's own pin on every context we ship unpinned** (skdd ships `check-links` unpinned). Same forgeability regression, one level over. Reproduced before fixing; that's why precedence is per-field.

## Verification

- **4 new tests, all control-tested** — reverting each fix makes the corresponding test fail:
  - reintroducing the strip → 2 fail
  - reverting per-field precedence → 1 fails
  - the drift test covers the diff half independently
- `npm test` → **1061 passed / 49 files**. `npm run test:fixtures` → 5 passed.
- 8 pre-existing "already-canonical" tests correctly began failing (their fixtures encoded the old **unpinned** state) and were updated — the fixture now represents a genuinely canonical repo.

## Operator note

Repos already configured with the unpinned gate need **`clud-bug configure-github <owner>/<repo>`** re-run to converge. It now reports the drift instead of claiming already-canonical.

## Follow-up (not in this PR)

§10.3.3 point 2 says to pin `clud-bug-review`, but says nothing about an applier never **downgrading** an existing pin — the normative rule this work produced. Filing that to protocol separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)