### PR TITLE
Fix #258: map dependabot secrets explicitly instead of `secrets: inherit`

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,4 +18,16 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     # Pinned to thrillmade/.github commit 6e1f9df for supply-chain immutability (per clud-bug-review on PR #144). Bump via dependabot or manual edit.
     uses: thrillmade/.github/.github/workflows/dependabot-auto-merge.yml@6e1f9dfd2695396d5ae2b14af9a84ca132784a94
-    secrets: inherit
+    # Map explicitly — `secrets: inherit` does NOT work here.
+    #
+    # `inherit` forwards the caller's secrets under THEIR OWN names, so the
+    # callee received `THRILLMADE_ORCHESTRATOR_APP_ID`. But the reusable
+    # workflow declares its inputs in kebab-case (`orchestrator-app-id`,
+    # `orchestrator-private-key`, both `required: true`), so those were never
+    # populated and every Dependabot PR silently failed to auto-merge.
+    #
+    # clud-bug was the only caller using `inherit`; logmind, agent-skills and
+    # reporulez all map explicitly, exactly as below. Keep it that way.
+    secrets:
+      orchestrator-app-id: ${{ secrets.THRILLMADE_ORCHESTRATOR_APP_ID }}
+      orchestrator-private-key: ${{ secrets.THRILLMADE_ORCHESTRATOR_PRIVATE_KEY }}

--- a/docs/decisions-branches/fix__258-secrets-mapping.md
+++ b/docs/decisions-branches/fix__258-secrets-mapping.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-07 16:26 - Fix 258: map dependabot secrets explicitly instead of secrets: inherit
+
+**Reasoning:** `secrets: inherit` forwards the caller's secrets under THEIR OWN names, so the reusable workflow's kebab-case inputs (orchestrator-app-id, orchestrator-private-key, both required) were never populated and every Dependabot PR silently failed to auto-merge. Verified against the callee at pinned commit 6e1f9df — its own documented usage example is byte-identical to this mapping.
+
+**Alternatives considered:** Keep secrets: inherit and rename the callee's inputs to SCREAMING_CASE — rejected: clud-bug is the only caller of four using inherit; logmind, agent-skills and reporulez already map explicitly, so changing the shared callee would break three working callers to accommodate one broken one
+
+**Implications:**
+- Dependabot PRs auto-merge again, which removes a human from every dependency merge across repos (named as a friction in protocol#83)
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,6 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
+## 2026-08
+
+- **2026-08-07** — Fix 258: map dependabot secrets explicitly instead of secrets: inherit *(fix/258-secrets-mapping)* — [decisions-branches/fix__258-secrets-mapping.md](decisions-branches/fix__258-secrets-mapping.md)
+
 ## 2026-07 (40 decisions)
 
 - **2026-07-28** — F1a follow-up: pin precedence is per-FIELD, never per-entry *(fix/f1a-integration-id-pin)* — [decisions-branches/fix__f1a-integration-id-pin.md](decisions-branches/fix__f1a-integration-id-pin.md)


### PR DESCRIPTION
Closes #258.

## The bug

`secrets: inherit` forwards the caller's secrets **under their own names**, so the reusable workflow received `THRILLMADE_ORCHESTRATOR_APP_ID`. But the callee declares its inputs in **kebab-case** — `orchestrator-app-id`, `orchestrator-private-key` — so both arrived unpopulated and every Dependabot PR silently failed to auto-merge.

## Verification

Read the callee at its pinned commit `6e1f9df`:

```
on:
  workflow_call:
    secrets:
      orchestrator-app-id:
```

Kebab-case confirmed. Its own documented usage example is **byte-identical** to this mapping:

```
#       secrets:
#         orchestrator-app-id: ${{ secrets.THRILLMADE_ORCHESTRATOR_APP_ID }}
#         orchestrator-private-key: ${{ secrets.THRILLMADE_ORCHESTRATOR_PRIVATE_KEY }}
```

clud-bug was the **only** caller of four using `inherit`; logmind, agent-skills and reporulez already map explicitly.

## Why this matters more than it looks

protocol#83 names this as one of two frictions putting a human on every merge:

> *"Every merge needs an administrator. One identity, a one-approval rule, and **Dependabot's auto-approve broken by a secrets mismatch**."*

That mismatch is this. The effect is cross-repo, not just the local Dependabot queue.

## How to verify it worked

**Leave #226 unmerged.** It's a lockfile-only devDependency bump against `main` — the safest possible live test. If it auto-merges after this lands, the fix is proven in production on a change that cannot hurt us. If it doesn't, we learn immediately and cheaply.

## Cleanup

The remote branch `fix/258-dependabot-secrets` points at `5df5717` — plain old `main`, containing **none** of this fix. The work had been stashed, never committed to it. It reads as if #258 were handled. Please delete it.

## Scope note

Branched from current `origin/main`, not from the preserved work — that predates #282, so rebuilding from it would have silently reverted the `next` CVE bump you just merged. Only the workflow hunk is applied here; `site/package.json` still reads `^16.2.12`.
