### PR TITLE
Release v0.7.0

### DIFF
--- a/.github/actions/strict-mode-gate/action.yml
+++ b/.github/actions/strict-mode-gate/action.yml
@@ -3,7 +3,7 @@
 # Replaces the ~24 lines of inline shell that v0.5.x rendered into every
 # workflow template. Templates now reference it via:
 #
-#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.27
+#   - uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0
 #     if: success()
 #     with:
 #       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to clud-bug. Format follows [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-08-24
+
 ### Added
 
 - **A `pre-push` local review surface (#276).** There was none: `git grep -inE 'pre-push|prePush|pre_push' origin/main -- src/ templates/` returned **0 hits** (control probe `PostToolUse` → 2 files, so the search itself worked), while SPEC 2.0 §4.1 says "A reviewer MUST support both, and **push is the default**" and §6.7 names the mechanism: "Git allows one `pre-push` hook, so ownership follows what is installed."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.27",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clud-bug",
-      "version": "0.7.0-rc.27",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clud-bug",
-  "version": "0.7.0-rc.27",
+  "version": "0.7.0",
   "description": "Skill-driven Claude PR review. Ship a brand-voice skill, get brand reviews. Each finding cites the skill that motivated it. CLI installs the workflow + a baseline kit; add more from skills.sh.",
   "homepage": "https://cludbug.dev",
   "bugs": "https://github.com/thrillmade/clud-bug/issues",

--- a/templates/workflow-py.yml.tmpl
+++ b/templates/workflow-py.yml.tmpl
@@ -512,7 +512,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.27
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow-ts.yml.tmpl
+++ b/templates/workflow-ts.yml.tmpl
@@ -512,7 +512,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.27
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/templates/workflow.yml.tmpl
+++ b/templates/workflow.yml.tmpl
@@ -893,7 +893,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0-rc.27
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.7.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow


### PR DESCRIPTION
## Summary

- First stable of the 0.7 line.
- Supersedes npm `latest` 0.6.34.
- `package.json` `0.7.0-rc.27` → `0.7.0`; lockfile version fields synced via `npm install --package-lock-only`.
- `CHANGELOG.md`: `[Unreleased]` retitled to `[0.7.0] — 2026-08-24`, fresh empty `[Unreleased]` opened above it.
- Composite `strict-mode-gate` pin bumped in lock-step (enforced by `test/release-discipline.test.js`): all 3 review templates + `action.yml` header docstring, `v0.7.0-rc.27` → `v0.7.0`.

The publish workflow auto-assigns the npm dist-tag `latest` for non-prerelease versions on tag push `v0.7.0`.

**CEO merges this, then pushes the `v0.7.0` tag.**

## Test plan

- [x] `node scripts/check-version.mjs` → `check-version: ok (package.json 0.7.0)`
- [x] `npm ci && npm run build && npm test && npm run test:fixtures` → 54 files / 1193 tests / 5 fixtures, all passed
- [x] Confirmed built `dist/core/version.js` bakes `PKG_VERSION = '0.7.0'`