### PR TITLE
Fix #263: an unrecognised skill `kind` resolved to `rule` (max authority), not `writing` (min)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- **A skill with an unrecognised `kind` was applied with the *highest* authority, not the lowest
+  (#263).** `parseFrontmatter` recognised `rule`, `design` and the pre-2.0 `voice`; everything else
+  resolved to `undefined`. But `undefined` is indistinguishable from an absent `kind`, and an absent
+  `kind` **is** a `rule` skill (SPEC 2.0 §2.1) — so every value outside the ladder inherited the tier
+  that may be the sole citation for a finding about code behaviour. `kind: writing` was one of those
+  values: SPEC 2.0 renamed `voice` → `writing`, and the ladder never followed, so the first prose skill
+  to ship would have been read as a code rule. §2.2 exists to withhold exactly that.
+
+  Three changes:
+  - `SkillKind` is now `rule | writing | design`. The retired `voice` value and its `voice_scope`
+    companion are gone from the schema (SPEC 2.0 §2.1 lists neither). A skill still carrying them
+    loads — unknown keys are dropped, never a load failure — and `kind: voice` now resolves to
+    `writing`, which is the tier it always belonged in.
+  - New `resolveSkillKind()` (exported from `clud-bug/core`) is the one implementation of the two
+    rules, and they fail in opposite directions: **absent → `rule`** (§2.1's default), **unrecognised
+    → `writing`** (§2.2: "An unrecognised `kind` MUST be treated as `writing`"). Unknown values
+    degrade rather than reject — §2.2 is explicit that "a typo does not discard it" — and they do not
+    fall to `design`, which routes to a pass that may not run at all.
+  - `review-prompt` now partitions three ways instead of testing `!== 'design'`. `kind: writing`
+    skills are rendered in their own **§3d Prose lens** block carrying §2.2's limit ("MUST NOT be the
+    sole citation for a finding about code behaviour") instead of being folded into the §3
+    code-correctness skill list. The block renders only when a writing skill is installed, so a repo
+    with none gets a byte-identical recipe.
+
+  No skill in the catalog uses `kind: writing` today, so nothing shipped was mis-applied — this had to
+  land before the first one does. The three-pass `review.passes` model (SPEC 2.0 §2.2 + §1.6) is still
+  not built; this is the routing fix, not that feature.
+
 - **🔴 The reviewer could execute untrusted diff content — SPEC 2.0 §4.7 bans this unconditionally
   (clud-bug#264 → #260).** `src/core/invariants.ts`'s executable-probe surface let a repo self-enable
   a reviewer-runs-a-shell-command behaviour by declaring a single `invariants` entry in

--- a/docs/decisions-branches/fix__263-skill-kind-writing.md
+++ b/docs/decisions-branches/fix__263-skill-kind-writing.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-07 17:11 - Fix #263: an unrecognised skill kind resolved to rule (max authority) instead of writing (min)
+
+**Reasoning:** parseFrontmatter's kind ladder knew rule/design/voice and mapped everything else to undefined. SPEC 2.0 §2.1 makes an ABSENT kind a rule skill, so undefined and absent were indistinguishable and every unknown value inherited rule — the tier that may be the sole citation for a finding about code behaviour. SPEC 2.0 renamed voice to writing and the ladder never followed, so kind: writing hit exactly that path. §2.2 states the rule the code needed: 'An unrecognised kind MUST be treated as writing.' New resolveSkillKind() implements both defaults so they fail in opposite directions (absent to rule, unrecognised to writing), and review-prompt now partitions three ways instead of testing != design, rendering writing skills in a §3d prose block that carries §2.2's sole-citation limit rather than folding them into the code-lens skill list.
+
+**Alternatives considered:** Reject a bad kind loudly. SPEC forbids it twice — §2.1 'A consumer MUST NOT refuse to load a skill because of a key it does not recognise' and §2.2 'A skill loads and is applied — a typo does not discard it'. Also considered resolving unknowns to design, the genuinely least-authority tier, which §2.2 explicitly rejects: design routes to a pass that may not run at all, so a typo there would discard the skill rather than demote it. And considered fixing only the parser, but with the router still testing != design a writing skill would keep landing in the code pass, so the resolution would have changed nothing a reviewer sees.
+
+**Implications:**
+- Zero catalog skills use kind: writing today (agent-skills origin/main: 4 design, 1 rule, control 52 name: hits), so nothing shipped was mis-applied — this had to land before the first prose skill is authored. voice and voice_scope leave the schema; a skill still carrying them loads and now resolves to writing. A repo with no writing skills renders a byte-identical recipe (11574 bytes, verified). The full three-pass review.passes model (§2.2 + §1.6) is still NOT built — this is the routing fix only. clud-bug-app/lib/orchestrator.ts:1275 has the same != design partition and needs the same change once it bumps past 0.7.0-rc.23.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-08 (5 decisions)
+## 2026-08 (6 decisions)
 
-- **2026-08-07** — Fix 258: map dependabot secrets explicitly instead of secrets: inherit *(fix/258-secrets-mapping)* — [decisions-branches/fix__258-secrets-mapping.md](decisions-branches/fix__258-secrets-mapping.md)
-- *... 3 more decisions ...*
+- **2026-08-07** — Fix #263: an unrecognised skill kind resolved to rule (max authority) instead of writing (min) *(fix/263-skill-kind-writing)* — [decisions-branches/fix__263-skill-kind-writing.md](decisions-branches/fix__263-skill-kind-writing.md)
+- *... 4 more decisions ...*
 - **2026-08-01** — File three Wave 0 admin findings (pre-push gap, spec-version drift, stale SPEC citations) and warn agents to read issue threads not bodies *(wave0-admin-issues)* — [decisions-branches/wave0-admin-issues.md](decisions-branches/wave0-admin-issues.md)
 
 ## 2026-07 (40 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-08 (6 decisions)
+## 2026-08 (7 decisions)
 
 - **2026-08-07** — Fix #263: an unrecognised skill kind resolved to rule (max authority) instead of writing (min) *(fix/263-skill-kind-writing)* — [decisions-branches/fix__263-skill-kind-writing.md](decisions-branches/fix__263-skill-kind-writing.md)
-- *... 4 more decisions ...*
+- *... 5 more decisions ...*
 - **2026-08-01** — File three Wave 0 admin findings (pre-push gap, spec-version drift, stale SPEC citations) and warn agents to read issue threads not bodies *(wave0-admin-issues)* — [decisions-branches/wave0-admin-issues.md](decisions-branches/wave0-admin-issues.md)
 
 ## 2026-07 (40 decisions)

--- a/src/cli/review-prompt.ts
+++ b/src/cli/review-prompt.ts
@@ -20,6 +20,7 @@ import {
   readReviewContext,
   readNotaryConfig,
   parseFrontmatter,
+  resolveSkillKind,
   type ReviewPlan,
   type ReviewPlanSkill,
   type ReviewTrigger,
@@ -142,6 +143,13 @@ export function renderReviewRecipe(input: {
    */
   design?: { skills: string[]; config: DesignConfig };
   /**
+   * Prose lens (clud-bug#263). The `kind: writing` skills the repo installed —
+   * SPEC 2.0 §2.2 routes these to their own pass, which reads the text a change
+   * ships rather than its code. Present only when at least one is installed, so
+   * the common recipe is unchanged.
+   */
+  prose?: { skills: string[] };
+  /**
    * CI evidence (SPEC 2.0 §4.7). Present whenever the caller's gate passed
    * (`shouldReadCiChecks`): the repo hasn't explicitly disabled it (ON by
    * default) and this is a `pr` trigger — no CI has run yet at commit/push.
@@ -176,7 +184,8 @@ export function renderReviewRecipe(input: {
    */
   targetSha?: string;
 }): string {
-  const { plan, trigger, design, reviewContext, ciChecks, notaryUrl, noVerifyFlagged, targetSha } = input;
+  const { plan, trigger, design, prose, reviewContext, ciChecks, notaryUrl, noVerifyFlagged, targetSha } =
+    input;
 
   // H2 — the contextual layer. Three parts, each trusted differently:
   //   1. trusted standing instructions from `.clud-bug.json` (if any);
@@ -366,6 +375,22 @@ ${design.skills.map((s) => `  - \`.claude/skills/${s}/SKILL.md\``).join('\n')}
    }`
     : '';
 
+  // 3d (clud-bug#263) — the prose lens. SPEC 2.0 §2.2 gives `kind: writing`
+  // skills a pass of their own because they read a different input (the text
+  // the change ships, not the diff's logic), and caps what they may justify:
+  // "A `writing` skill MAY justify a finding on its own, but only about prose.
+  // It MUST NOT be the sole citation for a finding about code behaviour."
+  // Rendering them here — instead of folding them into §3's skill list — is
+  // what makes that cap real: a reviewer that never sees a writing skill in
+  // the code lens cannot cite one for a code-behaviour finding.
+  const proseStep = prose
+    ? `\n\n## 3d. Prose lens (\`kind: writing\` skills)
+Review the **text this change ships** — documentation, error and log messages, product copy, UI strings — against the writing skills below. This is a separate read from §3: its input is the prose in the diff, not the code's behaviour.
+${prose.skills.map((s) => `  - \`.claude/skills/${s}/SKILL.md\``).join('\n')}
+
+**Authority limit (SPEC 2.0 §2.2):** a writing skill may be the sole citation for a finding **about prose only**. It MUST NOT be the sole citation for a finding about code behaviour — if a writing skill is the only thing supporting a claim that the code is wrong, drop the finding or re-ground it on a \`kind: rule\` skill. Record prose findings with \`file\`, \`line\`, \`severity\`, the writing \`skill\`, and a one-line \`summary\`; tag them \`<!-- pass: prose -->\`.`
+    : '';
+
   // 3c (SPEC 2.0 §4.7) — CI evidence. Replaces the deleted executable-probe
   // step (Phase R / #87 — clud-bug#264 / #260): §4.7 bans reviewer execution
   // unconditionally, so instead of running anything, the agent reads the
@@ -450,7 +475,7 @@ a review.
 ${contextStep}
 
 ## 3. Review
-${reviewStep}${designStep}${ciEvidenceStep}
+${reviewStep}${designStep}${proseStep}${ciEvidenceStep}
 
 ## 4. Report
 Render the body in clud-bug's standard shape (§1.8.1) — omit any empty section:
@@ -524,6 +549,8 @@ export interface ResolvedReviewInputs {
   plan: ReviewPlan;
   reviewContext?: string;
   design?: { skills: string[]; config: DesignConfig };
+  /** `kind: writing` skills (SPEC 2.0 §2.2 prose pass). Absent when none. */
+  prose?: { skills: string[] };
   ciChecks?: { names: string[] | null };
   notaryUrl: string | null;
 }
@@ -560,11 +587,19 @@ export async function resolveReviewInputs(
     }
   }
 
-  // Partition by lens: `kind: design` skills drive the visual design-critic
-  // pass, not the code-correctness multi-pass plan. Code skills go to
-  // planReview; design skills go to the (gated) design step.
-  const designSkills = skills.filter((s) => s.frontmatter.kind === 'design');
-  const codeSkills = skills.filter((s) => s.frontmatter.kind !== 'design');
+  // Partition by lens — SPEC 2.0 §2.2: "A planner MUST route a skill to the
+  // pass matching its `kind` and MUST NOT feed it to another." Three kinds,
+  // three destinations: `rule` → the code-correctness plan (planReview),
+  // `writing` → the prose lens, `design` → the (gated) design step.
+  //
+  // Normalise through `resolveSkillKind` rather than reading `frontmatter.kind`
+  // directly: a `!== 'design'` test sweeps every non-design value into the code
+  // pass, which is exactly how clud-bug#263's unrecognised `kind` ended up with
+  // rule authority. Routing on the resolved tier means a typo lands in prose.
+  const kindOf = (s: ReviewPlanSkill) => resolveSkillKind(s.frontmatter.kind);
+  const designSkills = skills.filter((s) => kindOf(s) === 'design');
+  const writingSkills = skills.filter((s) => kindOf(s) === 'writing');
+  const codeSkills = skills.filter((s) => kindOf(s) === 'rule');
 
   const config = readReviewPassesConfig(manifest);
   const plan = planReview({
@@ -582,6 +617,11 @@ export async function resolveReviewInputs(
   const design = shouldRunDesign(designConfig, designSkills.length, trigger)
     ? { skills: designSkills.map((s) => s.slug), config: designConfig }
     : undefined;
+
+  // clud-bug#263 — the prose lens. Ungated (SPEC 2.0 §2.2 table: the prose
+  // pass "Runs: always"), but rendered only when the repo actually installs a
+  // `kind: writing` skill, so a repo with none sees a byte-identical recipe.
+  const prose = writingSkills.length > 0 ? { skills: writingSkills.map((s) => s.slug) } : undefined;
 
   // H2 — trusted standing review instructions (`.clud-bug.json` `reviewContext`).
   const reviewContext = readReviewContext(manifest).instructions;
@@ -606,6 +646,7 @@ export async function resolveReviewInputs(
     plan,
     ...(reviewContext ? { reviewContext } : {}),
     ...(design ? { design } : {}),
+    ...(prose ? { prose } : {}),
     ...(ciChecks ? { ciChecks } : {}),
     notaryUrl,
   };
@@ -620,7 +661,7 @@ export async function runReviewPrompt(args: ReviewPromptArgs): Promise<void> {
   const cwd = args.cwd ?? process.cwd();
   const trigger = normalizeTrigger(args.trigger);
 
-  const { plan, reviewContext, design, ciChecks, notaryUrl } = await resolveReviewInputs(
+  const { plan, reviewContext, design, prose, ciChecks, notaryUrl } = await resolveReviewInputs(
     cwd,
     trigger,
     args.diffSizeBytes,
@@ -639,6 +680,7 @@ export async function runReviewPrompt(args: ReviewPromptArgs): Promise<void> {
       notaryUrl,
       ...(reviewContext ? { reviewContext } : {}),
       ...(design ? { design } : {}),
+      ...(prose ? { prose } : {}),
       ...(ciChecks ? { ciChecks } : {}),
       ...(noVerifyFlagged ? { noVerifyFlagged: true } : {}),
     }) + '\n',

--- a/src/cli/review.ts
+++ b/src/cli/review.ts
@@ -156,7 +156,15 @@ export async function runReview(args: ReviewArgs): Promise<void> {
     return;
   }
 
-  const { plan, reviewContext, notaryUrl } = await resolveReviewInputs(cwd, 'commit', args.diffSizeBytes);
+  // `design` + `probes` are deliberately not forwarded: both are pr-gated and
+  // this drain is always a `commit` trigger, so `resolveReviewInputs` returns
+  // them undefined anyway. `prose` IS forwarded — SPEC 2.0 §2.2's prose pass
+  // "Runs: always", so it is not trigger-gated (clud-bug#263).
+  const { plan, reviewContext, prose, notaryUrl } = await resolveReviewInputs(
+    cwd,
+    'commit',
+    args.diffSizeBytes,
+  );
 
   const recipes = shas.map((sha, i) => {
     const recipe = renderReviewRecipe({
@@ -165,6 +173,7 @@ export async function runReview(args: ReviewArgs): Promise<void> {
       notaryUrl,
       targetSha: sha,
       ...(reviewContext ? { reviewContext } : {}),
+      ...(prose ? { prose } : {}),
     });
     return `# Pending review ${i + 1}/${shas.length}\n\n${recipe}`;
   });

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -380,6 +380,7 @@ export {
   isCriticalReviewHeader,
   classifyPerSkillOutcome,
   parseFrontmatter,
+  resolveSkillKind,
   stripFrontmatter,
   type SkillDescriptor,
   type RankableSkill,
@@ -391,5 +392,4 @@ export {
   type SkillSource,
   type SkillReviewMode,
   type SkillKind,
-  type VoiceScope,
 } from './skills.js';

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -655,8 +655,62 @@ export type SkillReviewMode = 'shared' | 'dedicated';
  * `PromptSkillFrontmatter` is a narrower subset (name + description +
  * applies_to) so we keep the full shape here.
  */
-export type SkillKind = 'rule' | 'voice' | 'design';
-export type VoiceScope = 'personal' | 'team' | 'org' | 'community';
+/**
+ * SPEC 2.0 §2.2 — `kind` routes a skill to the pass that reads it.
+ * `rule` reads the diff, `writing` reads the prose the change ships,
+ * `design` reads the rendered surface.
+ *
+ * Renamed from the pre-2.0 `voice` (SPEC 2.0 dropped that value, and its
+ * `voice_scope` companion, from the frontmatter schema).
+ */
+export type SkillKind = 'rule' | 'writing' | 'design';
+
+const RECOGNISED_SKILL_KINDS: ReadonlySet<string> = new Set<SkillKind>([
+  'rule',
+  'writing',
+  'design',
+]);
+
+/**
+ * Resolve a raw frontmatter `kind` value to the kind a consumer routes on.
+ * The one place SPEC 2.0 §2.1 + §2.2's two rules are implemented:
+ *
+ *   - **Absent → `rule`.** §2.1 lists `kind` as `no — rule`, and §2.2:
+ *     "A skill with no `kind` is a `rule` skill."
+ *   - **Unrecognised → `writing`.** §2.2: "An unrecognised `kind` MUST be
+ *     treated as `writing`. […] Coercing an unknown value to `rule` hands a
+ *     misspelling *more* power than the value its author meant, which is the
+ *     wrong direction for a mistake to fail in. `design` is weaker still, but
+ *     it routes to a pass that may not run at all, so resolving a typo there
+ *     would discard the skill rather than demote it."
+ *
+ * So an unknown value degrades — it is never rejected and never discarded.
+ * That is §2.1's "A consumer MUST NOT refuse to load a skill because of a key
+ * it does not recognise" applied to the value as well as the key: a typo costs
+ * the skill its authority over code behaviour, not its existence.
+ *
+ * A `kind` that is present but not a string (a bare `kind:` parses as an empty
+ * nested block, not a scalar) is unrecognised too, and demotes the same way —
+ * only a genuinely absent key takes §2.1's `rule` default.
+ *
+ * Prior to v0.7.0-rc.28 this ladder produced `undefined` for anything it did
+ * not recognise, which every consumer then read as the absent-kind default —
+ * i.e. `rule`, the *highest* authority tier. `kind: writing` hit that path
+ * (the ladder still spelled the value `voice`), so the first prose skill to
+ * ship would have been applied as a code rule. See clud-bug#263.
+ */
+export function resolveSkillKind(raw: unknown): SkillKind {
+  // Genuinely absent — §2.1's documented default.
+  if (raw === undefined || raw === null) return 'rule';
+  // Present and recognised — route to its own pass.
+  if (typeof raw === 'string' && RECOGNISED_SKILL_KINDS.has(raw.trim())) {
+    return raw.trim() as SkillKind;
+  }
+  // Present and unrecognised (typo, retired value like `voice`, empty, or a
+  // non-scalar) — §2.2 demotes to the least authority a skill can be applied
+  // with while still being applied at all.
+  return 'writing';
+}
 
 export interface SkillFrontmatter {
   name: string;
@@ -664,17 +718,16 @@ export interface SkillFrontmatter {
   source: SkillSource | string; // string fallback for forward-compat
   review_mode: SkillReviewMode;
   /**
-   * SPEC §1.10.1 v0.5.0+ skill classification. OPTIONAL — absent =
-   * `kind: rule` (the v0.4.0 default). Surfaced on the parsed
-   * frontmatter (v0.7.0-rc.6+) so consumers can route on the field;
-   * v0.7.0-rc.5 and earlier silently dropped it.
+   * SPEC 2.0 §2.1/§2.2 skill classification — which pass reads this skill.
+   *
+   * `parseFrontmatter` ALWAYS populates this (via `resolveSkillKind`), so a
+   * parsed frontmatter never carries `undefined` here. The field stays
+   * optional on the type only so hand-built `SkillFrontmatter` literals still
+   * compile; routing sites MUST normalise with `resolveSkillKind(fm.kind)`
+   * rather than reading the raw field, so a literal that omits it still lands
+   * on §2.1's `rule` default instead of falling through a `!== 'design'` test.
    */
   kind?: SkillKind;
-  /**
-   * SPEC §1.10.1 v0.5.0+ voice scope. REQUIRED when `kind: voice`,
-   * absent otherwise. Surfaced on the parsed frontmatter (v0.7.0-rc.6+).
-   */
-  voice_scope?: VoiceScope;
   applies_to?: {
     paths?: string[];
     extensions?: string[];
@@ -770,29 +823,17 @@ export function parseFrontmatter(raw: string): SkillFrontmatter {
   const reviewMode: SkillReviewMode =
     out['review_mode'] === 'dedicated' ? 'dedicated' : 'shared';
 
-  // v0.7.0-rc.6 — surface SPEC §1.10.1 v0.5.0+ kind + voice_scope on
-  // the parsed frontmatter. v0.7.0-rc.5 silently dropped these fields
-  // (the Wave 4d reviewer-flagged silent-drop). Validation is lenient:
-  // unknown values are surfaced as undefined so downstream code sees a
-  // clean type rather than a malformed value. SPEC enforcement (e.g.,
-  // "voice_scope REQUIRED when kind: voice") is the caller's job.
-  const kindRaw = out['kind'];
-  const kind: SkillKind | undefined =
-    kindRaw === 'voice'
-      ? 'voice'
-      : kindRaw === 'design'
-        ? 'design'
-        : kindRaw === 'rule'
-          ? 'rule'
-          : undefined;
-  const voiceScopeRaw = out['voice_scope'];
-  const voiceScope: VoiceScope | undefined =
-    voiceScopeRaw === 'personal' ||
-    voiceScopeRaw === 'team' ||
-    voiceScopeRaw === 'org' ||
-    voiceScopeRaw === 'community'
-      ? voiceScopeRaw
-      : undefined;
+  // clud-bug#263 — resolve SPEC 2.0 §2.1/§2.2 `kind` to a concrete tier here
+  // rather than leaving an unrecognised value as `undefined`. `undefined` was
+  // indistinguishable from an absent key, and an absent key IS `rule` (§2.1) —
+  // so every unknown value, including the not-yet-in-the-ladder `writing`, was
+  // silently promoted to the highest-authority tier. `resolveSkillKind` fails
+  // the other way: absent → `rule`, anything unrecognised → `writing`.
+  //
+  // The result is ALWAYS set, so no consumer has to re-apply the default (and
+  // no consumer can forget to). SPEC enforcement beyond routing is still the
+  // caller's job.
+  const kind = resolveSkillKind(out['kind']);
 
   const appliesToRaw = out['applies_to'] as
     | { paths?: unknown; extensions?: unknown; author?: unknown }
@@ -834,8 +875,7 @@ export function parseFrontmatter(raw: string): SkillFrontmatter {
     description,
     source,
     review_mode: reviewMode,
-    ...(kind !== undefined ? { kind } : {}),
-    ...(voiceScope !== undefined ? { voice_scope: voiceScope } : {}),
+    kind,
     ...(appliesTo !== undefined ? { applies_to: appliesTo } : {}),
   };
 }

--- a/test/review-prompt.test.js
+++ b/test/review-prompt.test.js
@@ -10,7 +10,11 @@ import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 import { planReview } from '../src/core/plan-review.js';
-import { renderReviewRecipe, CLUD_BUG_RECIPE_MARKER } from '../src/cli/review-prompt.js';
+import {
+  renderReviewRecipe,
+  resolveReviewInputs,
+  CLUD_BUG_RECIPE_MARKER,
+} from '../src/cli/review-prompt.js';
 
 const CLI = join(dirname(dirname(fileURLToPath(import.meta.url))), 'bin', 'clud-bug.js');
 
@@ -535,5 +539,138 @@ describe('review-prompt verb (integration)', () => {
     });
     expect(r.status).toBe(0);
     expect(r.stdout).not.toMatch(/Automatic finding/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clud-bug#263 — `kind` routes a skill to a pass (SPEC 2.0 §2.2).
+//
+// The parser fix (resolveSkillKind) only matters because of what reads it: a
+// `!== 'design'` partition swept every non-design value — including `writing`
+// and every typo — into the code-correctness plan, where a skill can be the
+// sole citation for a finding about code behaviour. §2.2 withholds exactly
+// that from a prose skill, so the routing is where the authority actually
+// changes hands.
+// ---------------------------------------------------------------------------
+
+/** Write a repo with the given skills installed, and resolve its review inputs. */
+async function resolveRepo(prefix, skills, trigger = 'pr') {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  const skillsDir = join(dir, '.claude', 'skills');
+  await mkdir(skillsDir, { recursive: true });
+  await writeFile(
+    join(skillsDir, '.clud-bug.json'),
+    JSON.stringify({
+      version: 1,
+      installed: skills.map((s) => ({
+        slug: s.slug,
+        name: s.slug,
+        source: 'manual',
+        kind: 'baseline',
+        description: 'x',
+      })),
+    }),
+  );
+  for (const s of skills) {
+    await mkdir(join(skillsDir, s.slug), { recursive: true });
+    await writeFile(
+      join(skillsDir, s.slug, 'SKILL.md'),
+      `---\nname: ${s.slug}\ndescription: x\nsource: manual\nreview_mode: shared\n` +
+        (s.kind === undefined ? '' : `kind: ${s.kind}\n`) +
+        '---\n\nrules',
+    );
+  }
+  return { dir, inputs: await resolveReviewInputs(dir, trigger) };
+}
+
+const codeLensSlugs = (inputs) => inputs.plan.perSkill.map((p) => p.slug);
+
+describe('#263 — kind routes a skill to a pass', () => {
+  it('a kind: writing skill goes to the prose lens, NOT the code-correctness plan', async () => {
+    const { inputs } = await resolveRepo('clud-bug-rp263a-', [
+      { slug: 'a-rule-skill', kind: 'rule' },
+      { slug: 'a-writing-skill', kind: 'writing' },
+    ]);
+
+    // Control: the rule skill DID reach the code lens, so the absence below is
+    // a routing decision and not an empty/broken plan.
+    expect(codeLensSlugs(inputs)).toContain('a-rule-skill');
+    expect(codeLensSlugs(inputs)).not.toContain('a-writing-skill');
+    expect(inputs.prose?.skills).toEqual(['a-writing-skill']);
+  });
+
+  it('THE REGRESSION: an unrecognised kind lands in prose, never in the code plan', async () => {
+    const { inputs } = await resolveRepo('clud-bug-rp263b-', [
+      { slug: 'a-rule-skill', kind: 'rule' },
+      { slug: 'typo-skill', kind: 'writng' },
+      { slug: 'invented-skill', kind: 'enterprise' },
+      { slug: 'retired-voice-skill', kind: 'voice' },
+    ]);
+
+    expect(codeLensSlugs(inputs)).toEqual(['a-rule-skill']); // control: exactly one
+    expect(inputs.prose?.skills.sort()).toEqual(
+      ['invented-skill', 'retired-voice-skill', 'typo-skill'].sort(),
+    );
+  });
+
+  it('absent kind still means rule (§2.1) — the default is unchanged', async () => {
+    const { inputs } = await resolveRepo('clud-bug-rp263c-', [
+      { slug: 'no-kind-skill' }, // no `kind:` line at all
+      { slug: 'explicit-rule-skill', kind: 'rule' },
+    ]);
+    expect(codeLensSlugs(inputs).sort()).toEqual(['explicit-rule-skill', 'no-kind-skill']);
+    expect(inputs.prose).toBeUndefined();
+  });
+
+  it('a kind: design skill reaches neither the code plan nor the prose lens', async () => {
+    const { inputs } = await resolveRepo('clud-bug-rp263d-', [
+      { slug: 'a-rule-skill', kind: 'rule' },
+      { slug: 'a-design-skill', kind: 'design' },
+    ]);
+    expect(codeLensSlugs(inputs)).toEqual(['a-rule-skill']);
+    expect(inputs.prose).toBeUndefined();
+  });
+
+  it('renders the prose lens with §2.2’s sole-citation limit, and keeps it out of §3', async () => {
+    const { inputs } = await resolveRepo('clud-bug-rp263e-', [
+      { slug: 'a-rule-skill', kind: 'rule' },
+      { slug: 'a-writing-skill', kind: 'writing' },
+    ]);
+    const recipe = renderReviewRecipe({
+      plan: inputs.plan,
+      trigger: 'pr',
+      notaryUrl: null,
+      ...(inputs.prose ? { prose: inputs.prose } : {}),
+    });
+
+    expect(recipe).toContain('## 3d. Prose lens');
+    expect(recipe).toContain('.claude/skills/a-writing-skill/SKILL.md');
+    expect(recipe).toMatch(/MUST NOT be the sole citation for a finding about code behaviour/);
+    // The writing skill is named ONCE — in the prose block — never in the §3
+    // code-lens skill list a reviewer cites for code-behaviour findings.
+    expect(recipe.match(/a-writing-skill/g)).toHaveLength(1);
+    expect(recipe).toContain('.claude/skills/a-rule-skill/SKILL.md'); // control
+  });
+
+  it('control: a repo with no writing skills renders NO prose block', async () => {
+    const { inputs } = await resolveRepo('clud-bug-rp263f-', [{ slug: 'a-rule-skill', kind: 'rule' }]);
+    const recipe = renderReviewRecipe({ plan: inputs.plan, trigger: 'pr', notaryUrl: null });
+    expect(recipe).not.toContain('## 3d. Prose lens');
+    expect(recipe).toContain('.claude/skills/a-rule-skill/SKILL.md'); // control: recipe rendered
+  });
+
+  it('end-to-end: the CLI verb emits the prose lens for an installed writing skill', async () => {
+    const { dir } = await resolveRepo('clud-bug-rp263g-', [
+      { slug: 'a-rule-skill', kind: 'rule' },
+      { slug: 'a-writing-skill', kind: 'writing' },
+    ]);
+    const r = spawnSync(process.execPath, [CLI, 'review-prompt', '--trigger', 'pr'], {
+      cwd: dir,
+      encoding: 'utf8',
+      timeout: 30000,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('## 3d. Prose lens');
+    expect(r.stdout).toContain('a-writing-skill');
   });
 });

--- a/test/skills-frontmatter.test.js
+++ b/test/skills-frontmatter.test.js
@@ -10,7 +10,12 @@
 import { test } from 'vitest';
 import { strict as assert } from 'node:assert';
 
-import { appliesToAuthor, parseFrontmatter, stripFrontmatter } from '../src/core/skills.js';
+import {
+  appliesToAuthor,
+  parseFrontmatter,
+  resolveSkillKind,
+  stripFrontmatter,
+} from '../src/core/skills.js';
 
 // ---------------------------------------------------------------------------
 // Valid frontmatter
@@ -232,37 +237,37 @@ test('stripFrontmatter: handles CRLF line endings', () => {
 });
 
 // ---------------------------------------------------------------------------
-// v0.7.0-rc.6 — SPEC v0.5.0+ kind + voice_scope surfaced on frontmatter
-// (Wave 4d reviewer-flagged silent-drop, now formalized in v0.5.1)
+// clud-bug#263 — SPEC 2.0 §2.1/§2.2 `kind` resolution.
+//
+// Two rules, and the whole point is that they fail in OPPOSITE directions:
+//   §2.1 "A skill with no `kind` is a `rule` skill."      → absent       → rule
+//   §2.2 "An unrecognised `kind` MUST be treated as `writing`."          → writing
+//
+// Before this, EVERY value outside the ladder resolved to `undefined`, and
+// `undefined` is indistinguishable from absent — so a typo, and the not-yet-in-
+// the-ladder `writing`, inherited §2.1's `rule` default: the HIGHEST authority
+// tier, able to be the sole citation for a finding about code behaviour, which
+// §2.2 exists to withhold from a prose skill.
 // ---------------------------------------------------------------------------
 
-test('parseFrontmatter: kind: voice + voice_scope: org surfaced on parsed frontmatter', () => {
-  const raw = `---
-name: voice-acme
-description: Acme org voice for the bot.
-kind: voice
-voice_scope: org
----
+const KIND = (kind) => `---
+name: kind-fixture
+description: A skill with a kind.
+${kind === null ? '' : `kind: ${kind}\n`}---
 Body.
 `;
-  const fm = parseFrontmatter(raw);
-  assert.equal(fm.kind, 'voice');
-  assert.equal(fm.voice_scope, 'org');
-});
 
 test('parseFrontmatter: kind: rule surfaced explicitly', () => {
-  const raw = `---
-name: my-rule
-description: A rule skill.
-kind: rule
----
-Body.
-`;
-  const fm = parseFrontmatter(raw);
-  assert.equal(fm.kind, 'rule');
+  assert.equal(parseFrontmatter(KIND('rule')).kind, 'rule');
 });
 
-test('parseFrontmatter: kind: design surfaced (visual-review lens, no scope required)', () => {
+test('parseFrontmatter: kind: writing is RECOGNISED (SPEC 2.0 renamed it from `voice`)', () => {
+  // The bug in #263: `writing` was absent from the ladder, so it fell to
+  // `undefined` → read as the absent-kind default → `rule`.
+  assert.equal(parseFrontmatter(KIND('writing')).kind, 'writing');
+});
+
+test('parseFrontmatter: kind: design surfaced (visual-review lens)', () => {
   const raw = `---
 name: visual-polish
 description: A design skill.
@@ -273,41 +278,96 @@ Body.
 `;
   const fm = parseFrontmatter(raw);
   assert.equal(fm.kind, 'design');
-  // design needs no voice_scope (unlike kind: voice)
-  assert.equal(fm.voice_scope, undefined);
   assert.equal(fm.review_mode, 'dedicated');
 });
 
-test('parseFrontmatter: unknown kind silently drops (defensive)', () => {
+test('parseFrontmatter: absent kind → rule (SPEC 2.0 §2.1 default)', () => {
+  assert.equal(parseFrontmatter(MINIMAL_VALID).kind, 'rule');
+  assert.equal(parseFrontmatter(KIND(null)).kind, 'rule');
+});
+
+// The regression this issue is about: every one of these MUST land on
+// `writing`, and NOT ONE of them may come back `rule`.
+for (const garbage of [
+  'enterprise', // a value that never existed
+  'writng', // a plausible typo of the real value
+  'Writing', // right word, wrong case — SPEC enumerates lowercase values
+  'voice', // the retired pre-2.0 name; demotes, and prose is where it belonged
+  'rule ; design', // punctuation soup
+  '[]', // parses as an inline list, not a scalar
+  '"writing", "rule"', // two values where one is allowed
+]) {
+  test(`parseFrontmatter: unrecognised kind ${JSON.stringify(garbage)} → writing, never rule (SPEC 2.0 §2.2)`, () => {
+    const fm = parseFrontmatter(KIND(garbage));
+    assert.equal(fm.kind, 'writing');
+    assert.notEqual(fm.kind, 'rule');
+  });
+}
+
+test('parseFrontmatter: a bare `kind:` with no value → writing, not rule', () => {
+  // The hand-rolled parser reads a valueless key as a nested block (`{}`), so
+  // this arrives as a non-string. Present-but-unusable is a mistake, and a
+  // mistake resolves DOWN (§2.2), not to §2.1's absent-key default.
   const raw = `---
-name: weird
-description: Weird kind.
-kind: enterprise
+name: bare-kind
+description: A skill whose kind line has no value.
+kind:
 ---
 Body.
 `;
-  const fm = parseFrontmatter(raw);
-  assert.equal(fm.kind, undefined);
+  assert.equal(parseFrontmatter(raw).kind, 'writing');
 });
 
-test('parseFrontmatter: unknown voice_scope silently drops', () => {
+test('parseFrontmatter: an unrecognised kind still LOADS the skill (degrade, never reject)', () => {
+  // SPEC 2.0 §2.1: "A consumer MUST NOT refuse to load a skill because of a key
+  // it does not recognise"; §2.2: "A skill loads and is applied — a typo does
+  // not discard it". So this must not throw, and must keep every other field.
+  const fm = parseFrontmatter(KIND('enterprise'));
+  assert.equal(fm.name, 'kind-fixture');
+  assert.equal(fm.description, 'A skill with a kind.');
+  assert.equal(fm.source, 'manual');
+  assert.equal(fm.review_mode, 'shared');
+});
+
+test('parseFrontmatter: voice_scope is gone — SPEC 2.0 dropped it from the schema', () => {
   const raw = `---
-name: weird-voice
-description: Weird scope.
+name: voice-acme
+description: A skill still carrying the retired pre-2.0 fields.
 kind: voice
-voice_scope: galaxy
+voice_scope: org
 ---
 Body.
 `;
   const fm = parseFrontmatter(raw);
-  assert.equal(fm.kind, 'voice');
+  // Unknown keys are dropped from the parsed shape, never a load failure.
   assert.equal(fm.voice_scope, undefined);
+  assert.equal(fm.kind, 'writing');
 });
 
-test('parseFrontmatter: absent kind + voice_scope → both undefined (v0.5.0 default)', () => {
-  const fm = parseFrontmatter(MINIMAL_VALID);
-  assert.equal(fm.kind, undefined);
-  assert.equal(fm.voice_scope, undefined);
+// ---------------------------------------------------------------------------
+// resolveSkillKind — the rule on its own, so a consumer that builds a
+// frontmatter by hand (rather than via parseFrontmatter) routes identically.
+// ---------------------------------------------------------------------------
+
+test('resolveSkillKind: absent (undefined/null) → rule', () => {
+  assert.equal(resolveSkillKind(undefined), 'rule');
+  assert.equal(resolveSkillKind(null), 'rule');
+});
+
+test('resolveSkillKind: the three recognised values round-trip', () => {
+  assert.equal(resolveSkillKind('rule'), 'rule');
+  assert.equal(resolveSkillKind('writing'), 'writing');
+  assert.equal(resolveSkillKind('design'), 'design');
+});
+
+test('resolveSkillKind: whitespace around a recognised value is tolerated', () => {
+  assert.equal(resolveSkillKind('  design  '), 'design');
+});
+
+test('resolveSkillKind: non-string and unrecognised inputs → writing, never rule', () => {
+  for (const bad of ['enterprise', '', '  ', 42, true, {}, [], ['writing'], () => {}]) {
+    assert.equal(resolveSkillKind(bad), 'writing', `resolveSkillKind(${String(bad)})`);
+  }
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #263.

## The defect, confirmed in the code

`src/core/skills.ts` (pre-fix) recognised three `kind` values and mapped everything else to `undefined`:

```ts
const kind: SkillKind | undefined =
  kindRaw === 'voice' ? 'voice'
    : kindRaw === 'design' ? 'design'
      : kindRaw === 'rule' ? 'rule'
        : undefined;
```

`undefined` is indistinguishable from an absent `kind`, and SPEC 2.0 §2.2 says *"A skill with no `kind` is a `rule` skill."* So every unrecognised value inherited **`rule`** — the tier that may be the sole citation for a finding about code behaviour. SPEC 2.0 renamed `voice` → `writing`; the ladder never followed, so `kind: writing` landed on exactly that path.

The coercion was not only in the type. `src/cli/review-prompt.ts` partitioned with `s.frontmatter.kind !== 'design'`, which sweeps every non-design value into the code-correctness plan. Measured on a fixture repo with one `kind: rule`, one `kind: writing` and one `kind: writng` skill, against `origin/dev`:

```
$ node bin/clud-bug.js review-prompt --trigger pr     # BEFORE
Read each skill's discipline from the checkout:
  - `.claude/skills/plain-rule/SKILL.md`
  - `.claude/skills/house-style/SKILL.md`     ← kind: writing
  - `.claude/skills/typo-kind/SKILL.md`       ← kind: writng
$ grep -c "Prose lens" before.txt
0
```

All three sit in the §3 code-lens list a reviewer cites for code-behaviour findings — which is what §2.2 exists to prevent.

**Nothing is on fire.** Control-tested census of the catalog at `agent-skills` `origin/main`:

```
$ git grep -h "^kind:" origin/main -- '*.md' | sort | uniq -c
   4 kind: design
   1 kind: rule
$ git grep -h "^name:" origin/main -- '*.md' | wc -l    # control
52
```

Zero `writing`, zero `voice`. This has to land before the first prose skill is authored, not after.

## Reject loudly, or degrade safely?

**Degrade** — and the SPEC does not leave it to taste. §2.2:

> **An unrecognised `kind` MUST be treated as `writing`.** A skill loads and is applied — a typo does not discard it — but it MUST NOT be the sole citation for a finding about code behaviour. Coercing an unknown value to `rule` hands a misspelling *more* power than the value its author meant, which is the wrong direction for a mistake to fail in. `design` is weaker still, but it routes to a pass that may not run at all, so resolving a typo there would discard the skill rather than demote it.

Rejecting is forbidden twice over — §2.1 also says *"A consumer MUST NOT refuse to load a skill because of a key it does not recognise."* And `writing`, not `design`, even though `design` is the genuinely least-authority tier: §2.2 rules it out because a `design` skill routes to a pass that may not run at all, so a typo resolved there would be silently discarded rather than demoted.

So the two defaults deliberately fail in **opposite directions**, and that is the whole fix:

| Input | Resolves to | Rule |
|---|---|---|
| key absent | `rule` | §2.1 (`kind` — "no — `rule`"), §2.2 "A skill with no `kind` is a `rule` skill" |
| `rule` / `writing` / `design` | itself | §2.2 |
| anything else | `writing` | §2.2 "An unrecognised `kind` MUST be treated as `writing`" |

## What changed

1. **`SkillKind` is `rule | writing | design`.** The pre-2.0 `voice` value and its `voice_scope` companion leave the schema — SPEC 2.0 §2.1's frontmatter table lists neither. A skill still carrying them loads (unknown keys are dropped, never a load failure) and `kind: voice` now resolves to `writing`, the tier it always belonged in.

2. **New `resolveSkillKind()`**, exported from `clud-bug/core` — one implementation of both rules, so a consumer that builds a frontmatter by hand routes identically. `parseFrontmatter` now always populates `kind`, so no consumer has to re-apply the default (or can forget to).

3. **`review-prompt` partitions three ways** instead of testing `!== 'design'`, and routes through `resolveSkillKind` rather than reading the raw field. `kind: writing` skills render in a new **§3d Prose lens** block that carries §2.2's cap verbatim — *"MUST NOT be the sole citation for a finding about code behaviour"* — instead of being folded into the §3 code-lens list. Keeping them out of that list is what makes the cap real: a reviewer that never sees a writing skill in the code lens cannot cite one for a code-behaviour finding.

After, same fixture:

```
§3:   - `.claude/skills/plain-rule/SKILL.md`
§3d Prose lens (`kind: writing` skills)
      - `.claude/skills/house-style/SKILL.md`
      - `.claude/skills/typo-kind/SKILL.md`
      **Authority limit (SPEC 2.0 §2.2):** … MUST NOT be the sole citation for a finding about code behaviour …
```

## Scope, stated plainly

The full three-pass model — `review.passes` config choosing which passes run and with which model (§2.2 + §1.6) — is **not built**, and this PR does not build it. This is the routing fix: a `writing` skill stops being applied as a code rule. The prose block is the minimum that makes the resolution mean something at the one shipped consumer.

`clud-bug-app/lib/orchestrator.ts:1275` carries the identical `kind === 'design'` partition and needs the same change; it pins `clud-bug@0.7.0-rc.23`, so it is unaffected until it bumps. Filed as follow-up work, not smuggled in here.

## Evidence

```
$ npm run build && npm test
Test Files  49 passed (49)
     Tests  1082 passed (1082)
```

**The new tests fail against the pre-fix code** — 18 of them, run with `src/` stashed:

```
$ git stash push -- src/core/skills.ts src/core/index.ts src/cli/review-prompt.ts src/cli/review.ts
$ npx vitest run test/skills-frontmatter.test.js test/review-prompt.test.js
Tests  18 failed | 60 passed (78)

FAIL  #263 — kind routes a skill to a pass > THE REGRESSION: an unrecognised kind lands in prose, never in the code plan
AssertionError: expected [ 'a-rule-skill', 'typo-skill', …(2) ] to deeply equal [ 'a-rule-skill' ]
  [
    "a-rule-skill",
+   "typo-skill",
+   "invented-skill",
+   "retired-voice-skill",
  ]
```

Coverage includes a plausible typo (`writng`), a wrong-case value (`Writing`), a value that never existed (`enterprise`), the retired `voice`, punctuation soup, an inline list, two comma-separated values, a bare valueless `kind:`, and non-string inputs — each asserted `=== 'writing'` **and** `!== 'rule'`.

**A repo with no writing skills renders a byte-identical recipe** (so the golden byte-budget gate is untouched):

```
$ cmp dev-before.txt dev-after.txt && echo BYTE-IDENTICAL
BYTE-IDENTICAL (11574 bytes)
```

Every "zero" above is control-tested: the catalog census pairs its `kind:` count with a `name:` count from the same command shape (52 hits, so the grep works), and each absence assertion in the tests sits beside a presence assertion on the same rendered output.

## Notes for the reviewer

- **This issue has no comments** (`gh api …/issues/263 --jq '.comments'` → `0`; control: #260 → `1`), so its body is live. It was filed 2026-07-31, one day before the SPEC 2.0 merge, and its "SPEC-2" citations were checked against the merged text rather than trusted.
- **One difference between the issue and the merged SPEC, cited rather than resolved silently:** the issue body says an unrecognised kind must resolve to *"the least authority any kind carries"*. Read literally that is `design`. The merged §2.2 names `writing` specifically and explains why `design` is wrong (it routes to a pass that may not run, so a typo there is discarded rather than demoted). This PR follows the merged SPEC.
- **The task brief said the same thing** — "resolves to the LEAST authority" — and hits the same distinction. Same resolution, same reason.
- `test/skills-frontmatter.test.js`'s header calls itself an equivalence test against a port in `clud-bug-app/lib/skills-loader.ts`. That header is stale: the App re-exports `parseFrontmatter` from `clud-bug/core` (`lib/skills-loader.ts:5,40`), so there is one parser, not two. Left alone here — it is a comment fix belonging to its own change.
