### PR TITLE
chore(skills): refresh bundled respect-existing-conventions from agent-skills@1bec314

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ### Changed
 
+- **Bundled `respect-existing-conventions` SKILL.md refreshed** from `thrillmade/agent-skills@1bec314`. `BASELINE_SKILLS_REF` in `src/cli/skills.ts` pinned to the same commit so the install-time fetch path and the bundled offline-fallback path resolve to byte-identical content. Auto-synced by `agent-skills/.github/workflows/notify-clud-bug.yml`.
+
+
+### Changed
+
 - **Bundled `evidence-based-review` SKILL.md refreshed** from `thrillmade/agent-skills@2dc8360`. `BASELINE_SKILLS_REF` in `src/cli/skills.ts` pinned to the same commit so the install-time fetch path and the bundled offline-fallback path resolve to byte-identical content. Auto-synced by `agent-skills/.github/workflows/notify-clud-bug.yml`.
 - **Bundled `critical-issues-only` SKILL.md refreshed** from `thrillmade/agent-skills@2dc8360`. `BASELINE_SKILLS_REF` in `src/cli/skills.ts` pinned to the same commit so the install-time fetch path and the bundled offline-fallback path resolve to byte-identical content. Auto-synced by `agent-skills/.github/workflows/notify-clud-bug.yml`.
 - **Bundled `respect-existing-conventions` SKILL.md refreshed** from `thrillmade/agent-skills@2dc8360`. `BASELINE_SKILLS_REF` in `src/cli/skills.ts` pinned to the same commit so the install-time fetch path and the bundled offline-fallback path resolve to byte-identical content. Auto-synced by `agent-skills/.github/workflows/notify-clud-bug.yml`.

--- a/src/cli/skills.ts
+++ b/src/cli/skills.ts
@@ -31,7 +31,7 @@ export const MANIFEST_VERSION = 1;
 // skill content, bump BASELINE_SKILLS_REF below in the same clud-bug PR
 // that ships the corresponding bundled fallback update.
 // See thrillmade/agent-skills — skills.sh `skills/<name>/SKILL.md` layout.
-const BASELINE_SKILLS_REF = '2dc8360c8bdfb916d37fc85c23b04f63559daad6';
+const BASELINE_SKILLS_REF = '1bec3149c54826bf58711b16a15754547ffc84bf';
 const AGENT_SKILLS_BASE =
   process.env['CLUD_BUG_AGENT_SKILLS_BASE'] ??
   `https://raw.githubusercontent.com/thrillmade/agent-skills/${BASELINE_SKILLS_REF}/skills`;

--- a/templates/skills/baseline/respect-existing-conventions.md
+++ b/templates/skills/baseline/respect-existing-conventions.md
@@ -1,4 +1,5 @@
 ---
+version: "936899cf6899"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: respect-existing-conventions
 description: Don't suggest changes that fight the codebase's established patterns. Match what's already there.
 ---


### PR DESCRIPTION
Automated bundled-copy sync from `thrillmade/agent-skills`.

**Trigger:** `push` on `thrillmade/agent-skills`.
**Source SKILL.md:** https://github.com/thrillmade/agent-skills/blob/1bec3149c54826bf58711b16a15754547ffc84bf/skills/respect-existing-conventions/SKILL.md
**Source commit:** https://github.com/thrillmade/agent-skills/commit/1bec3149c54826bf58711b16a15754547ffc84bf

## Changes applied

- `templates/skills/baseline/respect-existing-conventions.md` ← byte-for-byte copy of the source above.
- `src/cli/skills.ts` — `BASELINE_SKILLS_REF` bumped to `1bec3149c54826bf58711b16a15754547ffc84bf` so the install-time fetch from `thrillmade/agent-skills` and the bundled offline-fallback both resolve to identical content.
- `CHANGELOG.md` — entry under [Unreleased] documenting the refresh.

**`package.json` is deliberately untouched.** This PR proposes *content*; assigning a version is your release decision, not ours. The CHANGELOG entry sits under [Unreleased] for your own release process to fold in.

## How this was generated

`agent-skills/.github/workflows/notify-clud-bug.yml` — fires on push to `main` matching one of the tracked baseline-skill paths, or via manual `workflow_dispatch` for a chosen skill.