### PR TITLE
SPEC §4.9: unset the default $5 per-PR cost ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,31 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
   `--jq 'select(.name == "<name>")'` command by splicing an observed (attacker-influenced) check name
   into a new shell invocation — one fetch reads name + summary together instead.
 
+- **🟡 The per-PR cost ceiling defaulted to $5 and silently truncated reviews nobody asked to
+  truncate (SPEC §4.9).** `core/budget-plan.ts` applied `DEFAULT_PER_PR_CAP_USD = 5.0`
+  unconditionally: `estimateBudget` fell back to it whenever a caller passed no `perPrCapUsd`, and
+  no caller ever passes one — not the CLI's `resolveReviewInputs`, not the hosted orchestrator. A
+  plan estimated over $5 was denied, and the customer got a "clud-bug paused this review" comment
+  telling them to lower `reviewPasses.count`.
+
+  §4.9 is explicit that the repository's own ceiling is the customer's choice, "configurable per
+  install and **defaulting to unset** — no ceiling until someone chooses one, because a default cap
+  silently truncates reviews nobody asked to truncate."
+
+  `estimateBudget` now treats an omitted `perPrCapUsd` as **no ceiling** and can never deny on that
+  path; `BudgetEstimate.capUsd` is `number | null` and reports `null` when unset. An
+  **explicitly-configured ceiling behaves exactly as before**, including `0` (a choice, not "unset")
+  and the `billingExempt` bypass.
+
+  Two nearby mechanisms §4.9 keeps separate are deliberately **unchanged**: the hosted App's
+  runaway guard (`clud-bug-app/lib/runaway-guard.ts`, $5/PR/24h on the operator's own spend, applied
+  to every install), which §4.9 explicitly permits; and `estimateVerifierBudget`'s D.2.6 cap, whose
+  deny routes threads through the heuristic fallback rather than truncating a review.
+
+  `DEFAULT_PER_PR_CAP_USD` is renamed `SUGGESTED_PER_PR_CAP_USD` — a value a caller may *choose*,
+  never one that is applied. The old name is kept as a deprecated alias so existing importers keep
+  compiling, and goes in a major (SPEC §7.5).
+
 - **🔴 The `clud-bug-review` merge gate was forgeable — `configure-github` shipped it unpinned, and
   stripped the pin if you set one by hand.** SPEC §10.3.3 point 2 requires the required-status-check
   entry to pin `integration_id` to the clud-bug App, so that only the App can satisfy the gate. Without

--- a/docs/decisions-branches/spec-4-9-unset-per-pr-cost-cap.md
+++ b/docs/decisions-branches/spec-4-9-unset-per-pr-cost-cap.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-07 17:01 - SPEC 4.9: unset the default $5 per-PR cost ceiling in core/budget-plan
+
+**Reasoning:** SPEC 2.0 4.9 requires the repository-facing cost ceiling to be 'configurable per install and defaulting to unset - no ceiling until someone chooses one, because a default cap silently truncates reviews nobody asked to truncate'. estimateBudget applied DEFAULT_PER_PR_CAP_USD = 5.0 whenever perPrCapUsd was absent, and no caller ever passes it (neither the CLI's resolveReviewInputs nor the hosted orchestrator), so every install ran under a $5 ceiling it never chose. An omitted perPrCapUsd now means no ceiling; capUsd is number|null and reports null. An explicitly-configured ceiling is unchanged, including 0 (a choice, not unset) and the billingExempt bypass.
+
+**Alternatives considered:** Delete the gate entirely - rejected: an explicitly-configured ceiling is exactly what 4.9 requires a reviewer to EXPOSE, so the machinery must stay. Also rejected: unsetting the neighbouring caps. 4.9 names two distinct limits and there are three mechanisms here - the App's runaway-guard (operator's floor on its OWN spend, $5/PR/24h, applies to every install) is explicitly permitted by 4.9 and is untouched, and estimateVerifierBudget's D.2.6 cap denies into the heuristic fallback rather than truncating a review, so it keeps its default.
+
+**Implications:**
+- estimateBudget now returns allow on every default path; the hosted 'clud-bug paused this review' comment can only fire for a repo that asked for a ceiling. DEFAULT_PER_PR_CAP_USD is renamed SUGGESTED_PER_PR_CAP_USD and kept as a deprecated alias so clud-bug-app's lib/budget-gate.ts re-export shim keeps compiling (7.5); removal waits for a major. Two halves of 4.9 remain UNBUILT and are not in this change: nothing maps a .clud-bug.json key onto perPrCapUsd (the 'configurable per install' half), and this gate is a per-attempt pre-flight estimate, not the cumulative-across-attempts actual spend 4.9 describes.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-08 (5 decisions)
+## 2026-08 (6 decisions)
 
