### PR TITLE
chore(skills): refresh bundled evidence-based-review from agent-skills@2dc8360

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+### Changed
+
+- **Bundled `evidence-based-review` SKILL.md refreshed** from `thrillmade/agent-skills@2dc8360`. `BASELINE_SKILLS_REF` in `src/cli/skills.ts` pinned to the same commit so the install-time fetch path and the bundled offline-fallback path resolve to byte-identical content. Auto-synced by `agent-skills/.github/workflows/notify-clud-bug.yml`.
+
+
 ### Fixed
 
 - **🔴 The `clud-bug-review` merge gate was forgeable — `configure-github` shipped it unpinned, and

--- a/src/cli/skills.ts
+++ b/src/cli/skills.ts
@@ -31,7 +31,7 @@ export const MANIFEST_VERSION = 1;
 // skill content, bump BASELINE_SKILLS_REF below in the same clud-bug PR
 // that ships the corresponding bundled fallback update.
 // See thrillmade/agent-skills — skills.sh `skills/<name>/SKILL.md` layout.
-const BASELINE_SKILLS_REF = 'bd1b554037ec08d4150e9fee89a087cc937092b5';
+const BASELINE_SKILLS_REF = '2dc8360c8bdfb916d37fc85c23b04f63559daad6';
 const AGENT_SKILLS_BASE =
   process.env['CLUD_BUG_AGENT_SKILLS_BASE'] ??
   `https://raw.githubusercontent.com/thrillmade/agent-skills/${BASELINE_SKILLS_REF}/skills`;

--- a/templates/skills/baseline/evidence-based-review.md
+++ b/templates/skills/baseline/evidence-based-review.md
@@ -1,7 +1,6 @@
 ---
 name: evidence-based-review
 description: Every PR review claim must quote the specific code being criticized. No hand-waving.
-review_mode: shared
 ---
 
 # Evidence-based review


### PR DESCRIPTION
Automated bundled-copy sync from `thrillmade/agent-skills`.

**Trigger:** `push` on `thrillmade/agent-skills`.
**Source SKILL.md:** https://github.com/thrillmade/agent-skills/blob/2dc8360c8bdfb916d37fc85c23b04f63559daad6/skills/evidence-based-review/SKILL.md
**Source commit:** https://github.com/thrillmade/agent-skills/commit/2dc8360c8bdfb916d37fc85c23b04f63559daad6

## Changes applied

- `templates/skills/baseline/evidence-based-review.md` ← byte-for-byte copy of the source above.
- `src/cli/skills.ts` — `BASELINE_SKILLS_REF` bumped to `2dc8360c8bdfb916d37fc85c23b04f63559daad6` so the install-time fetch from `thrillmade/agent-skills` and the bundled offline-fallback both resolve to identical content.
- `CHANGELOG.md` — entry under [Unreleased] documenting the refresh.

**`package.json` is deliberately untouched.** This PR proposes *content*; assigning a version is your release decision, not ours. The CHANGELOG entry sits under [Unreleased] for your own release process to fold in.

## How this was generated

`agent-skills/.github/workflows/notify-clud-bug.yml` — fires on push to `main` matching one of the tracked baseline-skill paths, or via manual `workflow_dispatch` for a chosen skill.