-- **2026-08-07** — Fix 258: map dependabot secrets explicitly instead of secrets: inherit *(fix/258-secrets-mapping)* — [decisions-branches/fix__258-secrets-mapping.md](decisions-branches/fix__258-secrets-mapping.md)
-- *... 3 more decisions ...*
+- **2026-08-07** — SPEC 4.9: unset the default $5 per-PR cost ceiling in core/budget-plan *(spec-4-9-unset-per-pr-cost-cap)* — [decisions-branches/spec-4-9-unset-per-pr-cost-cap.md](decisions-branches/spec-4-9-unset-per-pr-cost-cap.md)
+- *... 4 more decisions ...*
 - **2026-08-01** — File three Wave 0 admin findings (pre-push gap, spec-version drift, stale SPEC citations) and warn agents to read issue threads not bodies *(wave0-admin-issues)* — [decisions-branches/wave0-admin-issues.md](decisions-branches/wave0-admin-issues.md)
 
 ## 2026-07 (40 decisions)

--- a/src/core/budget-plan.ts
+++ b/src/core/budget-plan.ts
@@ -25,9 +25,29 @@ import type { ResolvedReviewPasses } from './review-plan.js';
  * customer eating a surprise bill. A 20% over-estimate that occasionally
  * causes a "we paused; raise the cap" comment is the right failure mode.
  *
- * Until D.4 wires real per-install budgets, this module always returns
- * `{ verdict: 'allow' }`. The implementation is intentionally complete so
- * D.4 can flip a single switch without changing the orchestrator surface.
+ * SPEC §4.9 — THREE MECHANISMS LIVE NEARBY; DO NOT CONFLATE THEM:
+ *
+ *   1. This module's `perPrCapUsd` — the REPOSITORY's own ceiling, and the
+ *      one §4.9 governs. It defaults to UNSET: "no ceiling until someone
+ *      chooses one, because a default cap silently truncates reviews nobody
+ *      asked to truncate." It used to default to $5, which is the bug this
+ *      docblock now exists to keep fixed.
+ *
+ *   2. clud-bug-app's `lib/runaway-guard.ts` — the OPERATOR's floor on its
+ *      OWN spend ($5/PR/24h + a review-count cap, applied to every install
+ *      including billing-exempt ones). §4.9 explicitly protects it: it "MUST
+ *      NOT be read as forbidden by the rule above." Not this module's
+ *      business, and not ours to unset.
+ *
+ *   3. `estimateVerifierBudget` below — the D.2.6 fix-verifier's own per-PR
+ *      budget. A separate surface with a separate failure mode (denying it
+ *      routes threads through the heuristic fallback rather than truncating
+ *      a review), so it keeps its default; see its own docblock.
+ *
+ * With (1) unset by default, `estimateBudget` returns `{ verdict: 'allow' }`
+ * on every path unless a caller passes a ceiling. The implementation stays
+ * complete so wiring a per-install ceiling is a plumbing change here, not a
+ * redesign of the orchestrator surface.
  */
 
 // ---------------------------------------------------------------------------
@@ -60,13 +80,25 @@ const MODEL_CEILING_USD: Record<string, number> = {
 const DEFAULT_PER_CALL_USD = 0.5;
 
 /**
- * Default per-PR cap. Real number lives in `env.REVIEW_SPEND_CAP_USD` once
- * D.4 wires that env var — for now this is the hard-coded ceiling.
+ * A *suggested* per-PR ceiling for an operator or repository that wants one.
+ * NOT applied by default — see `estimateBudget` and SPEC §4.9.
  *
  * $5 = a 3-pass review across 10 expensive skills (~30 calls × $0.15 avg).
- * Anything above that is almost certainly a misconfigured `reviewPasses`.
+ * Anything above that is almost certainly a misconfigured `reviewPasses`,
+ * which makes it a sane number to *offer*. It is only ever in force when a
+ * caller passes it as `perPrCapUsd`.
  */
-export const DEFAULT_PER_PR_CAP_USD = 5.0;
+export const SUGGESTED_PER_PR_CAP_USD = 5.0;
+
+/**
+ * @deprecated Renamed to {@link SUGGESTED_PER_PR_CAP_USD}. This value is no
+ * longer a default — SPEC §4.9 requires the repository-facing ceiling to
+ * default to unset, so nothing applies it unless a caller passes
+ * `perPrCapUsd`. Kept as an alias so existing importers (notably
+ * clud-bug-app's `lib/budget-gate.ts` re-export shim) keep compiling; it will
+ * go in a major (SPEC §7.5).
+ */
+export const DEFAULT_PER_PR_CAP_USD = SUGGESTED_PER_PR_CAP_USD;
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -78,8 +110,18 @@ export interface BudgetEstimateInput {
   /** Model slugs the orchestrator plans to route to, in pass order. */
   roleModels: string[];
   /**
-   * Optional per-PR USD cap override. Defaults to `DEFAULT_PER_PR_CAP_USD`.
-   * D.4 wires per-install caps via `INSTALLS:{id}.spend_cap_usd`.
+   * The repository's per-PR USD ceiling, when it has chosen one.
+   *
+   * **Omitted / `undefined` means UNSET — no ceiling, never a deny.** SPEC
+   * §4.9: the customer-facing ceiling is "configurable per install and
+   * defaulting to unset — no ceiling until someone chooses one, because a
+   * default cap silently truncates reviews nobody asked to truncate."
+   *
+   * This is NOT the operator's own runaway guard. §4.9 keeps those separate:
+   * "Whoever pays for the inference MAY cap what a single pull request can
+   * consume of it, at a default of their choosing." That guard lives in
+   * clud-bug-app (`lib/runaway-guard.ts`, $5/PR/24h, applies to every install
+   * including billing-exempt) and is untouched by this default.
    */
   perPrCapUsd?: number;
   /**
@@ -97,9 +139,15 @@ export interface BudgetEstimate {
   estimatedCostUsd: number;
   /** Per-call ceiling used (max across the role models). */
   perCallCeilingUsd: number;
-  /** The cap the estimate was checked against. */
-  capUsd: number;
+  /**
+   * The cap the estimate was checked against, or `null` when no ceiling is
+   * configured (the SPEC §4.9 default). A `null` cap can never deny.
+   */
+  capUsd: number | null;
 }
+
+/** A `deny` always has a ceiling — you cannot exceed a cap nobody set. */
+export type CappedBudgetEstimate = BudgetEstimate & { capUsd: number };
 
 export type BudgetVerdict =
   | {
@@ -108,7 +156,7 @@ export type BudgetVerdict =
     }
   | {
       verdict: 'deny';
-      estimate: BudgetEstimate;
+      estimate: CappedBudgetEstimate;
       /** Friendly reason for the orchestrator's "we paused this review" comment. */
       reason: string;
     };
@@ -131,19 +179,27 @@ export function perCallCeiling(models: string[]): number {
 }
 
 /**
- * Layer-1 cost gate. Decides whether the planned passes fit under the cap.
+ * Layer-1 cost gate. Decides whether the planned passes fit under the
+ * repository's ceiling — **if it has set one**.
  *
  * Behavior matrix:
+ *   perPrCapUsd omitted (UNSET)      → allow, always (SPEC §4.9 default)
  *   billingExempt = true             → allow (skip cap entirely)
  *   estimatedCostUsd > cap           → deny + friendly reason
  *   estimatedCostUsd <= cap          → allow
  *   resolved.length === 0            → allow (single-pass D.2.0 path)
  *
- * Until D.4 wires real per-install spending, callers see allow on every
- * normal path — the deny branch only fires on truly absurd estimates.
+ * The unset default is the SPEC §4.9 rule, quoted verbatim: a reviewer
+ * exposes a cost ceiling "configurable per install and defaulting to unset —
+ * no ceiling until someone chooses one, because a default cap silently
+ * truncates reviews nobody asked to truncate." An operator's own floor on its
+ * own spend is a different mechanism §4.9 explicitly permits ("MUST NOT be
+ * read as forbidden by the rule above") and lives elsewhere — see
+ * `perPrCapUsd`'s doc comment.
  */
 export function estimateBudget(input: BudgetEstimateInput): BudgetVerdict {
-  const cap = input.perPrCapUsd ?? DEFAULT_PER_PR_CAP_USD;
+  // UNSET by default. `?? null`, never `?? SUGGESTED_PER_PR_CAP_USD`.
+  const cap = input.perPrCapUsd ?? null;
   const ceiling = perCallCeiling(input.roleModels);
   // The orchestrator (runMultiPass) sends all skills in a SINGLE prompt
   // each pass and loops only the max skill's count times. Real call count
@@ -164,10 +220,10 @@ export function estimateBudget(input: BudgetEstimateInput): BudgetVerdict {
   if (input.billingExempt) {
     return { verdict: 'allow', estimate };
   }
-  if (cost > cap) {
+  if (cap !== null && cost > cap) {
     return {
       verdict: 'deny',
-      estimate,
+      estimate: { ...estimate, capUsd: cap },
       reason: friendlyDenyReason({ cost, cap, calls, ceiling }),
     };
   }
@@ -227,6 +283,12 @@ const VERIFIER_PER_CALL_CEILING_USD = 0.01;
  *
  * D.4 will plumb per-install caps; for D.2.6 we use a single repo-wide
  * default. Installs in BILLING_EXEMPT_ORGS bypass this entirely.
+ *
+ * This default is deliberately NOT unset (unlike the review ceiling above).
+ * It is mechanism (3) in the module docblock: denying it does not truncate a
+ * review — it routes the open threads through the heuristic auto-resolve
+ * fallback, so the review still lands complete. Changing it is a separate
+ * decision from the SPEC §4.9 fix; do not fold the two together.
  */
 export const DEFAULT_VERIFIER_PER_PR_CAP_USD = 0.6;
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -264,10 +264,15 @@ export {
   estimateBudget,
   estimateVerifierBudget,
   __setModelCeilingForTests,
+  SUGGESTED_PER_PR_CAP_USD,
+  // Deprecated alias of SUGGESTED_PER_PR_CAP_USD — no longer a default
+  // (SPEC §4.9 requires the repo-facing ceiling to default unset). Kept for
+  // existing importers until a major (SPEC §7.5).
   DEFAULT_PER_PR_CAP_USD,
   DEFAULT_VERIFIER_PER_PR_CAP_USD,
   type BudgetEstimateInput,
   type BudgetEstimate,
+  type CappedBudgetEstimate,
   type BudgetVerdict,
   type VerifierBudgetInput,
   type VerifierBudgetEstimate,

--- a/src/core/plan-review.ts
+++ b/src/core/plan-review.ts
@@ -42,7 +42,10 @@ export interface PlanReviewInput {
   trigger?: ReviewTrigger;
   /** Diff size under review, in bytes — enables large-diff auto-tiering. */
   diffSizeBytes?: number;
-  /** Optional per-PR USD cap forwarded to the budget gate. */
+  /**
+   * The repository's per-PR USD ceiling, forwarded to the budget gate.
+   * Omitted = UNSET = no ceiling (SPEC §4.9); see `BudgetEstimateInput`.
+   */
   perPrCapUsd?: number;
   /** Billing-exempt installs bypass the budget cap. */
   billingExempt?: boolean;

--- a/test/core/budget-plan.test.js
+++ b/test/core/budget-plan.test.js
@@ -9,13 +9,15 @@ import {
   __setModelCeilingForTests,
   DEFAULT_PER_PR_CAP_USD,
   DEFAULT_VERIFIER_PER_PR_CAP_USD,
+  SUGGESTED_PER_PR_CAP_USD,
   estimateBudget,
   estimateVerifierBudget,
   perCallCeiling,
 } from '../../src/core/budget-plan.js';
 
 // Tests focus on:
-//   - Per-PR cap blocks an obviously expensive plan
+//   - The per-PR ceiling is UNSET by default (SPEC §4.9)
+//   - An explicitly-configured ceiling blocks an over-budget plan
 //   - billingExempt bypasses the cap entirely
 //   - empty resolved (single-pass D.2.0 path) always allows
 //   - unknown models fall back to the conservative ceiling
@@ -83,9 +85,9 @@ describe('estimateBudget', () => {
   });
 
   it('denies when estimated cost exceeds the cap', () => {
-    // 3 passes × $0.50/call opus = $1.50. With a custom $1 cap → deny.
-    // (Default $5 cap with the new max-based math is not reachable via
-    // the count: 3 HARD CAP; this case validates the deny path explicitly.)
+    // 3 passes × $0.50/call opus = $1.50. With a configured $1 cap → deny.
+    // A ceiling only ever applies because the caller passed one (SPEC §4.9);
+    // this case validates that the deny path still works exactly as before.
     const verdict = estimateBudget({
       resolved: Array.from({ length: 20 }, (_, i) => pass(`s${i}`, 3)),
       roleModels: ['anthropic/claude-opus-4.7'],
@@ -121,12 +123,93 @@ describe('estimateBudget', () => {
     }
   });
 
-  it('reports the default cap when none provided', () => {
+  // -------------------------------------------------------------------------
+  // SPEC §4.9 — "configurable per install and defaulting to unset — no ceiling
+  // until someone chooses one, because a default cap silently truncates
+  // reviews nobody asked to truncate."
+  // -------------------------------------------------------------------------
+
+  it('reports NO cap when none is configured (§4.9 unset default)', () => {
     const verdict = estimateBudget({
       resolved: [pass('a', 1)],
       roleModels: ['anthropic/claude-sonnet-4.6'],
     });
-    expect(verdict.estimate.capUsd).toBe(DEFAULT_PER_PR_CAP_USD);
+    expect(verdict.estimate.capUsd).toBeNull();
+    expect(verdict.verdict).toBe('allow');
+  });
+
+  it('never denies with no ceiling configured, however expensive the plan', () => {
+    // 50 passes × $0.50/call opus = $25 — an estimate that would have blown
+    // straight through the old hard-coded $5 default and silently truncated
+    // the review. With the ceiling unset there is nothing to exceed.
+    const verdict = estimateBudget({
+      resolved: [pass('a', 50)],
+      roleModels: ['anthropic/claude-opus-4.7'],
+    });
+    expect(verdict.verdict).toBe('allow');
+    expect(verdict.estimate.estimatedCostUsd).toBeCloseTo(25, 5);
+    expect(verdict.estimate.capUsd).toBeNull();
+    // No deny → no "we paused this review" comment for the customer.
+    expect(verdict.reason).toBeUndefined();
+  });
+
+  it('does NOT apply the suggested $5 value as a default', () => {
+    // Regression pin for the §4.9 violation: `estimateBudget` must not fall
+    // back to SUGGESTED_PER_PR_CAP_USD. $5.50 > $5, so if the old default
+    // were still wired this would deny.
+    const overFive = estimateBudget({
+      resolved: [pass('a', 11)],
+      roleModels: ['anthropic/claude-opus-4.7'], // 11 × $0.50 = $5.50
+    });
+    expect(overFive.estimate.estimatedCostUsd).toBeGreaterThan(
+      SUGGESTED_PER_PR_CAP_USD,
+    );
+    expect(overFive.verdict).toBe('allow');
+
+    // The same plan WITH the suggested value passed explicitly still denies —
+    // an operator/repo that chooses $5 gets exactly the old behavior.
+    const explicit = estimateBudget({
+      resolved: [pass('a', 11)],
+      roleModels: ['anthropic/claude-opus-4.7'],
+      perPrCapUsd: SUGGESTED_PER_PR_CAP_USD,
+    });
+    expect(explicit.verdict).toBe('deny');
+    if (explicit.verdict === 'deny') {
+      expect(explicit.estimate.capUsd).toBe(5);
+      expect(explicit.reason).toMatch(/per-PR cap of `\$5\.00`/);
+    }
+  });
+
+  it('keeps DEFAULT_PER_PR_CAP_USD as a deprecated alias of the suggested value', () => {
+    // Kept only so existing importers (clud-bug-app lib/budget-gate.ts shim)
+    // keep compiling — SPEC §7.5. It is a suggestion now, not a default.
+    expect(DEFAULT_PER_PR_CAP_USD).toBe(SUGGESTED_PER_PR_CAP_USD);
+    expect(SUGGESTED_PER_PR_CAP_USD).toBe(5);
+  });
+
+  it('honours an explicit ceiling of 0 (0 is a choice, not "unset")', () => {
+    // `?? null` and not `|| null`: a repo that sets 0 means "review nothing
+    // that costs anything", and must not be silently read as unset.
+    const verdict = estimateBudget({
+      resolved: [pass('a', 1)],
+      roleModels: ['anthropic/claude-sonnet-4.6'], // $0.08 > $0
+      perPrCapUsd: 0,
+    });
+    expect(verdict.verdict).toBe('deny');
+    if (verdict.verdict === 'deny') {
+      expect(verdict.estimate.capUsd).toBe(0);
+    }
+  });
+
+  it('an explicit ceiling still yields to billingExempt', () => {
+    const verdict = estimateBudget({
+      resolved: [pass('a', 50)],
+      roleModels: ['anthropic/claude-opus-4.7'],
+      perPrCapUsd: 0.01,
+      billingExempt: true,
+    });
+    expect(verdict.verdict).toBe('allow');
+    expect(verdict.estimate.capUsd).toBe(0.01);
   });
 });
 

--- a/test/core/plan-review.test.js
+++ b/test/core/plan-review.test.js
@@ -103,4 +103,15 @@ describe('planReview', () => {
     expect(plan.budget.verdict).toBe('deny');
     expect(plan.summary).toMatch(/budget exceeded/i);
   });
+
+  it('plans with NO cost ceiling when the caller configures none (SPEC §4.9)', () => {
+    // The default path every consumer takes today — neither the CLI's
+    // `resolveReviewInputs` nor the hosted orchestrator passes `perPrCapUsd`.
+    const plan = planReview({ skills: SKILLS, config: CONFIG });
+    expect(plan.budget.estimate.capUsd).toBeNull();
+    expect(plan.budget.verdict).toBe('allow');
+    // The rendered recipe embeds `plan.summary`, so it must not name a cap.
+    expect(plan.summary).not.toMatch(/budget exceeded/i);
+    expect(plan.summary).toMatch(/est \$/);
+  });
 });


### PR DESCRIPTION
## The violation

`src/core/budget-plan.ts` applied `DEFAULT_PER_PR_CAP_USD = 5.0` unconditionally:

```ts
export const DEFAULT_PER_PR_CAP_USD = 5.0;          // was :69
const cap = input.perPrCapUsd ?? DEFAULT_PER_PR_CAP_USD;  // was :146
```

`perPrCapUsd` is optional and **no caller ever passes it** — not the CLI
(`src/cli/review-prompt.ts:548` calls `planReview` without it), not the hosted
orchestrator (`clud-bug-app/lib/orchestrator.ts:725` passes only `resolved`,
`roleModels`, `billingExempt: false`). So every install ran under a $5 ceiling it
never chose, and a plan estimated over it got a customer-facing
"clud-bug paused this review — … Lower `reviewPasses.count`" comment and, hosted,
`outcome: 'skipped:budget'`.

## What §4.9 actually says

From `git show origin/main:SPEC.md` in `thrillmade/protocol` (SPEC 2.0,
merged 2026-08-01), §4.9 "What a review may cost", verbatim:

> **A repository's own ceiling** is the customer's choice. A reviewer MUST expose
> a cumulative cost ceiling per pull request, counted across every review attempt
> on it, configurable per install and **defaulting to unset** — no ceiling until
> someone chooses one, because a default cap silently truncates reviews nobody
> asked to truncate.

and, in the same section:

> **An operator's floor on its own spend** is not that, and MUST NOT be read as
> forbidden by the rule above. Whoever pays for the inference MAY cap what a
> single pull request can consume of it, at a default of their choosing.

## The change

`estimateBudget` no longer substitutes a default:

```ts
// UNSET by default. `?? null`, never `?? SUGGESTED_PER_PR_CAP_USD`.
const cap = input.perPrCapUsd ?? null;
…
if (cap !== null && cost > cap) { /* deny, unchanged */ }
```

- `BudgetEstimate.capUsd` is now `number | null`; `null` = no ceiling configured.
- The `deny` variant carries `CappedBudgetEstimate` (`capUsd: number`) — you cannot
  exceed a cap nobody set, and this gives `plan-review.ts`'s summary its narrowing
  without a cast.
- **An explicitly-configured ceiling behaves exactly as before**, including `0`
  (`?? null`, not `|| null` — a repo that sets 0 means it, and must not be read as
  unset) and the `billingExempt` bypass.
- `DEFAULT_PER_PR_CAP_USD` → `SUGGESTED_PER_PR_CAP_USD`; the old name is kept as a
  deprecated alias, because `clud-bug-app/lib/budget-gate.ts` re-exports it and its
  `test/budget-gate.ts` asserts on it. Removing it belongs to a major (SPEC §7.5).

## Three mechanisms — what else reads this constant, and what was left alone

Asked for explicitly in the brief. `grep -rn 'DEFAULT_PER_PR_CAP_USD\|perPrCapUsd\|estimateBudget'` across both repos:

| # | Mechanism | Whose money | Verdict |
|---|---|---|---|
| 1 | `budget-plan.ts` `perPrCapUsd` | the **repository's** ceiling | **changed** — this is the one §4.9 governs |
| 2 | `clud-bug-app/lib/runaway-guard.ts` — $5/PR/24h + review-count cap | the **operator's** own spend | untouched. §4.9: "MUST NOT be read as forbidden by the rule above." Its own header records the PR #154 incident that motivated it, and that it must **not** be bypassed for `BILLING_EXEMPT_ORGS`. |
| 3 | `estimateVerifierBudget` (`DEFAULT_VERIFIER_PER_PR_CAP_USD = 0.6`) | D.2.6 fix-verifier | untouched. Different failure mode: a deny routes threads through the heuristic auto-resolve fallback, so the review still lands complete — it does not truncate a review. |

Consumers of the changed value: `src/core/plan-review.ts` (narrowing handled),
`src/core/index.ts` (export surface), and `clud-bug-app/lib/budget-gate.ts`
(pure re-export shim; keeps compiling via the deprecated alias).

The module docblock now carries this table so the next editor cannot conflate them.

## Tests

Both paths, in `test/core/budget-plan.test.js` + `test/core/plan-review.test.js`:

- `reports NO cap when none is configured (§4.9 unset default)` → `capUsd === null`
- `never denies with no ceiling configured, however expensive the plan` → a $25
  estimate allows, and emits no deny `reason`
- `does NOT apply the suggested $5 value as a default` → an $5.50 plan allows with no
  cap, and **denies with `perPrCapUsd: 5` passed explicitly** (old behaviour on demand)
- `honours an explicit ceiling of 0` → 0 is a choice, not "unset"
- `an explicit ceiling still yields to billingExempt`
- `keeps DEFAULT_PER_PR_CAP_USD as a deprecated alias`
- `plans with NO cost ceiling when the caller configures none` at the `planReview` level

Every pre-existing test in both files is unchanged and still passes — the
explicitly-configured path is not modified.

**Control-tested.** With only `?? null` reverted to `?? SUGGESTED_PER_PR_CAP_USD`,
the 4 new default-path tests fail and the 28 others still pass:

```
× reports NO cap when none is configured (§4.9 unset default)
× never denies with no ceiling configured, however expensive the plan
× does NOT apply the suggested $5 value as a default
× plans with NO cost ceiling when the caller configures none (SPEC §4.9)
Tests  4 failed | 28 passed (32)
```

Restored: `Test Files 49 passed (49) · Tests 1069 passed (1069)`; `tsc -p tsconfig.json` clean.

## ⚠️ Not fixed here — two halves of §4.9 that remain unbuilt

Flagged rather than silently expanded, per the brief's scope
("make the default unset while keeping an explicitly-configured ceiling working
exactly as before"):

1. **"configurable per install" is not wired.** `perPrCapUsd` is reachable only by a
   programmatic caller — no `.clud-bug.json` key maps onto it, and neither shipped
   consumer passes one. §4.9 requires a reviewer to *expose* the ceiling. After this
   PR the surface exists and defaults correctly, but a customer still has no way to
   set it in this repo. (Hosted, the per-install `review_spend_cap_cents` column feeds
   mechanism 2, not this one.)
2. **This gate is per-attempt, not cumulative.** §4.9 asks for a ceiling "counted
   across every review attempt on it". `estimateBudget` is a pre-flight *estimate* for
   a single attempt. The cumulative-across-attempts accounting exists only in
   mechanism 2 (`runaway_spend`, 24h window), which is the operator's floor.

Both want their own issue and their own decision; neither is a regression introduced here.

## Required follow-up in `clud-bug-app` (not broken today)

`clud-bug-app` pins `clud-bug@0.7.0-rc.23` (`git show origin/main:package.json`), so
nothing there changes until it re-pins past this. When it does, one test asserts the
behaviour this PR deliberately removes and **will fail**:

`clud-bug-app/test/budget-gate.test.ts:120-126`

```ts
it('reports the default cap when none provided', () => {
  const verdict = estimateBudget({ resolved: [pass('a', 1)], roleModels: [...] });
  expect(verdict.estimate.capUsd).toBe(DEFAULT_PER_PR_CAP_USD);   // now null
});
```

`lib/budget-gate.ts` (the re-export shim) keeps compiling — that is what the deprecated
alias is for. Only the assertion needs updating, to `toBeNull()`, when the pin moves.
